### PR TITLE
feat: runtime config and capability discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@
 tarpaulin-report.html
 lcov.info
 coverage/
+
+# Superpowers brainstorm tool (runtime files, session data)
+.superpowers/
+docs/superpowers/

--- a/crates/aion-agent/src/context.rs
+++ b/crates/aion-agent/src/context.rs
@@ -34,7 +34,7 @@ the diff, which is easier to review.
 /// Build the system prompt from config and environment.
 ///
 /// Sections are assembled in this order:
-/// 1. Base intro (role, working directory, date)
+/// 1. Base intro (role, model identity, working directory, date)
 /// 2. Tool usage guidance (dedicated tools, parallel calls, etc.)
 /// 3. Custom prompt (user config)
 /// 4. AGENTS.md (project instructions)
@@ -44,6 +44,7 @@ the diff, which is easier to review.
 pub fn build_system_prompt(
     custom_prompt: Option<&str>,
     cwd: &str,
+    model: &str,
     skills: &[SkillMetadata],
     context_window_tokens: Option<usize>,
     memory_dir: Option<&Path>,
@@ -53,6 +54,7 @@ pub fn build_system_prompt(
 
     parts.push(format!(
         "You are an AI assistant that can use tools to help with tasks.\n\
+         You are powered by the model {model}.\n\
          Working directory: {cwd}\n\
          Current date: {}",
         chrono::Local::now().format("%Y-%m-%d")
@@ -186,15 +188,29 @@ mod tests {
     fn test_build_system_prompt_includes_cwd() {
         // Verify that the returned prompt contains the provided working directory path
         let cwd = "/some/test/path";
-        let prompt = build_system_prompt(None, cwd, &[], None, None, false);
+        let prompt = build_system_prompt(None, cwd, "test-model", &[], None, None, false);
         assert!(prompt.contains(cwd), "system prompt should contain the cwd");
+    }
+
+    #[test]
+    fn test_build_system_prompt_includes_model_name() {
+        let prompt = build_system_prompt(None, "/tmp", "deepseek-chat", &[], None, None, false);
+        assert!(
+            prompt.contains("deepseek-chat"),
+            "system prompt should contain the model name"
+        );
+        assert!(
+            prompt.contains("You are powered by the model deepseek-chat"),
+            "system prompt should contain the model identity line"
+        );
     }
 
     #[test]
     fn test_build_system_prompt_with_custom_instructions() {
         // Verify that custom instructions are included in the returned prompt
         let custom = "Always respond in haiku.";
-        let prompt = build_system_prompt(Some(custom), "/tmp", &[], None, None, false);
+        let prompt =
+            build_system_prompt(Some(custom), "/tmp", "test-model", &[], None, None, false);
         assert!(
             prompt.contains(custom),
             "system prompt should contain the custom instructions"
@@ -314,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_no_skills_no_reminder() {
-        let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             !result.contains("The following skills are available"),
             "empty skills should not inject skill reminder"
@@ -327,7 +343,7 @@ mod tests {
             make_test_skill("skill-one", "Does one", false, false),
             make_test_skill("skill-two", "Does two", false, false),
         ];
-        let result = build_system_prompt(None, "/tmp", &skills, None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
         assert!(
             result.contains("<system-reminder>"),
             "result should contain <system-reminder>"
@@ -350,7 +366,7 @@ mod tests {
             make_test_skill("visible-skill", "Visible", false, false),
             make_test_skill("hidden-skill", "Hidden", false, true),
         ];
-        let result = build_system_prompt(None, "/tmp", &skills, None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
         assert!(
             result.contains("visible-skill"),
             "visible skill should appear"
@@ -367,7 +383,7 @@ mod tests {
             make_test_skill("hidden-a", "Hidden A", false, true),
             make_test_skill("hidden-b", "Hidden B", false, true),
         ];
-        let result = build_system_prompt(None, "/tmp", &skills, None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
         assert!(
             !result.contains("The following skills are available"),
             "all-hidden skills should not inject reminder"
@@ -380,6 +396,7 @@ mod tests {
         let result = build_system_prompt(
             Some("Custom instructions here"),
             "/tmp",
+            "test-model",
             &skills,
             None,
             None,
@@ -398,7 +415,15 @@ mod tests {
     #[test]
     fn test_build_system_prompt_skills_reminder_after_custom_prompt() {
         let skills = vec![make_test_skill("my-skill", "My desc", false, false)];
-        let result = build_system_prompt(Some("Custom text"), "/tmp", &skills, None, None, false);
+        let result = build_system_prompt(
+            Some("Custom text"),
+            "/tmp",
+            "test-model",
+            &skills,
+            None,
+            None,
+            false,
+        );
         let custom_pos = result.find("Custom text").unwrap();
         let reminder_pos = result.rfind("<system-reminder>").unwrap();
         assert!(
@@ -411,7 +436,8 @@ mod tests {
     fn test_build_system_prompt_small_budget_triggers_minimal_mode() {
         // context_window_tokens = 50 → budget = 2 chars, triggers minimal mode for non-bundled
         let skill = make_test_skill("nb-skill", &"x".repeat(100), false, false);
-        let result = build_system_prompt(None, "/tmp", &[skill], Some(50), None, false);
+        let result =
+            build_system_prompt(None, "/tmp", "test-model", &[skill], Some(50), None, false);
         // Minimal mode: skill appears as name only, no ': '
         assert!(
             result.contains("- nb-skill"),
@@ -425,7 +451,15 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_cwd_in_prompt() {
-        let result = build_system_prompt(None, "/workspace/my-project", &[], None, None, false);
+        let result = build_system_prompt(
+            None,
+            "/workspace/my-project",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             result.contains("/workspace/my-project"),
             "cwd should appear in the system prompt"
@@ -441,7 +475,15 @@ mod tests {
         std::fs::write(cwd.join("AGENTS.md"), "AGENTS_CONTENT_HERE").unwrap();
         std::fs::write(cwd.join("CLAUDE.md"), "CLAUDE_CONTENT_HERE").unwrap();
 
-        let result = build_system_prompt(None, &cwd.to_string_lossy(), &[], None, None, false);
+        let result = build_system_prompt(
+            None,
+            &cwd.to_string_lossy(),
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
 
         assert!(
             result.contains("AGENTS_CONTENT_HERE"),
@@ -465,7 +507,15 @@ mod tests {
         // Only CLAUDE.md exists, no AGENTS.md
         std::fs::write(cwd.join("CLAUDE.md"), "SHOULD_NOT_APPEAR").unwrap();
 
-        let result = build_system_prompt(None, &cwd.to_string_lossy(), &[], None, None, false);
+        let result = build_system_prompt(
+            None,
+            &cwd.to_string_lossy(),
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
 
         assert!(
             !result.contains("SHOULD_NOT_APPEAR"),
@@ -481,7 +531,7 @@ mod tests {
 
     #[test]
     fn memory_none_dir_no_injection() {
-        let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             !result.contains("auto memory"),
             "no memory content when memory_dir is None"
@@ -499,7 +549,8 @@ mod tests {
         )
         .unwrap();
 
-        let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+        let result =
+            build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
         assert!(
             result.contains("auto memory"),
@@ -520,6 +571,7 @@ mod tests {
         let result = build_system_prompt(
             None,
             "/tmp",
+            "test-model",
             &[],
             None,
             Some(Path::new("/nonexistent/memory/dir")),
@@ -540,7 +592,8 @@ mod tests {
         std::fs::create_dir_all(&mem_dir).unwrap();
         // No MEMORY.md
 
-        let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+        let result =
+            build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
         assert!(
             result.contains("currently empty"),
@@ -566,6 +619,7 @@ mod tests {
         let result = build_system_prompt(
             None,
             &cwd.to_string_lossy(),
+            "test-model",
             &skills,
             None,
             Some(&mem_dir),
@@ -597,7 +651,8 @@ mod tests {
         )
         .unwrap();
 
-        let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+        let result =
+            build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
         assert!(
             !result.contains("~/.claude"),
@@ -613,7 +668,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_section_exists() {
-        let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("# Using your tools"),
             "system prompt should contain the tool guidance heading"
@@ -622,7 +677,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_bash_prohibition_list() {
-        let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("Glob"),
             "should mention Glob as find/ls replacement"
@@ -647,7 +702,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_parallel_call_rules() {
-        let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("parallel"),
             "should contain parallel call guidance"
@@ -660,7 +715,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_edit_over_write_preference() {
-        let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("Prefer Edit over Write"),
             "should contain Edit-over-Write preference"
@@ -669,7 +724,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_read_before_edit_rule() {
-        let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("Read a file before editing"),
             "should contain Read-before-Edit rule"
@@ -678,7 +733,15 @@ mod tests {
 
     #[test]
     fn tool_guidance_after_intro_before_custom_prompt() {
-        let result = build_system_prompt(Some("CUSTOM_MARKER_43"), "/tmp", &[], None, None, false);
+        let result = build_system_prompt(
+            Some("CUSTOM_MARKER_43"),
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         let intro_pos = result.find("Working directory").unwrap();
         let guidance_pos = result.find("# Using your tools").unwrap();
         let custom_pos = result.find("CUSTOM_MARKER_43").unwrap();
@@ -695,7 +758,7 @@ mod tests {
     #[test]
     fn tool_guidance_before_skills_reminder() {
         let skills = vec![make_test_skill("guide-test-skill", "A skill", false, false)];
-        let result = build_system_prompt(None, "/tmp", &skills, None, None, false);
+        let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
         let guidance_pos = result.find("# Using your tools").unwrap();
         let skills_pos = result.find("guide-test-skill").unwrap();
         assert!(
@@ -706,7 +769,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_present_in_plan_mode() {
-        let result = build_system_prompt(None, "/tmp", &[], None, None, true);
+        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, true);
         assert!(
             result.contains("# Using your tools"),
             "tool guidance should be present in plan mode"
@@ -720,7 +783,8 @@ mod tests {
         std::fs::create_dir_all(&mem_dir).unwrap();
         std::fs::write(mem_dir.join("MEMORY.md"), "- [X](x.md) \u{2014} test\n").unwrap();
 
-        let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+        let result =
+            build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
         let guidance_pos = result.find("# Using your tools").unwrap();
         let memory_pos = result.find("auto memory").unwrap();
         assert!(

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -226,16 +226,65 @@ impl AgentEngine {
         self.plan_active_flag = Some(flag);
     }
 
+    /// Default thinking budget when "enabled" is requested without a specific budget.
+    const DEFAULT_THINKING_BUDGET: u32 = 10_000;
+
     /// Apply a runtime config update received from the protocol layer.
     ///
     /// Returns a list of human-readable change descriptions for the Info event.
     /// Empty list means no fields were changed.
-    pub fn apply_config_update(&mut self, model: Option<String>) -> Vec<String> {
+    pub fn apply_config_update(
+        &mut self,
+        model: Option<String>,
+        thinking: Option<String>,
+        thinking_budget: Option<u32>,
+        effort: Option<String>,
+    ) -> Vec<String> {
         let mut changes = Vec::new();
+
         if let Some(new_model) = model {
             let old = std::mem::replace(&mut self.model, new_model.clone());
             changes.push(format!("model: {old} → {new_model}"));
         }
+
+        if let Some(thinking_str) = thinking {
+            match thinking_str.as_str() {
+                "enabled" => {
+                    let budget = thinking_budget.unwrap_or(Self::DEFAULT_THINKING_BUDGET);
+                    self.thinking = Some(aion_types::llm::ThinkingConfig::Enabled {
+                        budget_tokens: budget,
+                    });
+                    changes.push(format!("thinking: enabled (budget: {budget})"));
+                }
+                "disabled" => {
+                    self.thinking = Some(aion_types::llm::ThinkingConfig::Disabled);
+                    changes.push("thinking: disabled".to_string());
+                }
+                other => {
+                    changes.push(format!("thinking: ignored invalid value \"{other}\""));
+                }
+            }
+        } else if let Some(new_budget) = thinking_budget
+            && let Some(aion_types::llm::ThinkingConfig::Enabled { budget_tokens }) =
+                &mut self.thinking
+        {
+            *budget_tokens = new_budget;
+            changes.push(format!("thinking budget: {new_budget}"));
+        }
+
+        if let Some(new_effort) = effort {
+            if new_effort.is_empty() {
+                self.current_reasoning_effort = None;
+                changes.push("effort: cleared".to_string());
+            } else {
+                let old = self
+                    .current_reasoning_effort
+                    .replace(new_effort.clone())
+                    .unwrap_or_else(|| "none".to_string());
+                changes.push(format!("effort: {old} → {new_effort}"));
+            }
+        }
+
         changes
     }
 
@@ -638,10 +687,12 @@ mod set_config_tests {
         }
     }
 
+    // --- Cycle 1 tests (updated signature) ---
+
     #[test]
     fn set_config_changes_model() {
         let mut engine = make_engine("old-model");
-        let changes = engine.apply_config_update(Some("new-model".into()));
+        let changes = engine.apply_config_update(Some("new-model".into()), None, None, None);
         assert_eq!(engine.model, "new-model");
         assert_eq!(changes.len(), 1);
         assert!(changes[0].contains("old-model"));
@@ -651,7 +702,7 @@ mod set_config_tests {
     #[test]
     fn set_config_none_model_no_change() {
         let mut engine = make_engine("current");
-        let changes = engine.apply_config_update(None);
+        let changes = engine.apply_config_update(None, None, None, None);
         assert_eq!(engine.model, "current");
         assert!(changes.is_empty());
     }
@@ -659,14 +710,14 @@ mod set_config_tests {
     #[test]
     fn set_config_same_model_still_reports_change() {
         let mut engine = make_engine("same");
-        let changes = engine.apply_config_update(Some("same".into()));
+        let changes = engine.apply_config_update(Some("same".into()), None, None, None);
         assert_eq!(changes.len(), 1);
     }
 
     #[test]
     fn set_config_empty_string_model_accepted() {
         let mut engine = make_engine("real-model");
-        engine.apply_config_update(Some(String::new()));
+        engine.apply_config_update(Some(String::new()), None, None, None);
         assert_eq!(engine.model, "");
     }
 
@@ -674,9 +725,154 @@ mod set_config_tests {
     fn set_config_model_does_not_affect_other_state() {
         let mut engine = make_engine("m");
         engine.current_reasoning_effort = Some("high".into());
-        engine.apply_config_update(Some("new-m".into()));
+        engine.apply_config_update(Some("new-m".into()), None, None, None);
         assert_eq!(engine.model, "new-m");
         assert_eq!(engine.current_reasoning_effort.as_deref(), Some("high"));
+    }
+
+    // --- Cycle 2: Effort config tests ---
+
+    #[test]
+    fn set_config_changes_effort() {
+        let mut engine = make_engine("m");
+        assert!(engine.current_reasoning_effort.is_none());
+        let changes = engine.apply_config_update(None, None, None, Some("high".into()));
+        assert_eq!(engine.current_reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(changes.len(), 1);
+        assert!(changes[0].contains("high"));
+    }
+
+    #[test]
+    fn set_config_clears_effort_with_empty_string() {
+        let mut engine = make_engine("m");
+        engine.current_reasoning_effort = Some("high".into());
+        let changes = engine.apply_config_update(None, None, None, Some(String::new()));
+        assert!(engine.current_reasoning_effort.is_none());
+        assert_eq!(changes.len(), 1);
+    }
+
+    // --- Cycle 2: Thinking config tests ---
+
+    #[test]
+    fn set_config_enables_thinking() {
+        let mut engine = make_engine("m");
+        let changes = engine.apply_config_update(None, Some("enabled".into()), Some(16000), None);
+        match &engine.thinking {
+            Some(aion_types::llm::ThinkingConfig::Enabled { budget_tokens }) => {
+                assert_eq!(*budget_tokens, 16000);
+            }
+            other => panic!("expected Enabled, got: {other:?}"),
+        }
+        assert_eq!(changes.len(), 1);
+    }
+
+    #[test]
+    fn set_config_disables_thinking() {
+        let mut engine = make_engine("m");
+        engine.thinking = Some(aion_types::llm::ThinkingConfig::Enabled {
+            budget_tokens: 8000,
+        });
+        let changes = engine.apply_config_update(None, Some("disabled".into()), None, None);
+        match &engine.thinking {
+            Some(aion_types::llm::ThinkingConfig::Disabled) => {}
+            other => panic!("expected Disabled, got: {other:?}"),
+        }
+        assert_eq!(changes.len(), 1);
+    }
+
+    #[test]
+    fn set_config_thinking_enabled_default_budget() {
+        let mut engine = make_engine("m");
+        let changes = engine.apply_config_update(None, Some("enabled".into()), None, None);
+        match &engine.thinking {
+            Some(aion_types::llm::ThinkingConfig::Enabled { budget_tokens }) => {
+                assert!(*budget_tokens > 0);
+            }
+            other => panic!("expected Enabled with default budget, got: {other:?}"),
+        }
+        assert_eq!(changes.len(), 1);
+    }
+
+    #[test]
+    fn set_config_invalid_thinking_ignored() {
+        let mut engine = make_engine("m");
+        engine.thinking = Some(aion_types::llm::ThinkingConfig::Enabled {
+            budget_tokens: 8000,
+        });
+        let changes = engine.apply_config_update(None, Some("invalid_value".into()), None, None);
+        match &engine.thinking {
+            Some(aion_types::llm::ThinkingConfig::Enabled { budget_tokens }) => {
+                assert_eq!(*budget_tokens, 8000);
+            }
+            other => panic!("expected Enabled unchanged, got: {other:?}"),
+        }
+        assert_eq!(changes.len(), 1);
+        assert!(changes[0].contains("invalid") || changes[0].contains("ignored"));
+    }
+
+    // --- Cycle 2: Combined fields test ---
+
+    #[test]
+    fn set_config_all_fields_at_once() {
+        let mut engine = make_engine("old-model");
+        let changes = engine.apply_config_update(
+            Some("new-model".into()),
+            Some("enabled".into()),
+            Some(12000),
+            Some("low".into()),
+        );
+        assert_eq!(engine.model, "new-model");
+        assert_eq!(engine.current_reasoning_effort.as_deref(), Some("low"));
+        match &engine.thinking {
+            Some(aion_types::llm::ThinkingConfig::Enabled { budget_tokens }) => {
+                assert_eq!(*budget_tokens, 12000);
+            }
+            other => panic!("expected Enabled, got: {other:?}"),
+        }
+        assert_eq!(changes.len(), 3);
+    }
+
+    // --- Cycle 2: White-box edge case tests ---
+
+    #[test]
+    fn set_config_thinking_budget_only_updates_existing_enabled() {
+        let mut engine = make_engine("m");
+        engine.thinking = Some(aion_types::llm::ThinkingConfig::Enabled {
+            budget_tokens: 5000,
+        });
+        let changes = engine.apply_config_update(None, None, Some(20000), None);
+        match &engine.thinking {
+            Some(aion_types::llm::ThinkingConfig::Enabled { budget_tokens }) => {
+                assert_eq!(*budget_tokens, 20000);
+            }
+            other => panic!("expected Enabled with 20000, got: {other:?}"),
+        }
+        assert_eq!(changes.len(), 1);
+    }
+
+    #[test]
+    fn set_config_thinking_budget_ignored_when_disabled() {
+        let mut engine = make_engine("m");
+        engine.thinking = Some(aion_types::llm::ThinkingConfig::Disabled);
+        let changes = engine.apply_config_update(None, None, Some(20000), None);
+        match &engine.thinking {
+            Some(aion_types::llm::ThinkingConfig::Disabled) => {}
+            other => panic!("expected Disabled unchanged, got: {other:?}"),
+        }
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn set_config_effort_valid_values() {
+        for value in ["low", "medium", "high", "max"] {
+            let mut engine = make_engine("m");
+            engine.apply_config_update(None, None, None, Some(value.to_string()));
+            assert_eq!(
+                engine.current_reasoning_effort.as_deref(),
+                Some(value),
+                "effort should be set to {value}"
+            );
+        }
     }
 }
 

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -32,6 +32,8 @@ pub struct AgentEngine {
     max_turns: usize,
     total_usage: TokenUsage,
     thinking: Option<aion_types::llm::ThinkingConfig>,
+    /// Resolved provider compat settings (for capability validation)
+    compat: aion_config::compat::ProviderCompat,
     confirmer: Arc<Mutex<ToolConfirmer>>,
     hooks: Option<HookEngine>,
     session_manager: Option<SessionManager>,
@@ -94,6 +96,7 @@ impl AgentEngine {
             max_turns: config.max_turns,
             total_usage: TokenUsage::default(),
             thinking: config.thinking,
+            compat: config.compat.clone(),
             confirmer: Arc::new(Mutex::new(confirmer)),
             // Always initialise Some so that skill-declared hooks can be merged in
             // even when the global config has no static hooks configured.
@@ -158,6 +161,7 @@ impl AgentEngine {
             max_turns: config.max_turns,
             total_usage: session.total_usage.clone(),
             thinking: config.thinking,
+            compat: config.compat.clone(),
             confirmer: Arc::new(Mutex::new(confirmer)),
             hooks: Some(HookEngine::new(config.hooks.clone())),
             session_manager,
@@ -178,6 +182,11 @@ impl AgentEngine {
     /// Get a reference to the shared provider
     pub fn provider(&self) -> &Arc<dyn LlmProvider> {
         &self.provider
+    }
+
+    /// Get a reference to the resolved compat settings
+    pub fn compat(&self) -> &aion_config::compat::ProviderCompat {
+        &self.compat
     }
 
     /// Initialize a new session for this engine run
@@ -248,20 +257,24 @@ impl AgentEngine {
         }
 
         if let Some(thinking_str) = thinking {
-            match thinking_str.as_str() {
-                "enabled" => {
-                    let budget = thinking_budget.unwrap_or(Self::DEFAULT_THINKING_BUDGET);
-                    self.thinking = Some(aion_types::llm::ThinkingConfig::Enabled {
-                        budget_tokens: budget,
-                    });
-                    changes.push(format!("thinking: enabled (budget: {budget})"));
-                }
-                "disabled" => {
-                    self.thinking = Some(aion_types::llm::ThinkingConfig::Disabled);
-                    changes.push("thinking: disabled".to_string());
-                }
-                other => {
-                    changes.push(format!("thinking: ignored invalid value \"{other}\""));
+            if !self.compat.supports_thinking() {
+                changes.push("thinking: not supported by current provider".to_string());
+            } else {
+                match thinking_str.as_str() {
+                    "enabled" => {
+                        let budget = thinking_budget.unwrap_or(Self::DEFAULT_THINKING_BUDGET);
+                        self.thinking = Some(aion_types::llm::ThinkingConfig::Enabled {
+                            budget_tokens: budget,
+                        });
+                        changes.push(format!("thinking: enabled (budget: {budget})"));
+                    }
+                    "disabled" => {
+                        self.thinking = Some(aion_types::llm::ThinkingConfig::Disabled);
+                        changes.push("thinking: disabled".to_string());
+                    }
+                    other => {
+                        changes.push(format!("thinking: ignored invalid value \"{other}\""));
+                    }
                 }
             }
         } else if let Some(new_budget) = thinking_budget
@@ -276,12 +289,23 @@ impl AgentEngine {
             if new_effort.is_empty() {
                 self.current_reasoning_effort = None;
                 changes.push("effort: cleared".to_string());
+            } else if !self.compat.supports_effort() {
+                changes.push("effort: not supported by current provider".to_string());
             } else {
-                let old = self
-                    .current_reasoning_effort
-                    .replace(new_effort.clone())
-                    .unwrap_or_else(|| "none".to_string());
-                changes.push(format!("effort: {old} → {new_effort}"));
+                let levels = self.compat.effort_levels();
+                if !levels.is_empty() && !levels.iter().any(|l| l == &new_effort) {
+                    changes.push(format!(
+                        "effort: invalid level \"{}\" (valid: {})",
+                        new_effort,
+                        levels.join(", ")
+                    ));
+                } else {
+                    let old = self
+                        .current_reasoning_effort
+                        .replace(new_effort.clone())
+                        .unwrap_or_else(|| "none".to_string());
+                    changes.push(format!("effort: {old} → {new_effort}"));
+                }
             }
         }
 
@@ -670,6 +694,7 @@ mod set_config_tests {
             max_turns: 10,
             total_usage: Default::default(),
             thinking: None,
+            compat: aion_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
             hooks: None,
             session_manager: None,
@@ -685,6 +710,15 @@ mod set_config_tests {
             plan_state: Default::default(),
             plan_active_flag: None,
         }
+    }
+
+    fn make_engine_with_compat(
+        model: &str,
+        compat: aion_config::compat::ProviderCompat,
+    ) -> super::AgentEngine {
+        let mut engine = make_engine(model);
+        engine.compat = compat;
+        engine
     }
 
     // --- Cycle 1 tests (updated signature) ---
@@ -734,7 +768,8 @@ mod set_config_tests {
 
     #[test]
     fn set_config_changes_effort() {
-        let mut engine = make_engine("m");
+        let mut engine =
+            make_engine_with_compat("m", aion_config::compat::ProviderCompat::openai_defaults());
         assert!(engine.current_reasoning_effort.is_none());
         let changes = engine.apply_config_update(None, None, None, Some("high".into()));
         assert_eq!(engine.current_reasoning_effort.as_deref(), Some("high"));
@@ -814,7 +849,13 @@ mod set_config_tests {
 
     #[test]
     fn set_config_all_fields_at_once() {
-        let mut engine = make_engine("old-model");
+        let compat = aion_config::compat::ProviderCompat {
+            supports_thinking: Some(true),
+            supports_effort: Some(true),
+            effort_levels: Some(vec!["low".into()]),
+            ..Default::default()
+        };
+        let mut engine = make_engine_with_compat("old-model", compat);
         let changes = engine.apply_config_update(
             Some("new-model".into()),
             Some("enabled".into()),
@@ -864,8 +905,18 @@ mod set_config_tests {
 
     #[test]
     fn set_config_effort_valid_values() {
+        let compat = aion_config::compat::ProviderCompat {
+            supports_effort: Some(true),
+            effort_levels: Some(vec![
+                "low".into(),
+                "medium".into(),
+                "high".into(),
+                "max".into(),
+            ]),
+            ..Default::default()
+        };
         for value in ["low", "medium", "high", "max"] {
-            let mut engine = make_engine("m");
+            let mut engine = make_engine_with_compat("m", compat.clone());
             engine.apply_config_update(None, None, None, Some(value.to_string()));
             assert_eq!(
                 engine.current_reasoning_effort.as_deref(),
@@ -873,6 +924,47 @@ mod set_config_tests {
                 "effort should be set to {value}"
             );
         }
+    }
+
+    // --- Capability validation tests ---
+
+    #[test]
+    fn set_config_thinking_rejected_when_unsupported() {
+        let mut engine = make_engine_with_compat(
+            "m",
+            aion_config::compat::ProviderCompat::openai_defaults(),
+        );
+        let changes = engine.apply_config_update(None, Some("enabled".into()), None, None);
+        assert!(changes.iter().any(|c| c.contains("not supported")));
+        assert!(engine.thinking.is_none());
+    }
+
+    #[test]
+    fn set_config_effort_rejected_when_unsupported() {
+        let mut engine = make_engine("m"); // anthropic defaults: supports_effort = false
+        let changes = engine.apply_config_update(None, None, None, Some("high".into()));
+        assert!(changes.iter().any(|c| c.contains("not supported")));
+        assert!(engine.current_reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn set_config_effort_rejected_invalid_level() {
+        let mut engine = make_engine_with_compat(
+            "m",
+            aion_config::compat::ProviderCompat::openai_defaults(),
+        );
+        let changes = engine.apply_config_update(None, None, None, Some("max".into()));
+        assert!(changes.iter().any(|c| c.contains("invalid")));
+        assert!(engine.current_reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn set_config_effort_clear_always_works() {
+        let mut engine = make_engine("m"); // anthropic defaults: supports_effort = false
+        engine.current_reasoning_effort = Some("high".into());
+        let changes = engine.apply_config_update(None, None, None, Some(String::new()));
+        assert!(engine.current_reasoning_effort.is_none());
+        assert!(changes.iter().any(|c| c.contains("cleared")));
     }
 }
 
@@ -927,6 +1019,7 @@ mod phase6_tests {
             max_turns: 10,
             total_usage: Default::default(),
             thinking: None,
+            compat: aion_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, allow_list.clone()))),
             hooks: None,
             session_manager: None,
@@ -1125,6 +1218,7 @@ mod compact_tests {
             max_turns: 10,
             total_usage: Default::default(),
             thinking: None,
+            compat: aion_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
             hooks: None,
             session_manager: None,
@@ -1386,6 +1480,7 @@ mod plan_mode_tests {
             max_turns: 10,
             total_usage: Default::default(),
             thinking: None,
+            compat: aion_config::compat::ProviderCompat::anthropic_defaults(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, allow_list.clone()))),
             hooks: None,
             session_manager: None,

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -930,10 +930,8 @@ mod set_config_tests {
 
     #[test]
     fn set_config_thinking_rejected_when_unsupported() {
-        let mut engine = make_engine_with_compat(
-            "m",
-            aion_config::compat::ProviderCompat::openai_defaults(),
-        );
+        let mut engine =
+            make_engine_with_compat("m", aion_config::compat::ProviderCompat::openai_defaults());
         let changes = engine.apply_config_update(None, Some("enabled".into()), None, None);
         assert!(changes.iter().any(|c| c.contains("not supported")));
         assert!(engine.thinking.is_none());
@@ -949,10 +947,8 @@ mod set_config_tests {
 
     #[test]
     fn set_config_effort_rejected_invalid_level() {
-        let mut engine = make_engine_with_compat(
-            "m",
-            aion_config::compat::ProviderCompat::openai_defaults(),
-        );
+        let mut engine =
+            make_engine_with_compat("m", aion_config::compat::ProviderCompat::openai_defaults());
         let changes = engine.apply_config_update(None, None, None, Some("max".into()));
         assert!(changes.iter().any(|c| c.contains("invalid")));
         assert!(engine.current_reasoning_effort.is_none());

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -226,6 +226,19 @@ impl AgentEngine {
         self.plan_active_flag = Some(flag);
     }
 
+    /// Apply a runtime config update received from the protocol layer.
+    ///
+    /// Returns a list of human-readable change descriptions for the Info event.
+    /// Empty list means no fields were changed.
+    pub fn apply_config_update(&mut self, model: Option<String>) -> Vec<String> {
+        let mut changes = Vec::new();
+        if let Some(new_model) = model {
+            let old = std::mem::replace(&mut self.model, new_model.clone());
+            changes.push(format!("model: {old} → {new_model}"));
+        }
+        changes
+    }
+
     /// Run the agent loop with user input
     pub async fn run(&mut self, user_input: &str, msg_id: &str) -> Result<AgentResult, AgentError> {
         self.current_msg_id = msg_id.to_string();
@@ -555,6 +568,115 @@ impl AgentEngine {
                     .emit_error(&format!("Failed to update session index: {}", e));
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// set_config tests — apply_config_update()
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod set_config_tests {
+    use std::sync::{Arc, Mutex};
+
+    use aion_providers::{LlmProvider, ProviderError};
+    use aion_tools::registry::ToolRegistry;
+    use aion_types::llm::{LlmEvent, LlmRequest};
+
+    use crate::confirm::ToolConfirmer;
+    use crate::output::OutputSink;
+
+    struct NullOutput;
+    impl OutputSink for NullOutput {
+        fn emit_text_delta(&self, _: &str, _: &str) {}
+        fn emit_thinking(&self, _: &str, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_stream_start(&self, _: &str) {}
+        fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
+        fn emit_error(&self, _: &str) {}
+        fn emit_info(&self, _: &str) {}
+    }
+
+    struct NullProvider;
+    #[async_trait::async_trait]
+    impl LlmProvider for NullProvider {
+        async fn stream(
+            &self,
+            _: &LlmRequest,
+        ) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(rx)
+        }
+    }
+
+    fn make_engine(model: &str) -> super::AgentEngine {
+        super::AgentEngine {
+            provider: Arc::new(NullProvider),
+            tools: ToolRegistry::new(),
+            messages: vec![],
+            system_prompt: String::new(),
+            model: model.to_string(),
+            max_tokens: 4096,
+            max_turns: 10,
+            total_usage: Default::default(),
+            thinking: None,
+            confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
+            hooks: None,
+            session_manager: None,
+            current_session: None,
+            output: Arc::new(NullOutput),
+            current_msg_id: String::new(),
+            approval_manager: None,
+            protocol_writer: None,
+            allow_list: vec![],
+            current_reasoning_effort: None,
+            compact_config: aion_config::compact::CompactConfig::default(),
+            compact_state: super::CompactState::new(),
+            plan_state: Default::default(),
+            plan_active_flag: None,
+        }
+    }
+
+    #[test]
+    fn set_config_changes_model() {
+        let mut engine = make_engine("old-model");
+        let changes = engine.apply_config_update(Some("new-model".into()));
+        assert_eq!(engine.model, "new-model");
+        assert_eq!(changes.len(), 1);
+        assert!(changes[0].contains("old-model"));
+        assert!(changes[0].contains("new-model"));
+    }
+
+    #[test]
+    fn set_config_none_model_no_change() {
+        let mut engine = make_engine("current");
+        let changes = engine.apply_config_update(None);
+        assert_eq!(engine.model, "current");
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn set_config_same_model_still_reports_change() {
+        let mut engine = make_engine("same");
+        let changes = engine.apply_config_update(Some("same".into()));
+        assert_eq!(changes.len(), 1);
+    }
+
+    #[test]
+    fn set_config_empty_string_model_accepted() {
+        let mut engine = make_engine("real-model");
+        engine.apply_config_update(Some(String::new()));
+        assert_eq!(engine.model, "");
+    }
+
+    #[test]
+    fn set_config_model_does_not_affect_other_state() {
+        let mut engine = make_engine("m");
+        engine.current_reasoning_effort = Some("high".into());
+        engine.apply_config_update(Some("new-m".into()));
+        assert_eq!(engine.model, "new-m");
+        assert_eq!(engine.current_reasoning_effort.as_deref(), Some("high"));
     }
 }
 

--- a/crates/aion-agent/src/output/protocol_sink.rs
+++ b/crates/aion-agent/src/output/protocol_sink.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use aion_config::compat::ProviderCompat;
 use aion_protocol::events::{Capabilities, ErrorInfo, ProtocolEvent, Usage};
 use aion_protocol::writer::ProtocolWriter;
 
@@ -16,24 +17,35 @@ impl ProtocolSink {
     }
 
     /// Emit the ready event at session start
-    pub fn emit_ready(&self, has_mcp: bool, session_id: Option<String>) {
+    pub fn emit_ready(&self, compat: &ProviderCompat, has_mcp: bool, session_id: Option<String>) {
         let _ = self.writer.emit(&ProtocolEvent::Ready {
             version: env!("CARGO_PKG_VERSION").to_string(),
             session_id,
-            capabilities: Capabilities {
-                tool_approval: true,
-                thinking: true,
-                effort: false,
-                effort_levels: vec![],
-                modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
-                mcp: has_mcp,
-            },
+            capabilities: Self::build_capabilities(compat, has_mcp),
+        });
+    }
+
+    /// Emit a config_changed event after set_config updates
+    pub fn emit_config_changed(&self, compat: &ProviderCompat, has_mcp: bool) {
+        let _ = self.writer.emit(&ProtocolEvent::ConfigChanged {
+            capabilities: Self::build_capabilities(compat, has_mcp),
         });
     }
 
     /// Access the underlying writer for custom events
     pub fn writer(&self) -> &Arc<ProtocolWriter> {
         &self.writer
+    }
+
+    fn build_capabilities(compat: &ProviderCompat, has_mcp: bool) -> Capabilities {
+        Capabilities {
+            tool_approval: true,
+            thinking: compat.supports_thinking(),
+            effort: compat.supports_effort(),
+            effort_levels: compat.effort_levels().to_vec(),
+            modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+            mcp: has_mcp,
+        }
     }
 }
 

--- a/crates/aion-agent/src/output/protocol_sink.rs
+++ b/crates/aion-agent/src/output/protocol_sink.rs
@@ -17,18 +17,24 @@ impl ProtocolSink {
     }
 
     /// Emit the ready event at session start
-    pub fn emit_ready(&self, compat: &ProviderCompat, has_mcp: bool, session_id: Option<String>) {
+    pub fn emit_ready(
+        &self,
+        compat: &ProviderCompat,
+        has_mcp: bool,
+        session_id: Option<String>,
+        current_mode: &str,
+    ) {
         let _ = self.writer.emit(&ProtocolEvent::Ready {
             version: env!("CARGO_PKG_VERSION").to_string(),
             session_id,
-            capabilities: Self::build_capabilities(compat, has_mcp),
+            capabilities: Self::build_capabilities(compat, has_mcp, current_mode),
         });
     }
 
-    /// Emit a config_changed event after set_config updates
-    pub fn emit_config_changed(&self, compat: &ProviderCompat, has_mcp: bool) {
+    /// Emit a config_changed event after set_config or set_mode updates
+    pub fn emit_config_changed(&self, compat: &ProviderCompat, has_mcp: bool, current_mode: &str) {
         let _ = self.writer.emit(&ProtocolEvent::ConfigChanged {
-            capabilities: Self::build_capabilities(compat, has_mcp),
+            capabilities: Self::build_capabilities(compat, has_mcp, current_mode),
         });
     }
 
@@ -37,13 +43,18 @@ impl ProtocolSink {
         &self.writer
     }
 
-    fn build_capabilities(compat: &ProviderCompat, has_mcp: bool) -> Capabilities {
+    fn build_capabilities(
+        compat: &ProviderCompat,
+        has_mcp: bool,
+        current_mode: &str,
+    ) -> Capabilities {
         Capabilities {
             tool_approval: true,
             thinking: compat.supports_thinking(),
             effort: compat.supports_effort(),
             effort_levels: compat.effort_levels().to_vec(),
             modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+            current_mode: current_mode.to_string(),
             mcp: has_mcp,
         }
     }

--- a/crates/aion-agent/src/output/protocol_sink.rs
+++ b/crates/aion-agent/src/output/protocol_sink.rs
@@ -23,6 +23,9 @@ impl ProtocolSink {
             capabilities: Capabilities {
                 tool_approval: true,
                 thinking: true,
+                effort: false,
+                effort_levels: vec![],
+                modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
                 mcp: has_mcp,
             },
         });

--- a/crates/aion-agent/tests/acceptance/cross_feature_test.rs
+++ b/crates/aion-agent/tests/acceptance/cross_feature_test.rs
@@ -34,6 +34,7 @@ async fn tc_ax_01_multi_feature_collaboration() {
     let system_prompt = build_system_prompt(
         None,
         "/tmp",
+        "test-model",
         &[],
         None,
         Some(&mem_dir),

--- a/crates/aion-agent/tests/acceptance/memory_test.rs
+++ b/crates/aion-agent/tests/acceptance/memory_test.rs
@@ -36,7 +36,7 @@ fn memory_injection_into_system_prompt() {
     )
     .unwrap();
 
-    let prompt = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+    let prompt = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     // Behavioral instructions must be present
     assert!(
@@ -108,7 +108,8 @@ fn memory_full_lifecycle() {
 
     // -- Phase 3: Verify system prompt includes the memory content ------------
 
-    let prompt_with_memory = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+    let prompt_with_memory =
+        build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         prompt_with_memory.contains("auto memory"),
@@ -147,7 +148,8 @@ fn memory_full_lifecycle() {
 
     // -- Phase 6: Verify the content is gone from the system prompt -----------
 
-    let prompt_after_delete = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+    let prompt_after_delete =
+        build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         !prompt_after_delete.contains(&entry_filename),

--- a/crates/aion-agent/tests/acceptance/plan_mode_test.rs
+++ b/crates/aion-agent/tests/acceptance/plan_mode_test.rs
@@ -158,7 +158,7 @@ fn tc_a3_01_plan_mode_tool_filtering() {
 #[test]
 fn tc_a3_02_plan_mode_system_prompt_injection() {
     // --- Plan mode active: prompt should contain plan mode instructions ---
-    let active_prompt = build_system_prompt(None, "/tmp", &[], None, None, true);
+    let active_prompt = build_system_prompt(None, "/tmp", "test-model", &[], None, None, true);
 
     assert!(
         active_prompt.contains("# Plan Mode"),
@@ -190,7 +190,7 @@ fn tc_a3_02_plan_mode_system_prompt_injection() {
     );
 
     // --- Plan mode inactive: prompt should NOT contain plan mode instructions ---
-    let inactive_prompt = build_system_prompt(None, "/tmp", &[], None, None, false);
+    let inactive_prompt = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
 
     assert!(
         !inactive_prompt.contains("# Plan Mode"),

--- a/crates/aion-agent/tests/acceptance/tool_desc_test.rs
+++ b/crates/aion-agent/tests/acceptance/tool_desc_test.rs
@@ -12,7 +12,7 @@ use aion_agent::context::build_system_prompt;
 /// Edit-over-Write preference, and Read-before-Edit rule.
 #[test]
 fn system_prompt_contains_tool_guidance() {
-    let prompt = build_system_prompt(None, "/tmp", &[], None, None, false);
+    let prompt = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
 
     // 1. Heading
     assert!(

--- a/crates/aion-agent/tests/memory_context_integration.rs
+++ b/crates/aion-agent/tests/memory_context_integration.rs
@@ -23,7 +23,7 @@ fn tc_7_1_memory_dir_with_content_injects_prompt() {
     )
     .unwrap();
 
-    let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     // Should contain memory system sections
     assert!(
@@ -64,7 +64,7 @@ fn tc_7_1_memory_dir_with_content_injects_prompt() {
 
 #[test]
 fn tc_7_2_no_memory_dir_no_injection() {
-    let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
 
     assert!(
         !result.contains("auto memory"),
@@ -124,6 +124,7 @@ fn tc_7_3_section_ordering() {
     let result = build_system_prompt(
         None,
         &cwd.to_string_lossy(),
+        "test-model",
         &[skill],
         None,
         Some(&mem_dir),
@@ -159,6 +160,7 @@ fn tc_7_4_nonexistent_dir_graceful_degradation() {
     let result = build_system_prompt(
         None,
         "/tmp",
+        "test-model",
         &[],
         None,
         Some(std::path::Path::new("/nonexistent/memory/dir")),
@@ -193,7 +195,7 @@ fn tc_7_5_memory_md_content_injected() {
     )
     .unwrap();
 
-    let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         result.contains("user_role.md"),
@@ -224,7 +226,7 @@ fn tc_7_6_no_memory_md_shows_empty() {
     fs::create_dir_all(&mem_dir).unwrap();
     // No MEMORY.md created
 
-    let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         result.contains("currently empty"),
@@ -247,7 +249,7 @@ fn tc_7_7_no_bb_brand_in_integrated_prompt() {
     )
     .unwrap();
 
-    let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         !result.contains("~/.claude"),

--- a/crates/aion-agent/tests/plan_prompt_file_test.rs
+++ b/crates/aion-agent/tests/plan_prompt_file_test.rs
@@ -62,7 +62,7 @@ fn tc_3_4_01_instructions_forbid_writes() {
 
 #[test]
 fn tc_3_4_03_system_prompt_includes_plan_instructions_when_active() {
-    let result = build_system_prompt(None, "/tmp", &[], None, None, true);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, true);
 
     // Should contain plan mode instructions
     assert!(
@@ -85,7 +85,7 @@ fn tc_3_4_03_system_prompt_includes_plan_instructions_when_active() {
 
 #[test]
 fn tc_3_4_04_system_prompt_excludes_plan_instructions_when_inactive() {
-    let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
 
     // Should NOT contain plan mode instructions
     assert!(
@@ -197,7 +197,7 @@ fn plan_instructions_appear_after_memory_before_skills() {
     std::fs::create_dir_all(&mem_dir).unwrap();
     std::fs::write(mem_dir.join("MEMORY.md"), "- [A](a.md) \u{2014} test\n").unwrap();
 
-    let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), true);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), true);
 
     let memory_pos = result
         .find("auto memory")

--- a/crates/aion-agent/tests/skills_e2e.rs
+++ b/crates/aion-agent/tests/skills_e2e.rs
@@ -219,7 +219,7 @@ async fn e7_system_prompt_injection() {
     let cwd = root.to_string_lossy().to_string();
     let skills = load_all_skills(&root, &[], false, None).await;
 
-    let prompt = build_system_prompt(None, &cwd, &skills, None, None, false);
+    let prompt = build_system_prompt(None, &cwd, "test-model", &skills, None, None, false);
     assert!(
         prompt.contains("greet"),
         "E7 FAIL: 'greet' not in system prompt"

--- a/crates/aion-agent/tests/tool_guidance_prompt_test.rs
+++ b/crates/aion-agent/tests/tool_guidance_prompt_test.rs
@@ -42,7 +42,7 @@ fn make_skill(name: &str, description: &str) -> SkillMetadata {
 
 #[test]
 fn tc_4_3_01_tool_guidance_section_exists() {
-    let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
     assert!(
         result.contains("# Using your tools"),
         "system prompt should contain the tool guidance section heading"
@@ -55,7 +55,7 @@ fn tc_4_3_01_tool_guidance_section_exists() {
 
 #[test]
 fn tc_4_3_02_bash_prohibition_list() {
-    let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
 
     // Glob replaces find/ls
     assert!(
@@ -90,7 +90,7 @@ fn tc_4_3_02_bash_prohibition_list() {
 
 #[test]
 fn tc_4_3_03_parallel_call_guidance() {
-    let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
     assert!(
         result.contains("parallel"),
         "should contain parallel call guidance"
@@ -107,7 +107,7 @@ fn tc_4_3_03_parallel_call_guidance() {
 
 #[test]
 fn tc_4_3_04_edit_write_read_rules() {
-    let result = build_system_prompt(None, "/tmp", &[], None, None, false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
     assert!(
         result.contains("Prefer Edit over Write"),
         "should contain Edit-over-Write preference"
@@ -124,7 +124,15 @@ fn tc_4_3_04_edit_write_read_rules() {
 
 #[test]
 fn tc_4_3_05_order_after_intro_before_custom() {
-    let result = build_system_prompt(Some("CUSTOM_PROMPT_MARKER"), "/tmp", &[], None, None, false);
+    let result = build_system_prompt(
+        Some("CUSTOM_PROMPT_MARKER"),
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        false,
+    );
 
     let intro_pos = result
         .find("Working directory")
@@ -153,7 +161,7 @@ fn tc_4_3_05_order_after_intro_before_custom() {
 #[test]
 fn tc_4_3_06_order_before_skills() {
     let skills = vec![make_skill("order-test-skill", "Order test")];
-    let result = build_system_prompt(None, "/tmp", &skills, None, None, false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
 
     let guidance_pos = result
         .find("# Using your tools")
@@ -179,7 +187,7 @@ fn tc_4_3_06_order_before_memory() {
     )
     .unwrap();
 
-    let result = build_system_prompt(None, "/tmp", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     let guidance_pos = result
         .find("# Using your tools")
@@ -220,6 +228,7 @@ fn tc_4_3_07_all_sections_coexist() {
     let result = build_system_prompt(
         Some("CUSTOM_COEXIST"),
         &cwd.to_string_lossy(),
+        "test-model",
         &skills,
         None,
         Some(&mem_dir),
@@ -270,7 +279,7 @@ fn tc_4_3_07_all_sections_coexist() {
 
 #[test]
 fn tc_4_3_08_guidance_in_plan_mode() {
-    let result = build_system_prompt(None, "/tmp", &[], None, None, true);
+    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, true);
     assert!(
         result.contains("# Using your tools"),
         "tool guidance should be present even in plan mode"

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -482,47 +482,69 @@ async fn run_json_stream_mode(
                 input,
                 files: _,
             } => {
-                let engine_fut = engine.run(&input, &msg_id);
-                tokio::pin!(engine_fut);
-
                 let mut stopped = false;
-                loop {
-                    tokio::select! {
-                        result = &mut engine_fut => {
-                            match result {
-                                Ok(result) => {
-                                    output.emit_stream_end(
-                                        &msg_id,
-                                        result.turns,
-                                        result.usage.input_tokens,
-                                        result.usage.output_tokens,
-                                        result.usage.cache_creation_tokens,
-                                        result.usage.cache_read_tokens,
-                                    );
+                let mut pending_config_model: Option<Option<String>> = None;
+
+                {
+                    let engine_fut = engine.run(&input, &msg_id);
+                    tokio::pin!(engine_fut);
+
+                    loop {
+                        tokio::select! {
+                            result = &mut engine_fut => {
+                                match result {
+                                    Ok(result) => {
+                                        output.emit_stream_end(
+                                            &msg_id,
+                                            result.turns,
+                                            result.usage.input_tokens,
+                                            result.usage.output_tokens,
+                                            result.usage.cache_creation_tokens,
+                                            result.usage.cache_read_tokens,
+                                        );
+                                    }
+                                    Err(e) => {
+                                        output.emit_error(&e.to_string());
+                                    }
                                 }
-                                Err(e) => {
-                                    output.emit_error(&e.to_string());
+                                break;
+                            }
+                            Some(sub_cmd) = cmd_rx.recv() => {
+                                match sub_cmd {
+                                    ProtocolCommand::ToolApprove { call_id, scope: _ } => {
+                                        approval_manager.resolve(&call_id, ToolApprovalResult::Approved);
+                                    }
+                                    ProtocolCommand::ToolDeny { call_id, reason } => {
+                                        approval_manager.resolve(&call_id, ToolApprovalResult::Denied { reason });
+                                    }
+                                    ProtocolCommand::Stop => {
+                                        stopped = true;
+                                        break;
+                                    }
+                                    ProtocolCommand::SetConfig { model } => {
+                                        pending_config_model = Some(model);
+                                        let _ = writer.emit(&aion_protocol::events::ProtocolEvent::Info {
+                                            msg_id: String::new(),
+                                            message: "set_config: queued, will apply after current response".to_string(),
+                                        });
+                                    }
+                                    _ => {
+                                        eprintln!("[protocol] Ignoring command during active message processing");
+                                    }
                                 }
                             }
-                            break;
                         }
-                        Some(sub_cmd) = cmd_rx.recv() => {
-                            match sub_cmd {
-                                ProtocolCommand::ToolApprove { call_id, scope: _ } => {
-                                    approval_manager.resolve(&call_id, ToolApprovalResult::Approved);
-                                }
-                                ProtocolCommand::ToolDeny { call_id, reason } => {
-                                    approval_manager.resolve(&call_id, ToolApprovalResult::Denied { reason });
-                                }
-                                ProtocolCommand::Stop => {
-                                    stopped = true;
-                                    break;
-                                }
-                                _ => {
-                                    eprintln!("[protocol] Ignoring command during active message processing");
-                                }
-                            }
-                        }
+                    }
+                } // engine_fut dropped here, releasing mutable borrow
+
+                // Apply any config changes that arrived during processing
+                if let Some(model) = pending_config_model.take() {
+                    let changes = engine.apply_config_update(model);
+                    if !changes.is_empty() {
+                        let _ = writer.emit(&aion_protocol::events::ProtocolEvent::Info {
+                            msg_id: String::new(),
+                            message: format!("config applied: {}", changes.join(", ")),
+                        });
                     }
                 }
                 if stopped {
@@ -545,7 +567,19 @@ async fn run_json_stream_mode(
                 eprintln!("[protocol] InitHistory received: {} chars", text.len());
             }
             ProtocolCommand::SetMode { mode: _ } => {
-                eprintln!("[protocol] SetMode received");
+                eprintln!("[protocol] SetMode received (not yet implemented)");
+            }
+            ProtocolCommand::SetConfig { model } => {
+                let changes = engine.apply_config_update(model);
+                let message = if changes.is_empty() {
+                    "set_config: no changes".to_string()
+                } else {
+                    format!("config updated: {}", changes.join(", "))
+                };
+                let _ = writer.emit(&aion_protocol::events::ProtocolEvent::Info {
+                    msg_id: String::new(),
+                    message,
+                });
             }
         }
     }

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -472,7 +472,12 @@ async fn run_json_stream_mode(
     engine.set_plan_active_flag(plan_active_flag);
 
     let sid = engine.current_session_id();
-    protocol_sink.emit_ready(engine.compat(), has_mcp, sid);
+    protocol_sink.emit_ready(
+        engine.compat(),
+        has_mcp,
+        sid,
+        &approval_manager.current_mode(),
+    );
 
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer.clone());
@@ -488,6 +493,7 @@ async fn run_json_stream_mode(
             } => {
                 let mut stopped = false;
                 let mut pending_config: Option<PendingConfig> = None;
+                let mut mode_changed = false;
 
                 {
                     let engine_fut = engine.run(&input, &msg_id);
@@ -532,6 +538,14 @@ async fn run_json_stream_mode(
                                             message: "set_config: queued, will apply after current response".to_string(),
                                         });
                                     }
+                                    ProtocolCommand::SetMode { mode } => {
+                                        approval_manager.set_mode(mode);
+                                        mode_changed = true;
+                                        let _ = writer.emit(&aion_protocol::events::ProtocolEvent::Info {
+                                            msg_id: String::new(),
+                                            message: format!("mode updated: {}", approval_manager.current_mode()),
+                                        });
+                                    }
                                     _ => {
                                         eprintln!("[protocol] Ignoring command during active message processing");
                                     }
@@ -551,7 +565,18 @@ async fn run_json_stream_mode(
                             message: format!("config applied: {}", changes.join(", ")),
                         });
                     }
-                    protocol_sink.emit_config_changed(engine.compat(), has_mcp);
+                    // config_changed covers both config and mode updates
+                    protocol_sink.emit_config_changed(
+                        engine.compat(),
+                        has_mcp,
+                        &approval_manager.current_mode(),
+                    );
+                } else if mode_changed {
+                    protocol_sink.emit_config_changed(
+                        engine.compat(),
+                        has_mcp,
+                        &approval_manager.current_mode(),
+                    );
                 }
                 if stopped {
                     break;
@@ -572,8 +597,19 @@ async fn run_json_stream_mode(
             ProtocolCommand::InitHistory { text } => {
                 eprintln!("[protocol] InitHistory received: {} chars", text.len());
             }
-            ProtocolCommand::SetMode { mode: _ } => {
-                eprintln!("[protocol] SetMode received (not yet implemented)");
+            ProtocolCommand::SetMode { mode } => {
+                let mode_str = format!("{mode:?}").to_lowercase();
+                approval_manager.set_mode(mode);
+                let _ = writer.emit(&aion_protocol::events::ProtocolEvent::Info {
+                    msg_id: String::new(),
+                    message: format!("mode updated: {}", approval_manager.current_mode()),
+                });
+                protocol_sink.emit_config_changed(
+                    engine.compat(),
+                    has_mcp,
+                    &approval_manager.current_mode(),
+                );
+                eprintln!("[protocol] SetMode applied: {mode_str}");
             }
             ProtocolCommand::SetConfig {
                 model,
@@ -591,7 +627,11 @@ async fn run_json_stream_mode(
                     msg_id: String::new(),
                     message,
                 });
-                protocol_sink.emit_config_changed(engine.compat(), has_mcp);
+                protocol_sink.emit_config_changed(
+                    engine.compat(),
+                    has_mcp,
+                    &approval_manager.current_mode(),
+                );
             }
         }
     }

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -254,6 +254,7 @@ async fn main() -> anyhow::Result<()> {
     let system_prompt = context::build_system_prompt(
         config.system_prompt.as_deref(),
         &cwd,
+        &config.model,
         &skills,
         None,
         memory_dir.as_deref(),

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -471,7 +471,7 @@ async fn run_json_stream_mode(
     engine.set_plan_active_flag(plan_active_flag);
 
     let sid = engine.current_session_id();
-    protocol_sink.emit_ready(has_mcp, sid);
+    protocol_sink.emit_ready(engine.compat(), has_mcp, sid);
 
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer.clone());
@@ -550,6 +550,7 @@ async fn run_json_stream_mode(
                             message: format!("config applied: {}", changes.join(", ")),
                         });
                     }
+                    protocol_sink.emit_config_changed(engine.compat(), has_mcp);
                 }
                 if stopped {
                     break;
@@ -589,6 +590,7 @@ async fn run_json_stream_mode(
                     msg_id: String::new(),
                     message,
                 });
+                protocol_sink.emit_config_changed(engine.compat(), has_mcp);
             }
         }
     }

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -435,6 +435,9 @@ fn print_skills_paths() {
     }
 }
 
+/// Pending config fields: (model, thinking, thinking_budget, effort)
+type PendingConfig = (Option<String>, Option<String>, Option<u32>, Option<String>);
+
 async fn run_json_stream_mode(
     config: Config,
     registry: ToolRegistry,
@@ -483,7 +486,7 @@ async fn run_json_stream_mode(
                 files: _,
             } => {
                 let mut stopped = false;
-                let mut pending_config_model: Option<Option<String>> = None;
+                let mut pending_config: Option<PendingConfig> = None;
 
                 {
                     let engine_fut = engine.run(&input, &msg_id);
@@ -521,8 +524,8 @@ async fn run_json_stream_mode(
                                         stopped = true;
                                         break;
                                     }
-                                    ProtocolCommand::SetConfig { model } => {
-                                        pending_config_model = Some(model);
+                                    ProtocolCommand::SetConfig { model, thinking, thinking_budget, effort } => {
+                                        pending_config = Some((model, thinking, thinking_budget, effort));
                                         let _ = writer.emit(&aion_protocol::events::ProtocolEvent::Info {
                                             msg_id: String::new(),
                                             message: "set_config: queued, will apply after current response".to_string(),
@@ -538,8 +541,9 @@ async fn run_json_stream_mode(
                 } // engine_fut dropped here, releasing mutable borrow
 
                 // Apply any config changes that arrived during processing
-                if let Some(model) = pending_config_model.take() {
-                    let changes = engine.apply_config_update(model);
+                if let Some((model, thinking, thinking_budget, effort)) = pending_config.take() {
+                    let changes =
+                        engine.apply_config_update(model, thinking, thinking_budget, effort);
                     if !changes.is_empty() {
                         let _ = writer.emit(&aion_protocol::events::ProtocolEvent::Info {
                             msg_id: String::new(),
@@ -569,8 +573,13 @@ async fn run_json_stream_mode(
             ProtocolCommand::SetMode { mode: _ } => {
                 eprintln!("[protocol] SetMode received (not yet implemented)");
             }
-            ProtocolCommand::SetConfig { model } => {
-                let changes = engine.apply_config_update(model);
+            ProtocolCommand::SetConfig {
+                model,
+                thinking,
+                thinking_budget,
+                effort,
+            } => {
+                let changes = engine.apply_config_update(model, thinking, thinking_budget, effort);
                 let message = if changes.is_empty() {
                     "set_config: no changes".to_string()
                 } else {

--- a/crates/aion-config/src/compat.rs
+++ b/crates/aion-config/src/compat.rs
@@ -365,7 +365,11 @@ mod tests {
         assert_eq!(compat.supports_effort, Some(true));
         assert_eq!(
             compat.effort_levels,
-            Some(vec!["low".to_string(), "medium".to_string(), "high".to_string()])
+            Some(vec![
+                "low".to_string(),
+                "medium".to_string(),
+                "high".to_string()
+            ])
         );
     }
 

--- a/crates/aion-config/src/compat.rs
+++ b/crates/aion-config/src/compat.rs
@@ -49,6 +49,18 @@ pub struct ProviderCompat {
     /// Override to "/chat/completions" for providers like Gemini that include
     /// version prefix in the base URL itself.
     pub api_path: Option<String>,
+
+    /// Whether this provider supports extended thinking (Anthropic-style).
+    /// Default: true for anthropic/bedrock/vertex, false for openai.
+    pub supports_thinking: Option<bool>,
+
+    /// Whether this provider supports reasoning_effort (OpenAI-style).
+    /// Default: false for anthropic/bedrock/vertex, true for openai.
+    pub supports_effort: Option<bool>,
+
+    /// Available effort levels for this provider (e.g., ["low", "medium", "high"]).
+    /// Only meaningful when supports_effort is true.
+    pub effort_levels: Option<Vec<String>>,
 }
 
 impl ProviderCompat {
@@ -58,6 +70,8 @@ impl ProviderCompat {
             ensure_alternation: Some(true),
             merge_same_role: Some(true),
             auto_tool_id: Some(true),
+            supports_thinking: Some(true),
+            supports_effort: Some(false),
             ..Default::default()
         }
     }
@@ -69,6 +83,8 @@ impl ProviderCompat {
             merge_same_role: Some(true),
             auto_tool_id: Some(true),
             sanitize_schema: Some(true),
+            supports_thinking: Some(true),
+            supports_effort: Some(false),
             ..Default::default()
         }
     }
@@ -80,6 +96,9 @@ impl ProviderCompat {
             merge_assistant_messages: Some(true),
             clean_orphan_tool_calls: Some(true),
             dedup_tool_results: Some(true),
+            supports_thinking: Some(false),
+            supports_effort: Some(true),
+            effort_levels: Some(vec!["low".into(), "medium".into(), "high".into()]),
             ..Default::default()
         }
     }
@@ -101,6 +120,9 @@ impl ProviderCompat {
             strip_patterns: user.strip_patterns.or(defaults.strip_patterns),
             auto_tool_id: user.auto_tool_id.or(defaults.auto_tool_id),
             api_path: user.api_path.or(defaults.api_path),
+            supports_thinking: user.supports_thinking.or(defaults.supports_thinking),
+            supports_effort: user.supports_effort.or(defaults.supports_effort),
+            effort_levels: user.effort_levels.or(defaults.effort_levels),
         }
     }
 
@@ -136,6 +158,18 @@ impl ProviderCompat {
 
     pub fn api_path(&self) -> &str {
         self.api_path.as_deref().unwrap_or("/v1/chat/completions")
+    }
+
+    pub fn supports_thinking(&self) -> bool {
+        self.supports_thinking.unwrap_or(false)
+    }
+
+    pub fn supports_effort(&self) -> bool {
+        self.supports_effort.unwrap_or(false)
+    }
+
+    pub fn effort_levels(&self) -> &[String] {
+        self.effort_levels.as_deref().unwrap_or(&[])
     }
 }
 
@@ -314,6 +348,57 @@ mod tests {
 
         assert_eq!(sanitized["type"], "object");
         assert_eq!(sanitized["properties"]["cmd"]["type"], "string");
+    }
+
+    #[test]
+    fn test_anthropic_defaults_capability_fields() {
+        let compat = ProviderCompat::anthropic_defaults();
+        assert_eq!(compat.supports_thinking, Some(true));
+        assert_eq!(compat.supports_effort, Some(false));
+        assert!(compat.effort_levels.is_none());
+    }
+
+    #[test]
+    fn test_openai_defaults_capability_fields() {
+        let compat = ProviderCompat::openai_defaults();
+        assert_eq!(compat.supports_thinking, Some(false));
+        assert_eq!(compat.supports_effort, Some(true));
+        assert_eq!(
+            compat.effort_levels,
+            Some(vec!["low".to_string(), "medium".to_string(), "high".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_bedrock_defaults_capability_fields() {
+        let compat = ProviderCompat::bedrock_defaults();
+        assert_eq!(compat.supports_thinking, Some(true));
+        assert_eq!(compat.supports_effort, Some(false));
+    }
+
+    #[test]
+    fn test_merge_capability_fields_user_overrides() {
+        let defaults = ProviderCompat::openai_defaults();
+        let user = ProviderCompat {
+            supports_thinking: Some(true),
+            ..Default::default()
+        };
+        let merged = ProviderCompat::merge(defaults, user);
+        assert_eq!(merged.supports_thinking, Some(true));
+        assert_eq!(merged.supports_effort, Some(true));
+    }
+
+    #[test]
+    fn test_capability_accessors() {
+        let compat = ProviderCompat::anthropic_defaults();
+        assert!(compat.supports_thinking());
+        assert!(!compat.supports_effort());
+        assert!(compat.effort_levels().is_empty());
+
+        let compat2 = ProviderCompat::openai_defaults();
+        assert!(!compat2.supports_thinking());
+        assert!(compat2.supports_effort());
+        assert_eq!(compat2.effort_levels(), &["low", "medium", "high"]);
     }
 
     #[test]

--- a/crates/aion-protocol/src/commands.rs
+++ b/crates/aion-protocol/src/commands.rs
@@ -28,6 +28,10 @@ pub enum ProtocolCommand {
     SetMode {
         mode: SessionMode,
     },
+    SetConfig {
+        #[serde(default)]
+        model: Option<String>,
+    },
 }
 
 #[derive(Debug, Deserialize, Default, PartialEq, Eq)]
@@ -44,4 +48,33 @@ pub enum SessionMode {
     Default,
     AutoEdit,
     Yolo,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_config_debug_format() {
+        let cmd = ProtocolCommand::SetConfig {
+            model: Some("test-model".into()),
+        };
+        let dbg = format!("{cmd:?}");
+        assert!(dbg.contains("SetConfig"));
+        assert!(dbg.contains("test-model"));
+    }
+
+    #[test]
+    fn set_config_equality() {
+        let a = ProtocolCommand::SetConfig {
+            model: Some("m".into()),
+        };
+        let b = ProtocolCommand::SetConfig {
+            model: Some("m".into()),
+        };
+        assert_eq!(a, b);
+
+        let c = ProtocolCommand::SetConfig { model: None };
+        assert_ne!(a, c);
+    }
 }

--- a/crates/aion-protocol/src/commands.rs
+++ b/crates/aion-protocol/src/commands.rs
@@ -31,6 +31,12 @@ pub enum ProtocolCommand {
     SetConfig {
         #[serde(default)]
         model: Option<String>,
+        #[serde(default)]
+        thinking: Option<String>,
+        #[serde(default)]
+        thinking_budget: Option<u32>,
+        #[serde(default)]
+        effort: Option<String>,
     },
 }
 
@@ -58,6 +64,9 @@ mod tests {
     fn set_config_debug_format() {
         let cmd = ProtocolCommand::SetConfig {
             model: Some("test-model".into()),
+            thinking: None,
+            thinking_budget: None,
+            effort: None,
         };
         let dbg = format!("{cmd:?}");
         assert!(dbg.contains("SetConfig"));
@@ -68,13 +77,53 @@ mod tests {
     fn set_config_equality() {
         let a = ProtocolCommand::SetConfig {
             model: Some("m".into()),
+            thinking: None,
+            thinking_budget: None,
+            effort: None,
         };
         let b = ProtocolCommand::SetConfig {
             model: Some("m".into()),
+            thinking: None,
+            thinking_budget: None,
+            effort: None,
         };
         assert_eq!(a, b);
 
-        let c = ProtocolCommand::SetConfig { model: None };
+        let c = ProtocolCommand::SetConfig {
+            model: None,
+            thinking: None,
+            thinking_budget: None,
+            effort: None,
+        };
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn set_config_with_all_fields_equality() {
+        let a = ProtocolCommand::SetConfig {
+            model: Some("m".into()),
+            thinking: Some("enabled".into()),
+            thinking_budget: Some(8000),
+            effort: Some("high".into()),
+        };
+        let b = ProtocolCommand::SetConfig {
+            model: Some("m".into()),
+            thinking: Some("enabled".into()),
+            thinking_budget: Some(8000),
+            effort: Some("high".into()),
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn set_config_all_none_fields() {
+        let cmd = ProtocolCommand::SetConfig {
+            model: None,
+            thinking: None,
+            thinking_budget: None,
+            effort: None,
+        };
+        let dbg = format!("{cmd:?}");
+        assert!(dbg.contains("SetConfig"));
     }
 }

--- a/crates/aion-protocol/src/events.rs
+++ b/crates/aion-protocol/src/events.rs
@@ -74,6 +74,7 @@ pub struct Capabilities {
     pub effort: bool,
     pub effort_levels: Vec<String>,
     pub modes: Vec<String>,
+    pub current_mode: String,
     pub mcp: bool,
 }
 
@@ -153,6 +154,7 @@ mod tests {
                 effort: false,
                 effort_levels: vec![],
                 modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+                current_mode: "default".into(),
                 mcp: false,
             },
         };
@@ -172,6 +174,7 @@ mod tests {
                 effort: false,
                 effort_levels: vec![],
                 modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+                current_mode: "default".into(),
                 mcp: false,
             },
         };
@@ -277,6 +280,7 @@ mod tests {
                 effort: true,
                 effort_levels: vec!["low".into(), "medium".into(), "high".into()],
                 modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+                current_mode: "default".into(),
                 mcp: false,
             },
         };
@@ -296,6 +300,7 @@ mod tests {
                 effort: true,
                 effort_levels: vec!["low".into(), "medium".into(), "high".into()],
                 modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+                current_mode: "default".into(),
                 mcp: true,
             },
         };

--- a/crates/aion-protocol/src/events.rs
+++ b/crates/aion-protocol/src/events.rs
@@ -62,12 +62,18 @@ pub enum ProtocolEvent {
         msg_id: String,
         message: String,
     },
+    ConfigChanged {
+        capabilities: Capabilities,
+    },
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Capabilities {
     pub tool_approval: bool,
     pub thinking: bool,
+    pub effort: bool,
+    pub effort_levels: Vec<String>,
+    pub modes: Vec<String>,
     pub mcp: bool,
 }
 
@@ -144,6 +150,9 @@ mod tests {
             capabilities: Capabilities {
                 tool_approval: true,
                 thinking: true,
+                effort: false,
+                effort_levels: vec![],
+                modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
                 mcp: false,
             },
         };
@@ -160,6 +169,9 @@ mod tests {
             capabilities: Capabilities {
                 tool_approval: true,
                 thinking: true,
+                effort: false,
+                effort_levels: vec![],
+                modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
                 mcp: false,
             },
         };
@@ -252,5 +264,44 @@ mod tests {
         assert_eq!(ToolCategory::Edit.to_string(), "edit");
         assert_eq!(ToolCategory::Exec.to_string(), "exec");
         assert_eq!(ToolCategory::Mcp.to_string(), "mcp");
+    }
+
+    #[test]
+    fn test_ready_event_with_expanded_capabilities() {
+        let event = ProtocolEvent::Ready {
+            version: "0.2.0".to_string(),
+            session_id: Some("abc".to_string()),
+            capabilities: Capabilities {
+                tool_approval: true,
+                thinking: true,
+                effort: true,
+                effort_levels: vec!["low".into(), "medium".into(), "high".into()],
+                modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+                mcp: false,
+            },
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["capabilities"]["thinking"], true);
+        assert_eq!(json["capabilities"]["effort"], true);
+        assert_eq!(json["capabilities"]["effort_levels"][0], "low");
+        assert_eq!(json["capabilities"]["modes"][2], "yolo");
+    }
+
+    #[test]
+    fn test_config_changed_event_serialization() {
+        let event = ProtocolEvent::ConfigChanged {
+            capabilities: Capabilities {
+                tool_approval: true,
+                thinking: false,
+                effort: true,
+                effort_levels: vec!["low".into(), "medium".into(), "high".into()],
+                modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+                mcp: true,
+            },
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "config_changed");
+        assert_eq!(json["capabilities"]["thinking"], false);
+        assert_eq!(json["capabilities"]["effort"], true);
     }
 }

--- a/crates/aion-protocol/src/lib.rs
+++ b/crates/aion-protocol/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 
 use tokio::sync::oneshot;
 
-use crate::commands::ApprovalScope;
+use crate::commands::{ApprovalScope, SessionMode};
 use crate::events::ToolCategory;
 
 /// Result of a tool approval request
@@ -31,9 +31,13 @@ struct PendingApproval {
 /// Each pending request also stores its tool category so a client approval with
 /// `ApprovalScope::Always` can persist auto-approval for future requests in the
 /// same category.
+///
+/// Also holds the current `SessionMode` which determines which tool categories
+/// are auto-approved based on the active approval policy.
 pub struct ToolApprovalManager {
     pending: Mutex<HashMap<String, PendingApproval>>,
     auto_approved: Mutex<HashSet<String>>,
+    session_mode: Mutex<SessionMode>,
 }
 
 impl ToolApprovalManager {
@@ -41,6 +45,7 @@ impl ToolApprovalManager {
         Self {
             pending: Mutex::new(HashMap::new()),
             auto_approved: Mutex::new(HashSet::new()),
+            session_mode: Mutex::new(SessionMode::Default),
         }
     }
 
@@ -89,10 +94,46 @@ impl ToolApprovalManager {
     }
 
     pub fn is_auto_approved(&self, category: &str) -> bool {
+        // Check session mode first
+        let mode_approved = self
+            .session_mode
+            .lock()
+            .map(|mode| match *mode {
+                SessionMode::Yolo => true,
+                SessionMode::AutoEdit => category == "info" || category == "edit",
+                SessionMode::Default => false,
+            })
+            .unwrap_or(false);
+
+        if mode_approved {
+            return true;
+        }
+
+        // Fall back to per-category "always" approvals
         self.auto_approved
             .lock()
             .map(|auto| auto.contains(category))
             .unwrap_or(false)
+    }
+
+    /// Set the session approval mode. Takes effect immediately.
+    pub fn set_mode(&self, mode: SessionMode) {
+        if let Ok(mut current) = self.session_mode.lock() {
+            *current = mode;
+        }
+    }
+
+    /// Return the current session mode as a string for capability reporting.
+    pub fn current_mode(&self) -> String {
+        self.session_mode
+            .lock()
+            .map(|mode| match *mode {
+                SessionMode::Default => "default",
+                SessionMode::AutoEdit => "auto_edit",
+                SessionMode::Yolo => "yolo",
+            })
+            .unwrap_or("default")
+            .to_string()
     }
 
     pub fn drop_pending(&self, call_id: &str) {
@@ -111,5 +152,116 @@ impl ToolApprovalManager {
 impl Default for ToolApprovalManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- SessionMode: default mode ---
+
+    #[test]
+    fn default_mode_does_not_auto_approve_any_category() {
+        let mgr = ToolApprovalManager::new();
+        assert!(!mgr.is_auto_approved("info"));
+        assert!(!mgr.is_auto_approved("edit"));
+        assert!(!mgr.is_auto_approved("exec"));
+        assert!(!mgr.is_auto_approved("mcp"));
+    }
+
+    #[test]
+    fn default_mode_current_mode_string() {
+        let mgr = ToolApprovalManager::new();
+        assert_eq!(mgr.current_mode(), "default");
+    }
+
+    // --- SessionMode: auto_edit mode ---
+
+    #[test]
+    fn auto_edit_mode_approves_info_and_edit() {
+        let mgr = ToolApprovalManager::new();
+        mgr.set_mode(SessionMode::AutoEdit);
+        assert!(mgr.is_auto_approved("info"));
+        assert!(mgr.is_auto_approved("edit"));
+    }
+
+    #[test]
+    fn auto_edit_mode_requires_approval_for_exec_and_mcp() {
+        let mgr = ToolApprovalManager::new();
+        mgr.set_mode(SessionMode::AutoEdit);
+        assert!(!mgr.is_auto_approved("exec"));
+        assert!(!mgr.is_auto_approved("mcp"));
+    }
+
+    #[test]
+    fn auto_edit_mode_current_mode_string() {
+        let mgr = ToolApprovalManager::new();
+        mgr.set_mode(SessionMode::AutoEdit);
+        assert_eq!(mgr.current_mode(), "auto_edit");
+    }
+
+    // --- SessionMode: yolo mode ---
+
+    #[test]
+    fn yolo_mode_approves_all_categories() {
+        let mgr = ToolApprovalManager::new();
+        mgr.set_mode(SessionMode::Yolo);
+        assert!(mgr.is_auto_approved("info"));
+        assert!(mgr.is_auto_approved("edit"));
+        assert!(mgr.is_auto_approved("exec"));
+        assert!(mgr.is_auto_approved("mcp"));
+    }
+
+    #[test]
+    fn yolo_mode_current_mode_string() {
+        let mgr = ToolApprovalManager::new();
+        mgr.set_mode(SessionMode::Yolo);
+        assert_eq!(mgr.current_mode(), "yolo");
+    }
+
+    // --- Mode switching ---
+
+    #[test]
+    fn switching_mode_changes_approval_behavior() {
+        let mgr = ToolApprovalManager::new();
+
+        // Start in default
+        assert!(!mgr.is_auto_approved("edit"));
+
+        // Switch to auto_edit
+        mgr.set_mode(SessionMode::AutoEdit);
+        assert!(mgr.is_auto_approved("edit"));
+        assert!(!mgr.is_auto_approved("exec"));
+
+        // Switch to yolo
+        mgr.set_mode(SessionMode::Yolo);
+        assert!(mgr.is_auto_approved("exec"));
+
+        // Switch back to default
+        mgr.set_mode(SessionMode::Default);
+        assert!(!mgr.is_auto_approved("edit"));
+        assert!(!mgr.is_auto_approved("exec"));
+    }
+
+    // --- Mode + user "always" approval coexistence ---
+
+    #[test]
+    fn user_always_approval_persists_across_mode_changes() {
+        let mgr = ToolApprovalManager::new();
+
+        // User manually approves "exec" category with "always"
+        mgr.add_auto_approve("exec");
+        assert!(mgr.is_auto_approved("exec"));
+
+        // Switch to auto_edit: exec still approved via user "always"
+        mgr.set_mode(SessionMode::AutoEdit);
+        assert!(mgr.is_auto_approved("exec"));
+        assert!(mgr.is_auto_approved("info")); // from mode
+
+        // Switch back to default: exec still approved via user "always"
+        mgr.set_mode(SessionMode::Default);
+        assert!(mgr.is_auto_approved("exec"));
+        assert!(!mgr.is_auto_approved("info")); // mode no longer provides this
     }
 }

--- a/crates/aion-protocol/src/writer.rs
+++ b/crates/aion-protocol/src/writer.rs
@@ -54,6 +54,9 @@ mod tests {
             capabilities: Capabilities {
                 tool_approval: true,
                 thinking: false,
+                effort: false,
+                effort_levels: vec![],
+                modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
                 mcp: false,
             },
         };

--- a/crates/aion-protocol/src/writer.rs
+++ b/crates/aion-protocol/src/writer.rs
@@ -57,6 +57,7 @@ mod tests {
                 effort: false,
                 effort_levels: vec![],
                 modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+                current_mode: "default".into(),
                 mcp: false,
             },
         };

--- a/crates/aion-protocol/tests/capability_discovery_test.rs
+++ b/crates/aion-protocol/tests/capability_discovery_test.rs
@@ -21,14 +21,13 @@ fn capabilities_serialize_with_all_fields() {
     assert_eq!(parsed["type"], "ready");
     assert_eq!(parsed["capabilities"]["thinking"], true);
     assert_eq!(parsed["capabilities"]["effort"], false);
-    assert!(parsed["capabilities"]["effort_levels"]
-        .as_array()
-        .unwrap()
-        .is_empty());
-    assert_eq!(
-        parsed["capabilities"]["modes"].as_array().unwrap().len(),
-        3
+    assert!(
+        parsed["capabilities"]["effort_levels"]
+            .as_array()
+            .unwrap()
+            .is_empty()
     );
+    assert_eq!(parsed["capabilities"]["modes"].as_array().unwrap().len(), 3);
 }
 
 #[test]
@@ -41,9 +40,7 @@ fn config_changed_event_serializes_correctly() {
         modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
         mcp: false,
     };
-    let event = ProtocolEvent::ConfigChanged {
-        capabilities: caps,
-    };
+    let event = ProtocolEvent::ConfigChanged { capabilities: caps };
     let json = serde_json::to_string(&event).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
 

--- a/crates/aion-protocol/tests/capability_discovery_test.rs
+++ b/crates/aion-protocol/tests/capability_discovery_test.rs
@@ -8,6 +8,7 @@ fn capabilities_serialize_with_all_fields() {
         effort: false,
         effort_levels: vec![],
         modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+        current_mode: "default".into(),
         mcp: true,
     };
     let event = ProtocolEvent::Ready {
@@ -28,6 +29,7 @@ fn capabilities_serialize_with_all_fields() {
             .is_empty()
     );
     assert_eq!(parsed["capabilities"]["modes"].as_array().unwrap().len(), 3);
+    assert_eq!(parsed["capabilities"]["current_mode"], "default");
 }
 
 #[test]
@@ -38,6 +40,7 @@ fn config_changed_event_serializes_correctly() {
         effort: true,
         effort_levels: vec!["low".into(), "medium".into(), "high".into()],
         modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+        current_mode: "default".into(),
         mcp: false,
     };
     let event = ProtocolEvent::ConfigChanged { capabilities: caps };
@@ -56,6 +59,7 @@ fn capabilities_with_effort_levels_roundtrip() {
         effort: true,
         effort_levels: vec!["low".into(), "medium".into(), "high".into()],
         modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+        current_mode: "default".into(),
         mcp: true,
     };
     let event = ProtocolEvent::Ready {

--- a/crates/aion-protocol/tests/capability_discovery_test.rs
+++ b/crates/aion-protocol/tests/capability_discovery_test.rs
@@ -1,0 +1,83 @@
+use aion_protocol::events::{Capabilities, ProtocolEvent};
+
+#[test]
+fn capabilities_serialize_with_all_fields() {
+    let caps = Capabilities {
+        tool_approval: true,
+        thinking: true,
+        effort: false,
+        effort_levels: vec![],
+        modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+        mcp: true,
+    };
+    let event = ProtocolEvent::Ready {
+        version: "0.2.0".into(),
+        session_id: None,
+        capabilities: caps,
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed["type"], "ready");
+    assert_eq!(parsed["capabilities"]["thinking"], true);
+    assert_eq!(parsed["capabilities"]["effort"], false);
+    assert!(parsed["capabilities"]["effort_levels"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        parsed["capabilities"]["modes"].as_array().unwrap().len(),
+        3
+    );
+}
+
+#[test]
+fn config_changed_event_serializes_correctly() {
+    let caps = Capabilities {
+        tool_approval: true,
+        thinking: false,
+        effort: true,
+        effort_levels: vec!["low".into(), "medium".into(), "high".into()],
+        modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+        mcp: false,
+    };
+    let event = ProtocolEvent::ConfigChanged {
+        capabilities: caps,
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed["type"], "config_changed");
+    assert_eq!(parsed["capabilities"]["effort_levels"][1], "medium");
+}
+
+#[test]
+fn capabilities_with_effort_levels_roundtrip() {
+    let caps = Capabilities {
+        tool_approval: true,
+        thinking: false,
+        effort: true,
+        effort_levels: vec!["low".into(), "medium".into(), "high".into()],
+        modes: vec!["default".into(), "auto_edit".into(), "yolo".into()],
+        mcp: true,
+    };
+    let event = ProtocolEvent::Ready {
+        version: "0.2.0".into(),
+        session_id: Some("test-session".into()),
+        capabilities: caps,
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed["capabilities"]["effort"], true);
+    assert_eq!(
+        parsed["capabilities"]["effort_levels"]
+            .as_array()
+            .unwrap()
+            .len(),
+        3
+    );
+    assert_eq!(parsed["capabilities"]["effort_levels"][0], "low");
+    assert_eq!(parsed["capabilities"]["effort_levels"][2], "high");
+    assert_eq!(parsed["session_id"], "test-session");
+}

--- a/crates/aion-protocol/tests/commands_test.rs
+++ b/crates/aion-protocol/tests/commands_test.rs
@@ -26,6 +26,18 @@ use rstest::rstest;
     }
 )]
 #[case(
+    r#"{"type":"set_mode","mode":"default"}"#,
+    ProtocolCommand::SetMode {
+        mode: SessionMode::Default,
+    }
+)]
+#[case(
+    r#"{"type":"set_mode","mode":"auto_edit"}"#,
+    ProtocolCommand::SetMode {
+        mode: SessionMode::AutoEdit,
+    }
+)]
+#[case(
     r#"{"type":"set_mode","mode":"yolo"}"#,
     ProtocolCommand::SetMode {
         mode: SessionMode::Yolo,

--- a/crates/aion-protocol/tests/set_config.rs
+++ b/crates/aion-protocol/tests/set_config.rs
@@ -5,7 +5,7 @@ fn parse_set_config_with_model() {
     let json = r#"{"type":"set_config","model":"claude-sonnet-4-5-20250514"}"#;
     let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
     match cmd {
-        ProtocolCommand::SetConfig { model } => {
+        ProtocolCommand::SetConfig { model, .. } => {
             assert_eq!(model.as_deref(), Some("claude-sonnet-4-5-20250514"));
         }
         other => panic!("expected SetConfig, got: {other:?}"),
@@ -17,7 +17,7 @@ fn parse_set_config_empty() {
     let json = r#"{"type":"set_config"}"#;
     let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
     match cmd {
-        ProtocolCommand::SetConfig { model } => {
+        ProtocolCommand::SetConfig { model, .. } => {
             assert!(model.is_none());
         }
         other => panic!("expected SetConfig, got: {other:?}"),
@@ -29,7 +29,7 @@ fn parse_set_config_null_model() {
     let json = r#"{"type":"set_config","model":null}"#;
     let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
     match cmd {
-        ProtocolCommand::SetConfig { model } => {
+        ProtocolCommand::SetConfig { model, .. } => {
             assert!(model.is_none());
         }
         other => panic!("expected SetConfig, got: {other:?}"),
@@ -41,7 +41,7 @@ fn parse_set_config_unknown_fields_ignored() {
     let json = r#"{"type":"set_config","model":"x","future_field":true,"nested":{"a":1}}"#;
     let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
     match cmd {
-        ProtocolCommand::SetConfig { model } => {
+        ProtocolCommand::SetConfig { model, .. } => {
             assert_eq!(model.as_deref(), Some("x"));
         }
         other => panic!("expected SetConfig, got: {other:?}"),
@@ -68,4 +68,118 @@ fn existing_commands_still_parse() {
 
     let mode = r#"{"type":"set_mode","mode":"yolo"}"#;
     assert!(serde_json::from_str::<ProtocolCommand>(mode).is_ok());
+}
+
+// --- Cycle 2: Effort parsing tests ---
+
+#[test]
+fn parse_set_config_with_effort() {
+    let json = r#"{"type":"set_config","effort":"high"}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig { effort, model, .. } => {
+            assert_eq!(effort.as_deref(), Some("high"));
+            assert!(model.is_none());
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_set_config_with_null_effort() {
+    let json = r#"{"type":"set_config","effort":null}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig { effort, .. } => {
+            assert!(effort.is_none());
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+// --- Cycle 2: Thinking parsing tests ---
+
+#[test]
+fn parse_set_config_with_thinking_enabled_and_budget() {
+    let json = r#"{"type":"set_config","thinking":"enabled","thinking_budget":16000}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig {
+            thinking,
+            thinking_budget,
+            ..
+        } => {
+            assert_eq!(thinking.as_deref(), Some("enabled"));
+            assert_eq!(thinking_budget, Some(16000));
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_set_config_with_thinking_disabled() {
+    let json = r#"{"type":"set_config","thinking":"disabled"}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig {
+            thinking,
+            thinking_budget,
+            ..
+        } => {
+            assert_eq!(thinking.as_deref(), Some("disabled"));
+            assert!(thinking_budget.is_none());
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_set_config_with_null_thinking() {
+    let json = r#"{"type":"set_config","thinking":null}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig { thinking, .. } => {
+            assert!(thinking.is_none());
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_set_config_thinking_enabled_no_budget() {
+    let json = r#"{"type":"set_config","thinking":"enabled"}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig {
+            thinking,
+            thinking_budget,
+            ..
+        } => {
+            assert_eq!(thinking.as_deref(), Some("enabled"));
+            assert!(thinking_budget.is_none());
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+// --- Cycle 2: Combined fields test ---
+
+#[test]
+fn parse_set_config_all_fields() {
+    let json = r#"{"type":"set_config","model":"m","effort":"low","thinking":"disabled"}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig {
+            model,
+            effort,
+            thinking,
+            thinking_budget,
+        } => {
+            assert_eq!(model.as_deref(), Some("m"));
+            assert_eq!(effort.as_deref(), Some("low"));
+            assert_eq!(thinking.as_deref(), Some("disabled"));
+            assert!(thinking_budget.is_none());
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
 }

--- a/crates/aion-protocol/tests/set_config.rs
+++ b/crates/aion-protocol/tests/set_config.rs
@@ -1,0 +1,71 @@
+use aion_protocol::commands::ProtocolCommand;
+
+#[test]
+fn parse_set_config_with_model() {
+    let json = r#"{"type":"set_config","model":"claude-sonnet-4-5-20250514"}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig { model } => {
+            assert_eq!(model.as_deref(), Some("claude-sonnet-4-5-20250514"));
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_set_config_empty() {
+    let json = r#"{"type":"set_config"}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig { model } => {
+            assert!(model.is_none());
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_set_config_null_model() {
+    let json = r#"{"type":"set_config","model":null}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig { model } => {
+            assert!(model.is_none());
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_set_config_unknown_fields_ignored() {
+    let json = r#"{"type":"set_config","model":"x","future_field":true,"nested":{"a":1}}"#;
+    let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+    match cmd {
+        ProtocolCommand::SetConfig { model } => {
+            assert_eq!(model.as_deref(), Some("x"));
+        }
+        other => panic!("expected SetConfig, got: {other:?}"),
+    }
+}
+
+#[test]
+fn existing_commands_still_parse() {
+    // AC-7: Verify SetConfig addition doesn't break existing variants
+    let message = r#"{"type":"message","msg_id":"m1","input":"hello"}"#;
+    assert!(serde_json::from_str::<ProtocolCommand>(message).is_ok());
+
+    let stop = r#"{"type":"stop"}"#;
+    assert!(serde_json::from_str::<ProtocolCommand>(stop).is_ok());
+
+    let approve = r#"{"type":"tool_approve","call_id":"c1"}"#;
+    assert!(serde_json::from_str::<ProtocolCommand>(approve).is_ok());
+
+    let deny = r#"{"type":"tool_deny","call_id":"c1"}"#;
+    assert!(serde_json::from_str::<ProtocolCommand>(deny).is_ok());
+
+    let init = r#"{"type":"init_history","text":"ctx"}"#;
+    assert!(serde_json::from_str::<ProtocolCommand>(init).is_ok());
+
+    let mode = r#"{"type":"set_mode","mode":"yolo"}"#;
+    assert!(serde_json::from_str::<ProtocolCommand>(mode).is_ok());
+}

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -30,11 +30,14 @@ Emitted once after initialization completes. Client MUST wait for this before se
 ```json
 {
   "type": "ready",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "session_id": "a1b2c3",
   "capabilities": {
     "tool_approval": true,
     "thinking": true,
+    "effort": false,
+    "effort_levels": [],
+    "modes": ["default", "auto_edit", "yolo"],
     "mcp": true
   }
 }
@@ -45,7 +48,10 @@ Emitted once after initialization completes. Client MUST wait for this before se
 | `version` | string | Protocol version (semver) |
 | `session_id` | string? | Session ID (omitted when sessions are disabled in config) |
 | `capabilities.tool_approval` | bool | Whether agent supports pause-and-wait tool approval |
-| `capabilities.thinking` | bool | Whether agent emits thinking events |
+| `capabilities.thinking` | bool | Whether current provider supports extended thinking |
+| `capabilities.effort` | bool | Whether current provider supports reasoning_effort |
+| `capabilities.effort_levels` | string[] | Valid effort values (e.g., `["low", "medium", "high"]`). Empty when effort is false |
+| `capabilities.modes` | string[] | Available approval modes for `set_mode` command |
 | `capabilities.mcp` | bool | Whether MCP tools are available |
 
 ### 1.2 `stream_start`
@@ -245,6 +251,26 @@ Informational message (non-critical, for display only).
 }
 ```
 
+### 1.12 `config_changed`
+
+Emitted after a `set_config` command is processed. Contains the updated capabilities snapshot reflecting the current provider/model configuration.
+
+```json
+{
+  "type": "config_changed",
+  "capabilities": {
+    "tool_approval": true,
+    "thinking": false,
+    "effort": true,
+    "effort_levels": ["low", "medium", "high"],
+    "modes": ["default", "auto_edit", "yolo"],
+    "mcp": true
+  }
+}
+```
+
+Clients should update their UI controls (e.g., enable/disable thinking toggle, populate effort dropdown) based on the new capabilities.
+
 ## 2. Client → Agent Commands (stdin)
 
 Every line is a JSON object with a `type` field.
@@ -348,6 +374,31 @@ Change the agent's approval mode for the session.
 | `"default"` | All tools need approval (except allow-listed) |
 | `"auto_edit"` | `info` and `edit` auto-approved; `exec` and `mcp` need approval |
 | `"yolo"` | All tools auto-approved |
+
+### 2.7 `set_config`
+
+Update model, thinking, or effort configuration at runtime.
+
+```json
+{
+  "type": "set_config",
+  "model": "claude-opus-4",
+  "thinking": "enabled",
+  "thinking_budget": 16000,
+  "effort": "high"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `model` | string | no | Switch to a different model |
+| `thinking` | string | no | `"enabled"` or `"disabled"` |
+| `thinking_budget` | number | no | Token budget for thinking (default: 10000) |
+| `effort` | string | no | Reasoning effort level (e.g., `"low"`, `"medium"`, `"high"`) |
+
+All fields are optional. Only provided fields are updated.
+
+> **Validation**: The agent validates `thinking` and `effort` values against the current provider's capabilities. If the provider does not support a feature, the change is rejected with a descriptive message in the `info` event. After processing, a `config_changed` event is always emitted with the updated capabilities.
 
 ## 3. Lifecycle
 
@@ -509,4 +560,4 @@ The `ready` event includes a `version` field. Clients should check version compa
 - **Minor version bump**: New optional event types or fields added (backward compatible)
 - **Major version bump**: Breaking changes to existing events/commands
 
-Current version: `0.1.0`
+Current version: `0.2.0`

--- a/tests/skills_e2e.rs
+++ b/tests/skills_e2e.rs
@@ -210,7 +210,7 @@ async fn e7_system_prompt_injection() {
     let cwd = root.to_string_lossy().to_string();
     let skills = load_all_skills(&root, &[], false, None).await;
 
-    let prompt = build_system_prompt(None, &cwd, &skills, None, None, false);
+    let prompt = build_system_prompt(None, &cwd, "test-model", &skills, None, None, false);
     assert!(prompt.contains("greet"), "E7 FAIL: 'greet' not in system prompt");
     assert!(prompt.contains("db:migrate"), "E7 FAIL: 'db:migrate' not in system prompt");
     assert!(prompt.contains("system-reminder"), "E7 FAIL: missing <system-reminder> wrapper");


### PR DESCRIPTION
## Summary

- Add `set_config` protocol command for dynamic model/thinking/effort switching at runtime
- Add capability discovery mechanism via `ProviderCompat` config layer
- External clients can now discover what features (thinking, effort, approval modes) the current provider supports
- `set_config` validates inputs against provider capabilities and rejects unsupported features
- New `config_changed` event emitted after every `set_config`, enabling clients to dynamically update UI controls

## Key Changes

### Runtime Config (`set_config` command)
- Switch model, toggle thinking (enabled/disabled + budget), set effort level at runtime
- Changes applied immediately or queued during active message processing
- Protocol version bumped to `0.2.0`

### Capability Discovery
- `ProviderCompat` gains `supports_thinking`, `supports_effort`, `effort_levels` fields with per-provider defaults
- `ready` event `capabilities` now includes `thinking`, `effort`, `effort_levels`, `modes`
- New `config_changed` event broadcasts updated capabilities after config changes
- Users can override defaults via `[providers.xxx.compat]` in config

### Validation
- Thinking rejected if provider doesn't support it (e.g., OpenAI)
- Effort rejected if provider doesn't support it (e.g., Anthropic) or value not in allowed levels
- Clear (empty string) always accepted regardless of support

## Files Changed

| Crate | File | Change |
|-------|------|--------|
| aion-config | `compat.rs` | Capability fields + per-provider defaults + merge + accessors |
| aion-protocol | `events.rs` | Expanded `Capabilities`, `ConfigChanged` event |
| aion-protocol | `commands.rs` | `SetConfig` command, `SessionMode` enum |
| aion-agent | `engine.rs` | Compat storage, validation in `apply_config_update` |
| aion-agent | `protocol_sink.rs` | Build capabilities from compat |
| aion-cli | `main.rs` | Wire ready/config_changed events |
| docs | `json-stream-protocol.md` | Protocol spec updated |

## Test plan

- [x] `ProviderCompat` capability defaults and merge behavior (5 new tests)
- [x] `Capabilities` and `ConfigChanged` serialization (4 new tests)
- [x] Validation: thinking rejected when unsupported
- [x] Validation: effort rejected when unsupported or invalid level
- [x] Validation: effort clear always works
- [x] Integration tests for protocol round-trip (3 new tests)
- [x] All existing tests still pass (268+ in aion-agent alone)
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all clean