### PR TITLE
feat: session ID and resume support for JSON stream mode

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -157,12 +157,17 @@ impl AgentEngine {
     }
 
     /// Initialize a new session for this engine run
-    pub fn init_session(&mut self, provider_name: &str, cwd: &str) -> anyhow::Result<()> {
+    pub fn init_session(&mut self, provider_name: &str, cwd: &str, session_id: Option<&str>) -> anyhow::Result<()> {
         if let Some(mgr) = &self.session_manager {
-            let session = mgr.create(provider_name, &self.model, cwd)?;
+            let session = mgr.create(provider_name, &self.model, cwd, session_id)?;
             self.current_session = Some(session);
         }
         Ok(())
+    }
+
+    /// Get the current session ID (if sessions are enabled and initialized)
+    pub fn current_session_id(&self) -> Option<String> {
+        self.current_session.as_ref().map(|s| s.id.clone())
     }
 
     /// Get a reference to the output sink

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,10 @@ struct Cli {
     #[arg(long)]
     resume: Option<String>,
 
+    /// Use a specific session ID (instead of auto-generating one)
+    #[arg(long)]
+    session_id: Option<String>,
+
     /// List saved sessions
     #[arg(long)]
     list_sessions: bool,
@@ -106,6 +110,10 @@ struct Cli {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+
+    if cli.resume.is_some() && cli.session_id.is_some() {
+        anyhow::bail!("Cannot use --resume and --session-id together");
+    }
 
     // Handle --config-path
     if cli.config_path {
@@ -220,7 +228,7 @@ async fn main() -> anyhow::Result<()> {
     registry.register(Box::new(SpawnTool::new(spawner)));
 
     if cli.json_stream {
-        return run_json_stream_mode(config, registry, provider, mcp_manager).await;
+        return run_json_stream_mode(config, registry, provider, mcp_manager, cli.resume, cli.session_id).await;
     }
 
     let provider_name = format!("{:?}", config.provider).to_lowercase();
@@ -241,7 +249,7 @@ async fn main() -> anyhow::Result<()> {
         AgentEngine::resume_with_provider(provider, config, registry, output.clone(), session)
     } else {
         let mut engine = AgentEngine::new_with_provider(provider, config, registry, output.clone());
-        engine.init_session(&provider_name, &cwd)?;
+        engine.init_session(&provider_name, &cwd, cli.session_id.as_deref())?;
         engine
     };
 
@@ -314,20 +322,34 @@ async fn run_json_stream_mode(
     registry: ToolRegistry,
     provider: Arc<dyn aionrs::provider::LlmProvider>,
     mcp_manager: Option<Arc<McpManager>>,
+    resume: Option<String>,
+    session_id: Option<String>,
 ) -> anyhow::Result<()> {
     let writer = Arc::new(ProtocolWriter::new());
     let protocol_sink = Arc::new(ProtocolSink::new(writer.clone()));
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let output: Arc<dyn OutputSink> = protocol_sink.clone();
-
     let has_mcp = mcp_manager.is_some();
-    protocol_sink.emit_ready(has_mcp);
 
     let provider_name = format!("{:?}", config.provider).to_lowercase();
     let cwd = std::env::current_dir()?.to_string_lossy().to_string();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output.clone());
-    engine.init_session(&provider_name, &cwd)?;
+    let mut engine = if let Some(resume_id) = resume {
+        let session_mgr = session::SessionManager::new(
+            config.session.directory.clone().into(),
+            config.session.max_sessions,
+        );
+        let session = session_mgr.load(&resume_id)?;
+        AgentEngine::resume_with_provider(provider, config, registry, output.clone(), session)
+    } else {
+        let mut engine = AgentEngine::new_with_provider(provider, config, registry, output.clone());
+        engine.init_session(&provider_name, &cwd, session_id.as_deref())?;
+        engine
+    };
+
+    let sid = engine.current_session_id();
+    protocol_sink.emit_ready(has_mcp, sid);
+
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer.clone());
 

--- a/src/output/protocol_sink.rs
+++ b/src/output/protocol_sink.rs
@@ -18,9 +18,10 @@ impl ProtocolSink {
     }
 
     /// Emit the ready event at session start
-    pub fn emit_ready(&self, has_mcp: bool) {
+    pub fn emit_ready(&self, has_mcp: bool, session_id: Option<String>) {
         self.writer.emit(&ProtocolEvent::Ready {
             version: env!("CARGO_PKG_VERSION").to_string(),
+            session_id,
             capabilities: Capabilities {
                 tool_approval: true,
                 thinking: true,

--- a/src/protocol/events.rs
+++ b/src/protocol/events.rs
@@ -8,6 +8,8 @@ use serde_json::Value;
 pub enum ProtocolEvent {
     Ready {
         version: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        session_id: Option<String>,
         capabilities: Capabilities,
     },
     StreamStart {
@@ -138,6 +140,7 @@ mod tests {
     fn test_ready_event_serialization() {
         let event = ProtocolEvent::Ready {
             version: "0.1.0".to_string(),
+            session_id: Some("abc123".to_string()),
             capabilities: Capabilities {
                 tool_approval: true,
                 thinking: true,
@@ -147,7 +150,21 @@ mod tests {
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "ready");
         assert_eq!(json["version"], "0.1.0");
+        assert_eq!(json["session_id"], "abc123");
         assert_eq!(json["capabilities"]["tool_approval"], true);
+
+        // session_id omitted when None
+        let event_no_sid = ProtocolEvent::Ready {
+            version: "0.1.0".to_string(),
+            session_id: None,
+            capabilities: Capabilities {
+                tool_approval: true,
+                thinking: true,
+                mcp: false,
+            },
+        };
+        let json2 = serde_json::to_value(&event_no_sid).unwrap();
+        assert!(json2.get("session_id").is_none());
     }
 
     #[test]

--- a/src/protocol/writer.rs
+++ b/src/protocol/writer.rs
@@ -40,6 +40,7 @@ mod tests {
         let writer = ProtocolWriter::new();
         let event = ProtocolEvent::Ready {
             version: "0.1.0".to_string(),
+            session_id: None,
             capabilities: Capabilities {
                 tool_approval: true,
                 thinking: false,

--- a/src/session.rs
+++ b/src/session.rs
@@ -47,10 +47,19 @@ impl SessionManager {
     }
 
     /// Create a new session, return it
-    pub fn create(&self, provider: &str, model: &str, cwd: &str) -> anyhow::Result<Session> {
+    pub fn create(&self, provider: &str, model: &str, cwd: &str, session_id: Option<&str>) -> anyhow::Result<Session> {
         std::fs::create_dir_all(&self.directory)?;
 
-        let id = generate_short_id();
+        let id = if let Some(custom_id) = session_id {
+            // Validate that the ID doesn't already exist
+            let index = self.load_index()?;
+            if index.sessions.iter().any(|s| s.id == custom_id) {
+                anyhow::bail!("Session ID '{}' already exists", custom_id);
+            }
+            custom_id.to_string()
+        } else {
+            generate_short_id()
+        };
         let session = Session {
             id,
             created_at: Utc::now(),
@@ -243,7 +252,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let manager = SessionManager::new(dir.path().to_path_buf(), 10);
 
-        let result = manager.create("openai", "gpt-4", "/tmp");
+        let result = manager.create("openai", "gpt-4", "/tmp", None);
         assert!(result.is_ok());
 
         let session = result.unwrap();
@@ -258,7 +267,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let manager = SessionManager::new(dir.path().to_path_buf(), 10);
 
-        let session = manager.create("anthropic", "claude-3", "/home").unwrap();
+        let session = manager.create("anthropic", "claude-3", "/home", None).unwrap();
         let loaded = manager.load(&session.id).unwrap();
 
         assert_eq!(loaded.id, session.id);
@@ -290,8 +299,8 @@ mod tests {
         let dir = tempdir().unwrap();
         let manager = SessionManager::new(dir.path().to_path_buf(), 10);
 
-        let s1 = manager.create("openai", "gpt-4", "/tmp").unwrap();
-        let s2 = manager.create("anthropic", "claude-3", "/home").unwrap();
+        let s1 = manager.create("openai", "gpt-4", "/tmp", None).unwrap();
+        let s2 = manager.create("anthropic", "claude-3", "/home", None).unwrap();
 
         let list = manager.list().unwrap();
         assert_eq!(list.len(), 2);
@@ -306,7 +315,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let manager = SessionManager::new(dir.path().to_path_buf(), 10);
 
-        let mut session = manager.create("openai", "gpt-4", "/tmp").unwrap();
+        let mut session = manager.create("openai", "gpt-4", "/tmp", None).unwrap();
 
         let msg = Message {
             role: Role::User,
@@ -329,9 +338,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let manager = SessionManager::new(dir.path().to_path_buf(), 2);
 
-        let _s1 = manager.create("openai", "gpt-4", "/tmp").unwrap();
-        let _s2 = manager.create("openai", "gpt-4", "/tmp").unwrap();
-        let _s3 = manager.create("openai", "gpt-4", "/tmp").unwrap();
+        let _s1 = manager.create("openai", "gpt-4", "/tmp", None).unwrap();
+        let _s2 = manager.create("openai", "gpt-4", "/tmp", None).unwrap();
+        let _s3 = manager.create("openai", "gpt-4", "/tmp", None).unwrap();
 
         let list = manager.list().unwrap();
         assert_eq!(list.len(), 2);

--- a/tests/engine_test.rs
+++ b/tests/engine_test.rs
@@ -183,7 +183,7 @@ async fn test_engine_message_accumulation() {
 
     // Initialize session so save_session() has a session to persist
     engine
-        .init_session("test-provider", "/tmp")
+        .init_session("test-provider", "/tmp", None)
         .expect("init_session should succeed");
 
     engine.run("First message", "").await.expect("first run should succeed");


### PR DESCRIPTION
## Summary

- Add `--session-id` CLI flag to specify a custom session ID (mutually exclusive with `--resume`)
- Add `--resume` support in `--json-stream` mode (previously only worked in interactive mode)
- Include `session_id` in the `Ready` protocol event so host clients can discover the session ID
- `SessionManager::create` now accepts an optional ID with collision validation
- `AgentEngine::current_session_id()` helper for retrieving the active session ID

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy` passes (no new warnings)
- [x] `cargo test` — 222/222 tests pass
- [x] Manual: `aionrs --json-stream --session-id my-id ...` emits `session_id` in Ready event
- [x] Manual: `aionrs --json-stream --resume my-id ...` resumes session and emits `session_id`
- [x] Manual: `aionrs --resume x --session-id y` errors with mutual exclusion message
- [x] Manual: `aionrs --session-id existing-id` errors when ID already exists