### PR TITLE
fix(ci): handle scoped release commit message in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
   # ─── Job 1: Tag + GitHub Release (release commits only) ───────────────────
   release:
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.head_commit.message, 'chore: release')"
+    if: "startsWith(github.event.head_commit.message, 'chore: release') || startsWith(github.event.head_commit.message, 'chore(main): release')"
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -56,7 +56,7 @@ jobs:
   # ─── Job 2: Create/update release PR (non-release commits) ────────────────
   update-pr:
     runs-on: ubuntu-latest
-    if: "!startsWith(github.event.head_commit.message, 'chore: release')"
+    if: "!startsWith(github.event.head_commit.message, 'chore: release') && !startsWith(github.event.head_commit.message, 'chore(main): release')"
     steps:
       - uses: googleapis/release-please-action@v4
         with:


### PR DESCRIPTION
## Summary

- `release-please` was generating commit messages like `chore(main): release 0.1.6` (with scope)
- The `if` condition in `release-please.yml` only matched `chore: release` (no scope)
- This caused Job 1 to be silently skipped, so `release.yml` was never triggered

## Changes

- Updated `release` job condition to also match `chore(main): release`
- Updated `update-pr` job condition to exclude `chore(main): release` (prevents duplicate PR bug)

## Test plan

- [ ] Merge this PR into `main`
- [ ] Verify `update-pr` job runs and updates/creates the release PR
- [ ] Merge the release PR and verify Job 1 triggers + `release.yml` builds binaries