### PR TITLE
fix(ci): fix action versions and install cargo-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Setup vx (installs Rust + just from vx.toml)
         uses: loonghao/vx@v0.8.23
@@ -36,6 +36,11 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
 
       - name: Check formatting
         run: vx just fmt-check
@@ -52,7 +57,7 @@ jobs:
 
       - name: Upload nextest JUnit report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: nextest-junit-${{ matrix.os }}
           path: target/nextest/ci/junit.xml
@@ -87,7 +92,7 @@ jobs:
             target: aarch64-pc-windows-msvc
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Setup vx (installs Rust from vx.toml)
         uses: loonghao/vx@v0.8.23
@@ -120,10 +125,10 @@ jobs:
       checks: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Download nextest JUnit artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           pattern: nextest-junit-*
           merge-multiple: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup vx (installs Rust + just from vx.toml)
         uses: loonghao/vx@v0.8.23
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload nextest JUnit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nextest-junit-${{ matrix.os }}
           path: target/nextest/ci/junit.xml
@@ -92,7 +92,7 @@ jobs:
             target: aarch64-pc-windows-msvc
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup vx (installs Rust from vx.toml)
         uses: loonghao/vx@v0.8.23
@@ -125,10 +125,10 @@ jobs:
       checks: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download nextest JUnit artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: nextest-junit-*
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
             archive: zip
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Setup vx (installs Rust from vx.toml)
         uses: loonghao/vx@v0.8.23
@@ -89,7 +89,7 @@ jobs:
           "ASSET=$archive" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Upload release asset
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -100,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
             archive: zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup vx (installs Rust from vx.toml)
         uses: loonghao/vx@v0.8.23
@@ -89,7 +89,7 @@ jobs:
           "ASSET=$archive" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Upload release asset
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -100,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary

- Replace non-existent `actions/checkout@v6`, `actions/upload-artifact@v6`, `actions/download-artifact@v6` with the correct `@v4` versions. These `@v6` tags do not exist, which caused the build artifacts to fail uploading and the release job to fail downloading them — resulting in no binaries being attached to GitHub Releases.
- Add `taiki-e/install-action` step for `cargo-audit` in `ci.yml` to fix the "Security audit" step failing with exit code 101 (`cargo-audit` binary was not installed before being invoked).

## Root Causes

| File | Issue | Fix |
|------|-------|-----|
| `release.yml` | `actions/checkout@v6`, `upload-artifact@v6`, `download-artifact@v6` are non-existent tags | Changed to `@v4` |
| `ci.yml` | `actions/checkout@v6`, `upload-artifact@v6`, `download-artifact@v6` are non-existent tags | Changed to `@v4` |
| `ci.yml` | `cargo audit` called without installing `cargo-audit` first → exit code 101 | Added `taiki-e/install-action@v2` for `cargo-audit` before the audit step |

## Test Plan

- [ ] Verify CI workflow passes on all three platforms (ubuntu, macos, windows)
- [ ] Trigger a release tag and confirm binaries are uploaded to GitHub Releases
- [ ] Confirm "Security audit" step no longer fails with exit code 101