### PR TITLE
chore: add release-please-config.json

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,34 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
+  "include-v-in-tag": true,
   "packages": {
     ".": {
-      "release-type": "rust",
       "package-name": "aionrs",
-      "changelog-path": "CHANGELOG.md"
+      "include-component-in-tag": false,
+      "release-type": "rust",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
+        }
+      ]
     }
-  }
+  },
+  "changelog-sections": [
+    {"type": "feat", "section": "Features", "hidden": false},
+    {"type": "fix", "section": "Bug Fixes", "hidden": false},
+    {"type": "perf", "section": "Performance Improvements", "hidden": false},
+    {"type": "refactor", "section": "Code Refactoring", "hidden": false},
+    {"type": "docs", "section": "Documentation", "hidden": false},
+    {"type": "style", "section": "Styles", "hidden": true},
+    {"type": "chore", "section": "Miscellaneous Chores", "hidden": true},
+    {"type": "test", "section": "Tests", "hidden": true},
+    {"type": "ci", "section": "Continuous Integration", "hidden": true},
+    {"type": "build", "section": "Build System", "hidden": true}
+  ]
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "rust",
+  "packages": {
+    ".": {
+      "release-type": "rust",
+      "package-name": "aionrs",
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add missing `release-please-config.json` required by `googleapis/release-please-action@v4`
- The `.release-please-manifest.json` already existed but the config file was absent, causing the workflow to fail with `Missing required manifest config: release-please-config.json`
- Config uses `release-type: rust` matching the project, with `packages["."]` aligned to the manifest key

## Test plan

- [ ] Merge PR to main
- [ ] Verify the `Release Please` workflow runs successfully on next push to main