### PR TITLE
feat: input token optimization — deferred tools, description truncation, prompt caching

### DIFF
--- a/crates/aion-agent/src/cache_diagnostics.rs
+++ b/crates/aion-agent/src/cache_diagnostics.rs
@@ -99,11 +99,7 @@ impl CacheBreakDetector {
         Some(diagnostic)
     }
 
-    fn compute_diagnostic(
-        &self,
-        current: &PromptSnapshot,
-        stats: &CacheStats,
-    ) -> CacheDiagnostic {
+    fn compute_diagnostic(&self, current: &PromptSnapshot, stats: &CacheStats) -> CacheDiagnostic {
         let Some(prev) = &self.prev_stats else {
             // First request — no previous data to compare
             return CacheDiagnostic::Healthy { hit_rate: 0.0 };
@@ -136,8 +132,7 @@ impl CacheBreakDetector {
 
         // Partial miss: cache_read dropped >5% compared to previous
         if prev.cache_read_tokens > 0 {
-            let drop_pct =
-                1.0 - (stats.cache_read_tokens as f64 / prev.cache_read_tokens as f64);
+            let drop_pct = 1.0 - (stats.cache_read_tokens as f64 / prev.cache_read_tokens as f64);
             if drop_pct > 0.05 {
                 let cause = self.attribute_cause(current);
                 return CacheDiagnostic::PartialMiss { hit_rate, cause };

--- a/crates/aion-agent/src/cache_diagnostics.rs
+++ b/crates/aion-agent/src/cache_diagnostics.rs
@@ -1,0 +1,408 @@
+//! Prompt cache break detection.
+//!
+//! Pairs request-side prompt state (hashes) with response-side cache tokens
+//! to detect and diagnose prompt cache breaks across turns.
+
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use aion_types::tool::ToolDef;
+
+/// Snapshot of prompt state taken before each API call.
+#[derive(Debug, Clone)]
+struct PromptSnapshot {
+    system_hash: u64,
+    tools_hash: u64,
+}
+
+/// Cache token statistics from a single API response.
+#[derive(Debug, Clone)]
+pub struct CacheStats {
+    pub input_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+}
+
+/// Diagnostic result after comparing two consecutive turns.
+#[derive(Debug, Clone)]
+pub enum CacheDiagnostic {
+    Healthy {
+        hit_rate: f64,
+    },
+    PartialMiss {
+        hit_rate: f64,
+        cause: CacheBreakCause,
+    },
+    FullMiss {
+        cause: CacheBreakCause,
+    },
+}
+
+/// What caused a cache break.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheBreakCause {
+    SystemPromptChanged,
+    ToolsChanged,
+    TtlExpiry,
+    FirstRequest,
+}
+
+/// Detects prompt cache breaks by comparing consecutive turns.
+pub struct CacheBreakDetector {
+    /// Snapshot from the PREVIOUS turn (used for attribution on cache break).
+    prev_snapshot: Option<PromptSnapshot>,
+    /// Snapshot from the CURRENT turn (just recorded by record_request).
+    current_snapshot: Option<PromptSnapshot>,
+    /// Cache stats from the previous API response.
+    prev_stats: Option<CacheStats>,
+}
+
+impl CacheBreakDetector {
+    pub fn new() -> Self {
+        Self {
+            prev_snapshot: None,
+            current_snapshot: None,
+            prev_stats: None,
+        }
+    }
+
+    /// Record the prompt state before an API call.
+    pub fn record_request(&mut self, system: &str, tools: &[ToolDef]) {
+        let mut system_hasher = DefaultHasher::new();
+        system.hash(&mut system_hasher);
+        let system_hash = system_hasher.finish();
+
+        let mut tools_hasher = DefaultHasher::new();
+        for t in tools {
+            t.name.hash(&mut tools_hasher);
+            t.description.hash(&mut tools_hasher);
+            let schema_str = serde_json::to_string(&t.input_schema).unwrap_or_default();
+            schema_str.hash(&mut tools_hasher);
+            t.deferred.hash(&mut tools_hasher);
+        }
+        let tools_hash = tools_hasher.finish();
+
+        // Rotate: current becomes prev, new snapshot becomes current
+        self.prev_snapshot = self.current_snapshot.take();
+        self.current_snapshot = Some(PromptSnapshot {
+            system_hash,
+            tools_hash,
+        });
+    }
+
+    /// Check the response cache tokens against the previous turn.
+    ///
+    /// Returns `None` if no snapshot was recorded before the call.
+    pub fn check_response(&mut self, stats: CacheStats) -> Option<CacheDiagnostic> {
+        let current = self.current_snapshot.as_ref()?;
+        let diagnostic = self.compute_diagnostic(current, &stats);
+        self.prev_stats = Some(stats);
+        Some(diagnostic)
+    }
+
+    fn compute_diagnostic(
+        &self,
+        current: &PromptSnapshot,
+        stats: &CacheStats,
+    ) -> CacheDiagnostic {
+        let Some(prev) = &self.prev_stats else {
+            // First request — no previous data to compare
+            return CacheDiagnostic::Healthy { hit_rate: 0.0 };
+        };
+
+        // If provider doesn't support caching (both turns have 0 cache tokens),
+        // report healthy to avoid false alarms (e.g., OpenAI).
+        if prev.cache_read_tokens == 0
+            && prev.cache_creation_tokens == 0
+            && stats.cache_read_tokens == 0
+            && stats.cache_creation_tokens == 0
+        {
+            return CacheDiagnostic::Healthy { hit_rate: 0.0 };
+        }
+
+        let prev_had_cache = prev.cache_read_tokens > 0 || prev.cache_creation_tokens > 0;
+
+        // Full miss: had cache before, now read tokens dropped to 0
+        if prev_had_cache && stats.cache_read_tokens == 0 {
+            let cause = self.attribute_cause(current);
+            return CacheDiagnostic::FullMiss { cause };
+        }
+
+        // Calculate hit rate
+        let hit_rate = if stats.input_tokens > 0 {
+            stats.cache_read_tokens as f64 / stats.input_tokens as f64
+        } else {
+            0.0
+        };
+
+        // Partial miss: cache_read dropped >5% compared to previous
+        if prev.cache_read_tokens > 0 {
+            let drop_pct =
+                1.0 - (stats.cache_read_tokens as f64 / prev.cache_read_tokens as f64);
+            if drop_pct > 0.05 {
+                let cause = self.attribute_cause(current);
+                return CacheDiagnostic::PartialMiss { hit_rate, cause };
+            }
+        }
+
+        CacheDiagnostic::Healthy { hit_rate }
+    }
+
+    /// Determine what caused the cache break by comparing prev vs current snapshots.
+    fn attribute_cause(&self, current: &PromptSnapshot) -> CacheBreakCause {
+        let Some(prev) = &self.prev_snapshot else {
+            return CacheBreakCause::FirstRequest;
+        };
+
+        if prev.system_hash != current.system_hash {
+            return CacheBreakCause::SystemPromptChanged;
+        }
+        if prev.tools_hash != current.tools_hash {
+            return CacheBreakCause::ToolsChanged;
+        }
+
+        // Hashes match but cache was lost — server-side TTL expiry
+        CacheBreakCause::TtlExpiry
+    }
+}
+
+impl Default for CacheBreakDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_tools() -> Vec<ToolDef> {
+        vec![ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: json!({"type": "object"}),
+            deferred: false,
+        }]
+    }
+
+    #[test]
+    fn first_request_returns_healthy() {
+        let mut detector = CacheBreakDetector::new();
+        detector.record_request("system prompt", &make_tools());
+        let diag = detector
+            .check_response(CacheStats {
+                input_tokens: 10000,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 5000,
+            })
+            .unwrap();
+        assert!(matches!(diag, CacheDiagnostic::Healthy { .. }));
+    }
+
+    #[test]
+    fn healthy_when_cache_read_stable() {
+        let mut detector = CacheBreakDetector::new();
+
+        // Turn 1
+        detector.record_request("prompt", &make_tools());
+        detector.check_response(CacheStats {
+            input_tokens: 10000,
+            cache_read_tokens: 8000,
+            cache_creation_tokens: 2000,
+        });
+
+        // Turn 2 — similar cache_read
+        detector.record_request("prompt", &make_tools());
+        let diag = detector
+            .check_response(CacheStats {
+                input_tokens: 11000,
+                cache_read_tokens: 8000,
+                cache_creation_tokens: 0,
+            })
+            .unwrap();
+
+        assert!(matches!(diag, CacheDiagnostic::Healthy { .. }));
+    }
+
+    #[test]
+    fn full_miss_when_cache_read_drops_to_zero() {
+        let mut detector = CacheBreakDetector::new();
+
+        // Turn 1 — cache established
+        detector.record_request("prompt", &make_tools());
+        detector.check_response(CacheStats {
+            input_tokens: 10000,
+            cache_read_tokens: 8000,
+            cache_creation_tokens: 2000,
+        });
+
+        // Turn 2 — cache_read drops to 0
+        detector.record_request("prompt", &make_tools());
+        let diag = detector
+            .check_response(CacheStats {
+                input_tokens: 10000,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 10000,
+            })
+            .unwrap();
+
+        assert!(matches!(diag, CacheDiagnostic::FullMiss { .. }));
+    }
+
+    #[test]
+    fn full_miss_system_prompt_changed() {
+        let mut detector = CacheBreakDetector::new();
+
+        // Turn 1
+        detector.record_request("prompt v1", &make_tools());
+        detector.check_response(CacheStats {
+            input_tokens: 10000,
+            cache_read_tokens: 8000,
+            cache_creation_tokens: 2000,
+        });
+
+        // Turn 2 — different system prompt
+        detector.record_request("prompt v2", &make_tools());
+        let diag = detector
+            .check_response(CacheStats {
+                input_tokens: 10000,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 10000,
+            })
+            .unwrap();
+
+        match diag {
+            CacheDiagnostic::FullMiss { cause } => {
+                assert_eq!(cause, CacheBreakCause::SystemPromptChanged);
+            }
+            _ => panic!("expected FullMiss"),
+        }
+    }
+
+    #[test]
+    fn full_miss_tools_changed() {
+        let mut detector = CacheBreakDetector::new();
+
+        // Turn 1
+        detector.record_request("prompt", &make_tools());
+        detector.check_response(CacheStats {
+            input_tokens: 10000,
+            cache_read_tokens: 8000,
+            cache_creation_tokens: 2000,
+        });
+
+        // Turn 2 — different tools
+        let new_tools = vec![ToolDef {
+            name: "Write".into(),
+            description: "Write a file".into(),
+            input_schema: json!({"type": "object"}),
+            deferred: false,
+        }];
+        detector.record_request("prompt", &new_tools);
+        let diag = detector
+            .check_response(CacheStats {
+                input_tokens: 10000,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 10000,
+            })
+            .unwrap();
+
+        match diag {
+            CacheDiagnostic::FullMiss { cause } => {
+                assert_eq!(cause, CacheBreakCause::ToolsChanged);
+            }
+            _ => panic!("expected FullMiss"),
+        }
+    }
+
+    #[test]
+    fn full_miss_ttl_expiry() {
+        let mut detector = CacheBreakDetector::new();
+
+        // Turn 1
+        detector.record_request("prompt", &make_tools());
+        detector.check_response(CacheStats {
+            input_tokens: 10000,
+            cache_read_tokens: 8000,
+            cache_creation_tokens: 2000,
+        });
+
+        // Turn 2 — same prompt and tools but cache lost (TTL expired server-side)
+        detector.record_request("prompt", &make_tools());
+        let diag = detector
+            .check_response(CacheStats {
+                input_tokens: 10000,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 10000,
+            })
+            .unwrap();
+
+        match diag {
+            CacheDiagnostic::FullMiss { cause } => {
+                assert_eq!(cause, CacheBreakCause::TtlExpiry);
+            }
+            _ => panic!("expected FullMiss"),
+        }
+    }
+
+    #[test]
+    fn partial_miss_when_cache_read_drops_significantly() {
+        let mut detector = CacheBreakDetector::new();
+
+        // Turn 1
+        detector.record_request("prompt", &make_tools());
+        detector.check_response(CacheStats {
+            input_tokens: 10000,
+            cache_read_tokens: 8000,
+            cache_creation_tokens: 2000,
+        });
+
+        // Turn 2 — 50% drop in cache_read
+        detector.record_request("prompt", &make_tools());
+        let diag = detector
+            .check_response(CacheStats {
+                input_tokens: 10000,
+                cache_read_tokens: 4000,
+                cache_creation_tokens: 6000,
+            })
+            .unwrap();
+
+        assert!(matches!(diag, CacheDiagnostic::PartialMiss { .. }));
+    }
+
+    #[test]
+    fn openai_no_false_alarm() {
+        // OpenAI never returns cache tokens — both turns have all zeros
+        let mut detector = CacheBreakDetector::new();
+
+        detector.record_request("prompt", &make_tools());
+        detector.check_response(CacheStats {
+            input_tokens: 10000,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+        });
+
+        detector.record_request("prompt", &make_tools());
+        let diag = detector
+            .check_response(CacheStats {
+                input_tokens: 10000,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+            })
+            .unwrap();
+
+        // Should be Healthy, not FullMiss
+        assert!(matches!(diag, CacheDiagnostic::Healthy { .. }));
+    }
+
+    #[test]
+    fn no_diagnostic_without_record_request() {
+        let mut detector = CacheBreakDetector::new();
+        let diag = detector.check_response(CacheStats {
+            input_tokens: 10000,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+        });
+        assert!(diag.is_none());
+    }
+}

--- a/crates/aion-agent/src/context.rs
+++ b/crates/aion-agent/src/context.rs
@@ -13,7 +13,6 @@ use crate::plan::prompt as plan_prompt;
 /// Each section (intro, tool guidance, AGENTS.md, memory, skills) is cached
 /// independently. The `joined` field holds the pre-joined full prompt string
 /// and is invalidated whenever any section changes.
-#[allow(dead_code)]
 pub struct SystemPromptCache {
     /// Cached section strings, keyed by section name.
     pub(crate) sections: HashMap<&'static str, String>,
@@ -87,7 +86,14 @@ a deferred tool, use ToolSearch to load its full schema first."
 /// 5. Memory system prompt (behavioral instructions + MEMORY.md content)
 /// 6. Plan mode instructions (when active)
 /// 7. Skills reminder (available skills listing)
+///
+/// Session-permanent sections (intro, tool guidance, custom prompt, AGENTS.md)
+/// are cached in `cache.sections` and reused across calls. The `joined` field
+/// caches the final concatenated result; it is returned on subsequent calls
+/// unless plan_mode_active has changed.
+#[allow(clippy::too_many_arguments)]
 pub fn build_system_prompt(
+    cache: &mut SystemPromptCache,
     custom_prompt: Option<&str>,
     cwd: &str,
     model: &str,
@@ -96,45 +102,74 @@ pub fn build_system_prompt(
     memory_dir: Option<&Path>,
     plan_mode_active: bool,
 ) -> String {
+    // Fast path: return cached joined result if nothing changed
+    if let Some(ref joined) = cache.joined
+        && cache.last_plan_mode == plan_mode_active
+    {
+        return joined.clone();
+    }
+
     let mut parts = Vec::new();
 
-    parts.push(format!(
-        "You are an AI assistant that can use tools to help with tasks.\n\
-         You are powered by the model {model}.\n\
-         Working directory: {cwd}\n\
-         Current date: {}",
-        chrono::Local::now().format("%Y-%m-%d")
-    ));
+    // Section: intro (session permanent)
+    let intro = cache.sections.entry("intro").or_insert_with(|| {
+        format!(
+            "You are an AI assistant that can use tools to help with tasks.\n\
+             You are powered by the model {model}.\n\
+             Working directory: {cwd}\n\
+             Current date: {}",
+            chrono::Local::now().format("%Y-%m-%d")
+        )
+    });
+    parts.push(intro.clone());
 
-    // Tool usage guidance — placed early so the model sees it before making any tool call
-    parts.push(tool_usage_guidance().to_string());
+    // Section: tool guidance (session permanent)
+    let guidance = cache
+        .sections
+        .entry("tool_guidance")
+        .or_insert_with(|| tool_usage_guidance().to_string());
+    parts.push(guidance.clone());
 
+    // Section: custom prompt (session permanent)
     if let Some(custom) = custom_prompt {
-        parts.push(custom.to_string());
+        let custom_cached = cache
+            .sections
+            .entry("custom")
+            .or_insert_with(|| custom.to_string());
+        parts.push(custom_cached.clone());
     }
 
-    // Read AGENTS.md if it exists
-    let agents_md = Path::new(cwd).join("AGENTS.md");
-    if agents_md.exists()
-        && let Ok(content) = std::fs::read_to_string(&agents_md)
-    {
-        parts.push(format!("# Project Instructions (AGENTS.md)\n\n{content}"));
+    // Section: AGENTS.md (session permanent)
+    let agents_section = cache.sections.entry("agents_md").or_insert_with(|| {
+        let agents_md = Path::new(cwd).join("AGENTS.md");
+        if agents_md.exists()
+            && let Ok(content) = std::fs::read_to_string(&agents_md)
+        {
+            return format!("# Project Instructions (AGENTS.md)\n\n{content}");
+        }
+        String::new()
+    });
+    if !agents_section.is_empty() {
+        parts.push(agents_section.clone());
     }
 
-    // Inject memory system prompt (behavioral instructions + MEMORY.md content)
+    // Section: memory (cached, event-invalidated)
     if let Some(dir) = memory_dir {
-        let memory_prompt = build_memory_prompt(dir);
-        if !memory_prompt.is_empty() {
-            parts.push(memory_prompt);
+        let memory_section = cache
+            .sections
+            .entry("memory")
+            .or_insert_with(|| build_memory_prompt(dir));
+        if !memory_section.is_empty() {
+            parts.push(memory_section.clone());
         }
     }
 
-    // Inject plan mode instructions when active
+    // Section: plan mode (NOT cached — rebuilt every call when active)
     if plan_mode_active {
         parts.push(plan_prompt::plan_mode_instructions().to_string());
     }
 
-    // Inject visible skill listing (exclude skills hidden from model invocation)
+    // Section: skills (cached, event-invalidated)
     let visible_skills: Vec<SkillMetadata> = skills
         .iter()
         .filter(|s| !s.disable_model_invocation)
@@ -142,15 +177,25 @@ pub fn build_system_prompt(
         .collect();
 
     if !visible_skills.is_empty() {
-        let listing = format_skills_within_budget(&visible_skills, context_window_tokens);
-        if !listing.is_empty() {
-            parts.push(format!(
-                "<system-reminder>\nThe following skills are available for use with the Skill tool:\n\n{listing}\n</system-reminder>"
-            ));
+        let skills_section = cache.sections.entry("skills").or_insert_with(|| {
+            let listing = format_skills_within_budget(&visible_skills, context_window_tokens);
+            if listing.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "<system-reminder>\nThe following skills are available for use with the Skill tool:\n\n{listing}\n</system-reminder>"
+                )
+            }
+        });
+        if !skills_section.is_empty() {
+            parts.push(skills_section.clone());
         }
     }
 
-    parts.join("\n\n")
+    let joined = parts.join("\n\n");
+    cache.joined = Some(joined.clone());
+    cache.last_plan_mode = plan_mode_active;
+    joined
 }
 
 /// Compact old messages to reduce context size.
@@ -234,13 +279,13 @@ mod tests {
     fn test_build_system_prompt_includes_cwd() {
         // Verify that the returned prompt contains the provided working directory path
         let cwd = "/some/test/path";
-        let prompt = build_system_prompt(None, cwd, "test-model", &[], None, None, false);
+        let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, cwd, "test-model", &[], None, None, false);
         assert!(prompt.contains(cwd), "system prompt should contain the cwd");
     }
 
     #[test]
     fn test_build_system_prompt_includes_model_name() {
-        let prompt = build_system_prompt(None, "/tmp", "deepseek-chat", &[], None, None, false);
+        let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "deepseek-chat", &[], None, None, false);
         assert!(
             prompt.contains("deepseek-chat"),
             "system prompt should contain the model name"
@@ -256,7 +301,7 @@ mod tests {
         // Verify that custom instructions are included in the returned prompt
         let custom = "Always respond in haiku.";
         let prompt =
-            build_system_prompt(Some(custom), "/tmp", "test-model", &[], None, None, false);
+            build_system_prompt(&mut SystemPromptCache::new(), Some(custom), "/tmp", "test-model", &[], None, None, false);
         assert!(
             prompt.contains(custom),
             "system prompt should contain the custom instructions"
@@ -376,7 +421,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_no_skills_no_reminder() {
-        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             !result.contains("The following skills are available"),
             "empty skills should not inject skill reminder"
@@ -389,7 +434,7 @@ mod tests {
             make_test_skill("skill-one", "Does one", false, false),
             make_test_skill("skill-two", "Does two", false, false),
         ];
-        let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
         assert!(
             result.contains("<system-reminder>"),
             "result should contain <system-reminder>"
@@ -412,7 +457,7 @@ mod tests {
             make_test_skill("visible-skill", "Visible", false, false),
             make_test_skill("hidden-skill", "Hidden", false, true),
         ];
-        let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
         assert!(
             result.contains("visible-skill"),
             "visible skill should appear"
@@ -429,7 +474,7 @@ mod tests {
             make_test_skill("hidden-a", "Hidden A", false, true),
             make_test_skill("hidden-b", "Hidden B", false, true),
         ];
-        let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
         assert!(
             !result.contains("The following skills are available"),
             "all-hidden skills should not inject reminder"
@@ -440,6 +485,7 @@ mod tests {
     fn test_build_system_prompt_custom_prompt_and_skills() {
         let skills = vec![make_test_skill("my-skill", "My desc", false, false)];
         let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
             Some("Custom instructions here"),
             "/tmp",
             "test-model",
@@ -462,6 +508,7 @@ mod tests {
     fn test_build_system_prompt_skills_reminder_after_custom_prompt() {
         let skills = vec![make_test_skill("my-skill", "My desc", false, false)];
         let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
             Some("Custom text"),
             "/tmp",
             "test-model",
@@ -483,7 +530,7 @@ mod tests {
         // context_window_tokens = 50 → budget = 2 chars, triggers minimal mode for non-bundled
         let skill = make_test_skill("nb-skill", &"x".repeat(100), false, false);
         let result =
-            build_system_prompt(None, "/tmp", "test-model", &[skill], Some(50), None, false);
+            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[skill], Some(50), None, false);
         // Minimal mode: skill appears as name only, no ': '
         assert!(
             result.contains("- nb-skill"),
@@ -498,6 +545,7 @@ mod tests {
     #[test]
     fn test_build_system_prompt_cwd_in_prompt() {
         let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
             None,
             "/workspace/my-project",
             "test-model",
@@ -522,6 +570,7 @@ mod tests {
         std::fs::write(cwd.join("CLAUDE.md"), "CLAUDE_CONTENT_HERE").unwrap();
 
         let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
             None,
             &cwd.to_string_lossy(),
             "test-model",
@@ -554,6 +603,7 @@ mod tests {
         std::fs::write(cwd.join("CLAUDE.md"), "SHOULD_NOT_APPEAR").unwrap();
 
         let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
             None,
             &cwd.to_string_lossy(),
             "test-model",
@@ -577,7 +627,7 @@ mod tests {
 
     #[test]
     fn memory_none_dir_no_injection() {
-        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             !result.contains("auto memory"),
             "no memory content when memory_dir is None"
@@ -596,7 +646,7 @@ mod tests {
         .unwrap();
 
         let result =
-            build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
         assert!(
             result.contains("auto memory"),
@@ -615,6 +665,7 @@ mod tests {
     #[test]
     fn memory_nonexistent_dir_graceful_degradation() {
         let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
             None,
             "/tmp",
             "test-model",
@@ -639,7 +690,7 @@ mod tests {
         // No MEMORY.md
 
         let result =
-            build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
         assert!(
             result.contains("currently empty"),
@@ -663,6 +714,7 @@ mod tests {
         let skills = vec![make_test_skill("test-skill", "A skill", false, false)];
 
         let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
             None,
             &cwd.to_string_lossy(),
             "test-model",
@@ -698,7 +750,7 @@ mod tests {
         .unwrap();
 
         let result =
-            build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
         assert!(
             !result.contains("~/.claude"),
@@ -714,7 +766,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_section_exists() {
-        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("# Using your tools"),
             "system prompt should contain the tool guidance heading"
@@ -723,7 +775,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_bash_prohibition_list() {
-        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("Glob"),
             "should mention Glob as find/ls replacement"
@@ -748,7 +800,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_parallel_call_rules() {
-        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("parallel"),
             "should contain parallel call guidance"
@@ -761,7 +813,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_edit_over_write_preference() {
-        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("Prefer Edit over Write"),
             "should contain Edit-over-Write preference"
@@ -770,7 +822,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_read_before_edit_rule() {
-        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("Read a file before editing"),
             "should contain Read-before-Edit rule"
@@ -780,6 +832,7 @@ mod tests {
     #[test]
     fn tool_guidance_after_intro_before_custom_prompt() {
         let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
             Some("CUSTOM_MARKER_43"),
             "/tmp",
             "test-model",
@@ -804,7 +857,7 @@ mod tests {
     #[test]
     fn tool_guidance_before_skills_reminder() {
         let skills = vec![make_test_skill("guide-test-skill", "A skill", false, false)];
-        let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
         let guidance_pos = result.find("# Using your tools").unwrap();
         let skills_pos = result.find("guide-test-skill").unwrap();
         assert!(
@@ -815,7 +868,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_present_in_plan_mode() {
-        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, true);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, true);
         assert!(
             result.contains("# Using your tools"),
             "tool guidance should be present in plan mode"
@@ -824,7 +877,7 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_deferred_instruction() {
-        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
         assert!(
             result.contains("deferred"),
             "tool guidance should mention deferred tools"
@@ -843,7 +896,7 @@ mod tests {
         std::fs::write(mem_dir.join("MEMORY.md"), "- [X](x.md) \u{2014} test\n").unwrap();
 
         let result =
-            build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
         let guidance_pos = result.find("# Using your tools").unwrap();
         let memory_pos = result.find("auto memory").unwrap();
         assert!(
@@ -907,5 +960,33 @@ mod tests {
         // joined is still invalidated (conservative behavior)
         assert!(cache.joined.is_none());
         assert_eq!(cache.sections.get("intro").unwrap(), "Hello");
+    }
+
+    // --- Cache integration tests ---
+
+    #[test]
+    fn build_system_prompt_uses_cache_on_second_call() {
+        let mut cache = SystemPromptCache::new();
+        let first = build_system_prompt(
+            &mut cache, None, "/tmp", "test-model", &[], None, None, false,
+        );
+        assert!(cache.joined.is_some());
+
+        let second = build_system_prompt(
+            &mut cache, None, "/tmp", "test-model", &[], None, None, false,
+        );
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn build_system_prompt_plan_mode_change_rebuilds() {
+        let mut cache = SystemPromptCache::new();
+        let without_plan = build_system_prompt(
+            &mut cache, None, "/tmp", "test-model", &[], None, None, false,
+        );
+        let with_plan = build_system_prompt(
+            &mut cache, None, "/tmp", "test-model", &[], None, None, true,
+        );
+        assert_ne!(without_plan, with_plan);
     }
 }

--- a/crates/aion-agent/src/context.rs
+++ b/crates/aion-agent/src/context.rs
@@ -279,13 +279,31 @@ mod tests {
     fn test_build_system_prompt_includes_cwd() {
         // Verify that the returned prompt contains the provided working directory path
         let cwd = "/some/test/path";
-        let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, cwd, "test-model", &[], None, None, false);
+        let prompt = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            cwd,
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(prompt.contains(cwd), "system prompt should contain the cwd");
     }
 
     #[test]
     fn test_build_system_prompt_includes_model_name() {
-        let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "deepseek-chat", &[], None, None, false);
+        let prompt = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "deepseek-chat",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             prompt.contains("deepseek-chat"),
             "system prompt should contain the model name"
@@ -300,8 +318,16 @@ mod tests {
     fn test_build_system_prompt_with_custom_instructions() {
         // Verify that custom instructions are included in the returned prompt
         let custom = "Always respond in haiku.";
-        let prompt =
-            build_system_prompt(&mut SystemPromptCache::new(), Some(custom), "/tmp", "test-model", &[], None, None, false);
+        let prompt = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            Some(custom),
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             prompt.contains(custom),
             "system prompt should contain the custom instructions"
@@ -421,7 +447,16 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_no_skills_no_reminder() {
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             !result.contains("The following skills are available"),
             "empty skills should not inject skill reminder"
@@ -434,7 +469,16 @@ mod tests {
             make_test_skill("skill-one", "Does one", false, false),
             make_test_skill("skill-two", "Does two", false, false),
         ];
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &skills,
+            None,
+            None,
+            false,
+        );
         assert!(
             result.contains("<system-reminder>"),
             "result should contain <system-reminder>"
@@ -457,7 +501,16 @@ mod tests {
             make_test_skill("visible-skill", "Visible", false, false),
             make_test_skill("hidden-skill", "Hidden", false, true),
         ];
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &skills,
+            None,
+            None,
+            false,
+        );
         assert!(
             result.contains("visible-skill"),
             "visible skill should appear"
@@ -474,7 +527,16 @@ mod tests {
             make_test_skill("hidden-a", "Hidden A", false, true),
             make_test_skill("hidden-b", "Hidden B", false, true),
         ];
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &skills,
+            None,
+            None,
+            false,
+        );
         assert!(
             !result.contains("The following skills are available"),
             "all-hidden skills should not inject reminder"
@@ -529,8 +591,16 @@ mod tests {
     fn test_build_system_prompt_small_budget_triggers_minimal_mode() {
         // context_window_tokens = 50 → budget = 2 chars, triggers minimal mode for non-bundled
         let skill = make_test_skill("nb-skill", &"x".repeat(100), false, false);
-        let result =
-            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[skill], Some(50), None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[skill],
+            Some(50),
+            None,
+            false,
+        );
         // Minimal mode: skill appears as name only, no ': '
         assert!(
             result.contains("- nb-skill"),
@@ -627,7 +697,16 @@ mod tests {
 
     #[test]
     fn memory_none_dir_no_injection() {
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             !result.contains("auto memory"),
             "no memory content when memory_dir is None"
@@ -645,8 +724,16 @@ mod tests {
         )
         .unwrap();
 
-        let result =
-            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            Some(&mem_dir),
+            false,
+        );
 
         assert!(
             result.contains("auto memory"),
@@ -689,8 +776,16 @@ mod tests {
         std::fs::create_dir_all(&mem_dir).unwrap();
         // No MEMORY.md
 
-        let result =
-            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            Some(&mem_dir),
+            false,
+        );
 
         assert!(
             result.contains("currently empty"),
@@ -749,8 +844,16 @@ mod tests {
         )
         .unwrap();
 
-        let result =
-            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            Some(&mem_dir),
+            false,
+        );
 
         assert!(
             !result.contains("~/.claude"),
@@ -766,7 +869,16 @@ mod tests {
 
     #[test]
     fn tool_guidance_section_exists() {
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             result.contains("# Using your tools"),
             "system prompt should contain the tool guidance heading"
@@ -775,7 +887,16 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_bash_prohibition_list() {
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             result.contains("Glob"),
             "should mention Glob as find/ls replacement"
@@ -800,7 +921,16 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_parallel_call_rules() {
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             result.contains("parallel"),
             "should contain parallel call guidance"
@@ -813,7 +943,16 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_edit_over_write_preference() {
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             result.contains("Prefer Edit over Write"),
             "should contain Edit-over-Write preference"
@@ -822,7 +961,16 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_read_before_edit_rule() {
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             result.contains("Read a file before editing"),
             "should contain Read-before-Edit rule"
@@ -857,7 +1005,16 @@ mod tests {
     #[test]
     fn tool_guidance_before_skills_reminder() {
         let skills = vec![make_test_skill("guide-test-skill", "A skill", false, false)];
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &skills,
+            None,
+            None,
+            false,
+        );
         let guidance_pos = result.find("# Using your tools").unwrap();
         let skills_pos = result.find("guide-test-skill").unwrap();
         assert!(
@@ -868,7 +1025,16 @@ mod tests {
 
     #[test]
     fn tool_guidance_present_in_plan_mode() {
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, true);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            true,
+        );
         assert!(
             result.contains("# Using your tools"),
             "tool guidance should be present in plan mode"
@@ -877,7 +1043,16 @@ mod tests {
 
     #[test]
     fn tool_guidance_contains_deferred_instruction() {
-        let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
+        );
         assert!(
             result.contains("deferred"),
             "tool guidance should mention deferred tools"
@@ -895,8 +1070,16 @@ mod tests {
         std::fs::create_dir_all(&mem_dir).unwrap();
         std::fs::write(mem_dir.join("MEMORY.md"), "- [X](x.md) \u{2014} test\n").unwrap();
 
-        let result =
-            build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+        let result = build_system_prompt(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            Some(&mem_dir),
+            false,
+        );
         let guidance_pos = result.find("# Using your tools").unwrap();
         let memory_pos = result.find("auto memory").unwrap();
         assert!(
@@ -925,7 +1108,9 @@ mod tests {
     fn cache_invalidate_removes_section_and_joined() {
         let mut cache = SystemPromptCache::new();
         cache.sections.insert("intro", "Hello".to_string());
-        cache.sections.insert("memory", "Memory content".to_string());
+        cache
+            .sections
+            .insert("memory", "Memory content".to_string());
         cache.joined = Some("Hello\n\nMemory content".to_string());
 
         cache.invalidate("memory");
@@ -968,12 +1153,26 @@ mod tests {
     fn build_system_prompt_uses_cache_on_second_call() {
         let mut cache = SystemPromptCache::new();
         let first = build_system_prompt(
-            &mut cache, None, "/tmp", "test-model", &[], None, None, false,
+            &mut cache,
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
         );
         assert!(cache.joined.is_some());
 
         let second = build_system_prompt(
-            &mut cache, None, "/tmp", "test-model", &[], None, None, false,
+            &mut cache,
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
         );
         assert_eq!(first, second);
     }
@@ -982,10 +1181,24 @@ mod tests {
     fn build_system_prompt_plan_mode_change_rebuilds() {
         let mut cache = SystemPromptCache::new();
         let without_plan = build_system_prompt(
-            &mut cache, None, "/tmp", "test-model", &[], None, None, false,
+            &mut cache,
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            false,
         );
         let with_plan = build_system_prompt(
-            &mut cache, None, "/tmp", "test-model", &[], None, None, true,
+            &mut cache,
+            None,
+            "/tmp",
+            "test-model",
+            &[],
+            None,
+            None,
+            true,
         );
         assert_ne!(without_plan, with_plan);
     }

--- a/crates/aion-agent/src/context.rs
+++ b/crates/aion-agent/src/context.rs
@@ -28,7 +28,9 @@ dependencies between them, make all independent calls in parallel. \
 However, if one call depends on a previous result, run them sequentially.
  - Prefer Edit over Write for modifying existing files — Edit sends only \
 the diff, which is easier to review.
- - Always Read a file before editing it."
+ - Always Read a file before editing it.
+ - Some tools are deferred — only their names are visible. Before calling \
+a deferred tool, use ToolSearch to load its full schema first."
 }
 
 /// Build the system prompt from config and environment.
@@ -773,6 +775,19 @@ mod tests {
         assert!(
             result.contains("# Using your tools"),
             "tool guidance should be present in plan mode"
+        );
+    }
+
+    #[test]
+    fn tool_guidance_contains_deferred_instruction() {
+        let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+        assert!(
+            result.contains("deferred"),
+            "tool guidance should mention deferred tools"
+        );
+        assert!(
+            result.contains("ToolSearch"),
+            "tool guidance should mention ToolSearch"
         );
     }
 

--- a/crates/aion-agent/src/context.rs
+++ b/crates/aion-agent/src/context.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use aion_memory::prompt::build_memory_prompt;
+use aion_memory::prompt::build_memory_prompt_minimal;
 use aion_skills::prompt::format_skills_within_budget;
 use aion_skills::types::SkillMetadata;
 use aion_types::message::{ContentBlock, Message, Role};
@@ -154,11 +154,13 @@ pub fn build_system_prompt(
     }
 
     // Section: memory (cached, event-invalidated)
+    // Uses the minimal prompt to save ~2,500 tokens — omits full type taxonomy
+    // and examples. The full instructions are available via build_memory_prompt().
     if let Some(dir) = memory_dir {
         let memory_section = cache
             .sections
             .entry("memory")
-            .or_insert_with(|| build_memory_prompt(dir));
+            .or_insert_with(|| build_memory_prompt_minimal(dir));
         if !memory_section.is_empty() {
             parts.push(memory_section.clone());
         }
@@ -740,8 +742,8 @@ mod tests {
             "should contain memory system display name"
         );
         assert!(
-            result.contains("Types of memory"),
-            "should contain type definitions"
+            result.contains("Memory types:"),
+            "should contain compact memory type summary"
         );
         assert!(
             result.contains("user_role.md"),
@@ -1115,7 +1117,7 @@ mod tests {
 
         cache.invalidate("memory");
 
-        assert!(cache.sections.get("memory").is_none());
+        assert!(!cache.sections.contains_key("memory"));
         assert!(cache.joined.is_none());
         // Other sections preserved
         assert_eq!(cache.sections.get("intro").unwrap(), "Hello");

--- a/crates/aion-agent/src/context.rs
+++ b/crates/aion-agent/src/context.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use aion_memory::prompt::build_memory_prompt;
@@ -6,6 +7,49 @@ use aion_skills::types::SkillMetadata;
 use aion_types::message::{ContentBlock, Message, Role};
 
 use crate::plan::prompt as plan_prompt;
+
+/// Session-scoped cache for system prompt sections.
+///
+/// Each section (intro, tool guidance, AGENTS.md, memory, skills) is cached
+/// independently. The `joined` field holds the pre-joined full prompt string
+/// and is invalidated whenever any section changes.
+#[allow(dead_code)]
+pub struct SystemPromptCache {
+    /// Cached section strings, keyed by section name.
+    pub(crate) sections: HashMap<&'static str, String>,
+    /// Pre-joined full prompt. Invalidated on any section change.
+    pub(crate) joined: Option<String>,
+    /// Track last plan_mode_active value to detect changes.
+    pub(crate) last_plan_mode: bool,
+}
+
+impl SystemPromptCache {
+    pub fn new() -> Self {
+        Self {
+            sections: HashMap::new(),
+            joined: None,
+            last_plan_mode: false,
+        }
+    }
+
+    /// Invalidate a specific section by name.
+    pub fn invalidate(&mut self, section: &str) {
+        self.sections.remove(section);
+        self.joined = None;
+    }
+
+    /// Invalidate all cached sections (e.g., on /compact).
+    pub fn invalidate_all(&mut self) {
+        self.sections.clear();
+        self.joined = None;
+    }
+}
+
+impl Default for SystemPromptCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Return the tool-usage guidance section for the system prompt.
 ///
@@ -806,5 +850,62 @@ mod tests {
             guidance_pos < memory_pos,
             "tool guidance should appear before memory section"
         );
+    }
+
+    // --- SystemPromptCache tests ---
+
+    #[test]
+    fn cache_new_is_empty() {
+        let cache = SystemPromptCache::new();
+        assert!(cache.joined.is_none());
+        assert!(cache.sections.is_empty());
+    }
+
+    #[test]
+    fn cache_stores_and_retrieves_section() {
+        let mut cache = SystemPromptCache::new();
+        cache.sections.insert("intro", "Hello world".to_string());
+        assert_eq!(cache.sections.get("intro").unwrap(), "Hello world");
+    }
+
+    #[test]
+    fn cache_invalidate_removes_section_and_joined() {
+        let mut cache = SystemPromptCache::new();
+        cache.sections.insert("intro", "Hello".to_string());
+        cache.sections.insert("memory", "Memory content".to_string());
+        cache.joined = Some("Hello\n\nMemory content".to_string());
+
+        cache.invalidate("memory");
+
+        assert!(cache.sections.get("memory").is_none());
+        assert!(cache.joined.is_none());
+        // Other sections preserved
+        assert_eq!(cache.sections.get("intro").unwrap(), "Hello");
+    }
+
+    #[test]
+    fn cache_invalidate_all_clears_everything() {
+        let mut cache = SystemPromptCache::new();
+        cache.sections.insert("intro", "Hello".to_string());
+        cache.sections.insert("memory", "Mem".to_string());
+        cache.joined = Some("joined".to_string());
+
+        cache.invalidate_all();
+
+        assert!(cache.sections.is_empty());
+        assert!(cache.joined.is_none());
+    }
+
+    #[test]
+    fn cache_invalidate_nonexistent_key_is_noop() {
+        let mut cache = SystemPromptCache::new();
+        cache.sections.insert("intro", "Hello".to_string());
+        cache.joined = Some("joined".to_string());
+
+        cache.invalidate("nonexistent");
+
+        // joined is still invalidated (conservative behavior)
+        assert!(cache.joined.is_none());
+        assert_eq!(cache.sections.get("intro").unwrap(), "Hello");
     }
 }

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -11,6 +11,7 @@ use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 use aion_types::skill_types::{ContextModifier, PlanModeTransition, effort_to_string};
 
+use crate::cache_diagnostics::{CacheBreakDetector, CacheDiagnostic, CacheStats};
 use crate::compact::state::CompactState;
 use crate::compact::{auto, emergency, micro};
 use crate::confirm::ToolConfirmer;
@@ -55,6 +56,8 @@ pub struct AgentEngine {
     /// Shared flag read by EnterPlanMode/ExitPlanMode tools to validate transitions.
     /// Updated by the engine when processing PlanModeTransition modifiers.
     plan_active_flag: Option<Arc<AtomicBool>>,
+    /// Prompt cache break detector for diagnostics.
+    cache_detector: CacheBreakDetector,
 }
 
 impl AgentEngine {
@@ -113,6 +116,7 @@ impl AgentEngine {
             compact_state: CompactState::new(),
             plan_state: PlanState::default(),
             plan_active_flag: None,
+            cache_detector: CacheBreakDetector::new(),
         }
     }
 
@@ -176,6 +180,7 @@ impl AgentEngine {
             compact_state: CompactState::new(),
             plan_state: PlanState::default(),
             plan_active_flag: None,
+            cache_detector: CacheBreakDetector::new(),
         }
     }
 
@@ -352,6 +357,9 @@ impl AgentEngine {
                 self.system_prompt.clone()
             };
 
+            // Record prompt state for cache diagnostics
+            self.cache_detector.record_request(&system, &tools);
+
             let request = LlmRequest {
                 model: self.model.clone(),
                 system,
@@ -404,6 +412,35 @@ impl AgentEngine {
 
             // Track per-turn input tokens for compaction watermark
             self.compact_state.last_input_tokens = turn_usage.input_tokens;
+
+            // Cache break detection
+            let cache_stats = CacheStats {
+                input_tokens: turn_usage.input_tokens,
+                cache_read_tokens: turn_usage.cache_read_tokens,
+                cache_creation_tokens: turn_usage.cache_creation_tokens,
+            };
+            if let Some(diagnostic) = self.cache_detector.check_response(cache_stats) {
+                match &diagnostic {
+                    CacheDiagnostic::FullMiss { cause } => {
+                        self.output
+                            .emit_error(&format!("Cache full miss: {cause:?}"));
+                    }
+                    CacheDiagnostic::PartialMiss { hit_rate, cause } => {
+                        if self.compact_config.cache_diagnostics {
+                            self.output.emit_info(&format!(
+                                "Cache: {:.0}% hit rate (cause: {cause:?})",
+                                hit_rate * 100.0
+                            ));
+                        }
+                    }
+                    CacheDiagnostic::Healthy { hit_rate } => {
+                        if self.compact_config.cache_diagnostics {
+                            self.output
+                                .emit_info(&format!("Cache: {:.0}% hit rate", hit_rate * 100.0));
+                        }
+                    }
+                }
+            }
 
             let mut assistant_content: Vec<ContentBlock> = Vec::new();
             if !thinking_text.is_empty() {
@@ -709,6 +746,7 @@ mod set_config_tests {
             compact_state: super::CompactState::new(),
             plan_state: Default::default(),
             plan_active_flag: None,
+            cache_detector: super::CacheBreakDetector::new(),
         }
     }
 
@@ -1030,6 +1068,7 @@ mod phase6_tests {
             compact_state: super::CompactState::new(),
             plan_state: Default::default(),
             plan_active_flag: None,
+            cache_detector: super::CacheBreakDetector::new(),
         }
     }
 
@@ -1229,6 +1268,7 @@ mod compact_tests {
             compact_state,
             plan_state: Default::default(),
             plan_active_flag: None,
+            cache_detector: super::CacheBreakDetector::new(),
         }
     }
 
@@ -1491,6 +1531,7 @@ mod plan_mode_tests {
             compact_state: CompactState::new(),
             plan_state: PlanState::default(),
             plan_active_flag: Some(flag),
+            cache_detector: super::CacheBreakDetector::new(),
         }
     }
 

--- a/crates/aion-agent/src/lib.rs
+++ b/crates/aion-agent/src/lib.rs
@@ -1,5 +1,6 @@
 // Core agent infrastructure: engine, session, orchestration, output sinks.
 
+pub mod cache_diagnostics;
 pub mod compact;
 pub mod confirm;
 pub mod context;

--- a/crates/aion-agent/src/plan/tools.rs
+++ b/crates/aion-agent/src/plan/tools.rs
@@ -54,6 +54,10 @@ impl Tool for EnterPlanModeTool {
         true
     }
 
+    fn is_deferred(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, _input: Value) -> ToolResult {
         if self.plan_active.load(Ordering::Acquire) {
             return ToolResult {
@@ -127,6 +131,10 @@ impl Tool for ExitPlanModeTool {
     }
 
     fn is_concurrency_safe(&self, _input: &Value) -> bool {
+        true
+    }
+
+    fn is_deferred(&self) -> bool {
         true
     }
 

--- a/crates/aion-agent/src/spawn_tool.rs
+++ b/crates/aion-agent/src/spawn_tool.rs
@@ -70,6 +70,10 @@ impl Tool for SpawnTool {
         false // manages its own concurrency
     }
 
+    fn is_deferred(&self) -> bool {
+        true
+    }
+
     async fn execute(&self, input: Value) -> ToolResult {
         let tasks = match parse_tasks(&input) {
             Ok(tasks) => tasks,

--- a/crates/aion-agent/tests/acceptance/cross_feature_test.rs
+++ b/crates/aion-agent/tests/acceptance/cross_feature_test.rs
@@ -3,7 +3,7 @@
 // Exercises memory + compression + file cache + tool description all at once.
 
 use aion_agent::compact::micro::{CLEARED_TOOL_RESULT, microcompact};
-use aion_agent::context::build_system_prompt;
+use aion_agent::context::{SystemPromptCache, build_system_prompt};
 use aion_config::compact::CompactConfig;
 use aion_config::file_cache::FileCacheConfig;
 use aion_tools::Tool;
@@ -32,6 +32,7 @@ async fn tc_ax_01_multi_feature_collaboration() {
 
     // ── Step 2: Build system prompt with memory ──
     let system_prompt = build_system_prompt(
+        &mut SystemPromptCache::new(),
         None,
         "/tmp",
         "test-model",

--- a/crates/aion-agent/tests/acceptance/helpers.rs
+++ b/crates/aion-agent/tests/acceptance/helpers.rs
@@ -94,6 +94,7 @@ pub fn openai_config(api_key: &str) -> Config {
         bedrock: None,
         vertex: None,
         mcp: McpConfig::default(),
+        debug: aion_config::debug::DebugConfig::default(),
     }
 }
 
@@ -128,5 +129,6 @@ pub fn bedrock_config() -> Config {
         bedrock: Some(BedrockConfig::default()),
         vertex: None,
         mcp: McpConfig::default(),
+        debug: aion_config::debug::DebugConfig::default(),
     }
 }

--- a/crates/aion-agent/tests/acceptance/memory_test.rs
+++ b/crates/aion-agent/tests/acceptance/memory_test.rs
@@ -36,7 +36,16 @@ fn memory_injection_into_system_prompt() {
     )
     .unwrap();
 
-    let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let prompt = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        Some(&mem_dir),
+        false,
+    );
 
     // Behavioral instructions must be present
     assert!(
@@ -108,8 +117,16 @@ fn memory_full_lifecycle() {
 
     // -- Phase 3: Verify system prompt includes the memory content ------------
 
-    let prompt_with_memory =
-        build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let prompt_with_memory = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        Some(&mem_dir),
+        false,
+    );
 
     assert!(
         prompt_with_memory.contains("auto memory"),
@@ -148,8 +165,16 @@ fn memory_full_lifecycle() {
 
     // -- Phase 6: Verify the content is gone from the system prompt -----------
 
-    let prompt_after_delete =
-        build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let prompt_after_delete = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        Some(&mem_dir),
+        false,
+    );
 
     assert!(
         !prompt_after_delete.contains(&entry_filename),

--- a/crates/aion-agent/tests/acceptance/memory_test.rs
+++ b/crates/aion-agent/tests/acceptance/memory_test.rs
@@ -3,7 +3,7 @@
 // These tests verify that the memory system's file I/O, index management,
 // and prompt building work together correctly. No LLM API calls are needed.
 
-use aion_agent::context::build_system_prompt;
+use aion_agent::context::{SystemPromptCache, build_system_prompt};
 use aion_memory::index::{append_index_entry, remove_index_entry};
 use aion_memory::paths::ENTRYPOINT_NAME;
 use aion_memory::store::{delete_memory, write_memory};
@@ -36,7 +36,7 @@ fn memory_injection_into_system_prompt() {
     )
     .unwrap();
 
-    let prompt = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     // Behavioral instructions must be present
     assert!(
@@ -109,7 +109,7 @@ fn memory_full_lifecycle() {
     // -- Phase 3: Verify system prompt includes the memory content ------------
 
     let prompt_with_memory =
-        build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+        build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         prompt_with_memory.contains("auto memory"),
@@ -149,7 +149,7 @@ fn memory_full_lifecycle() {
     // -- Phase 6: Verify the content is gone from the system prompt -----------
 
     let prompt_after_delete =
-        build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+        build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         !prompt_after_delete.contains(&entry_filename),

--- a/crates/aion-agent/tests/acceptance/memory_test.rs
+++ b/crates/aion-agent/tests/acceptance/memory_test.rs
@@ -13,8 +13,7 @@ use aion_memory::types::{MemoryEntry, MemoryType};
 ///
 /// Verifies that when a memory directory exists with an index file and a
 /// memory entry, `build_system_prompt()` produces output containing both
-/// the behavioral instructions (type taxonomy, guidance) and the MEMORY.md
-/// index content.
+/// the compact behavioral instructions and the MEMORY.md index content.
 #[test]
 fn memory_injection_into_system_prompt() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -53,8 +52,8 @@ fn memory_injection_into_system_prompt() {
         "system prompt should contain the memory display name"
     );
     assert!(
-        prompt.contains("Types of memory"),
-        "system prompt should contain the memory type taxonomy"
+        prompt.contains("Memory types:"),
+        "system prompt should contain the compact memory type summary"
     );
 
     // MEMORY.md content must be injected
@@ -133,8 +132,8 @@ fn memory_full_lifecycle() {
         "prompt should contain behavioral instructions"
     );
     assert!(
-        prompt_with_memory.contains("Types of memory"),
-        "prompt should contain memory type taxonomy"
+        prompt_with_memory.contains("Memory types:"),
+        "prompt should contain compact memory type summary"
     );
     assert!(
         prompt_with_memory.contains(&entry_filename),

--- a/crates/aion-agent/tests/acceptance/plan_mode_test.rs
+++ b/crates/aion-agent/tests/acceptance/plan_mode_test.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use aion_agent::context::build_system_prompt;
+use aion_agent::context::{SystemPromptCache, build_system_prompt};
 use aion_agent::plan::tools::{EnterPlanModeTool, ExitPlanModeTool};
 use aion_protocol::events::ToolCategory;
 use aion_tools::Tool;
@@ -158,7 +158,7 @@ fn tc_a3_01_plan_mode_tool_filtering() {
 #[test]
 fn tc_a3_02_plan_mode_system_prompt_injection() {
     // --- Plan mode active: prompt should contain plan mode instructions ---
-    let active_prompt = build_system_prompt(None, "/tmp", "test-model", &[], None, None, true);
+    let active_prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, true);
 
     assert!(
         active_prompt.contains("# Plan Mode"),
@@ -190,7 +190,7 @@ fn tc_a3_02_plan_mode_system_prompt_injection() {
     );
 
     // --- Plan mode inactive: prompt should NOT contain plan mode instructions ---
-    let inactive_prompt = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+    let inactive_prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
 
     assert!(
         !inactive_prompt.contains("# Plan Mode"),

--- a/crates/aion-agent/tests/acceptance/plan_mode_test.rs
+++ b/crates/aion-agent/tests/acceptance/plan_mode_test.rs
@@ -158,7 +158,16 @@ fn tc_a3_01_plan_mode_tool_filtering() {
 #[test]
 fn tc_a3_02_plan_mode_system_prompt_injection() {
     // --- Plan mode active: prompt should contain plan mode instructions ---
-    let active_prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, true);
+    let active_prompt = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        true,
+    );
 
     assert!(
         active_prompt.contains("# Plan Mode"),
@@ -190,7 +199,16 @@ fn tc_a3_02_plan_mode_system_prompt_injection() {
     );
 
     // --- Plan mode inactive: prompt should NOT contain plan mode instructions ---
-    let inactive_prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+    let inactive_prompt = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        false,
+    );
 
     assert!(
         !inactive_prompt.contains("# Plan Mode"),

--- a/crates/aion-agent/tests/acceptance/tool_desc_test.rs
+++ b/crates/aion-agent/tests/acceptance/tool_desc_test.rs
@@ -2,7 +2,7 @@
 //
 // This is a LOCAL test — no LLM call required.
 
-use aion_agent::context::build_system_prompt;
+use aion_agent::context::{SystemPromptCache, build_system_prompt};
 
 /// TC-A4-01: System prompt contains tool guidance.
 ///
@@ -12,7 +12,7 @@ use aion_agent::context::build_system_prompt;
 /// Edit-over-Write preference, and Read-before-Edit rule.
 #[test]
 fn system_prompt_contains_tool_guidance() {
-    let prompt = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+    let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
 
     // 1. Heading
     assert!(

--- a/crates/aion-agent/tests/acceptance/tool_desc_test.rs
+++ b/crates/aion-agent/tests/acceptance/tool_desc_test.rs
@@ -12,7 +12,16 @@ use aion_agent::context::{SystemPromptCache, build_system_prompt};
 /// Edit-over-Write preference, and Read-before-Edit rule.
 #[test]
 fn system_prompt_contains_tool_guidance() {
-    let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+    let prompt = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        false,
+    );
 
     // 1. Heading
     assert!(

--- a/crates/aion-agent/tests/common/mod.rs
+++ b/crates/aion-agent/tests/common/mod.rs
@@ -265,6 +265,7 @@ pub fn test_config() -> Config {
         bedrock: None,
         vertex: None,
         mcp: McpConfig::default(),
+        debug: aion_config::debug::DebugConfig::default(),
     }
 }
 

--- a/crates/aion-agent/tests/e2e/anthropic.rs
+++ b/crates/aion-agent/tests/e2e/anthropic.rs
@@ -48,6 +48,7 @@ fn anthropic_config(api_key: &str) -> Config {
         bedrock: None,
         vertex: None,
         mcp: McpConfig::default(),
+        debug: aion_config::debug::DebugConfig::default(),
     }
 }
 

--- a/crates/aion-agent/tests/e2e/openai.rs
+++ b/crates/aion-agent/tests/e2e/openai.rs
@@ -47,6 +47,7 @@ fn openai_config(api_key: &str) -> Config {
         bedrock: None,
         vertex: None,
         mcp: McpConfig::default(),
+        debug: aion_config::debug::DebugConfig::default(),
     }
 }
 

--- a/crates/aion-agent/tests/memory_context_integration.rs
+++ b/crates/aion-agent/tests/memory_context_integration.rs
@@ -5,7 +5,7 @@
 
 use std::fs;
 
-use aion_agent::context::build_system_prompt;
+use aion_agent::context::{SystemPromptCache, build_system_prompt};
 
 // ---------------------------------------------------------------------------
 // TC-7.1: With memory_dir, system prompt includes memory content
@@ -23,7 +23,7 @@ fn tc_7_1_memory_dir_with_content_injects_prompt() {
     )
     .unwrap();
 
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     // Should contain memory system sections
     assert!(
@@ -64,7 +64,7 @@ fn tc_7_1_memory_dir_with_content_injects_prompt() {
 
 #[test]
 fn tc_7_2_no_memory_dir_no_injection() {
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
 
     assert!(
         !result.contains("auto memory"),
@@ -122,6 +122,7 @@ fn tc_7_3_section_ordering() {
     };
 
     let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
         None,
         &cwd.to_string_lossy(),
         "test-model",
@@ -158,6 +159,7 @@ fn tc_7_3_section_ordering() {
 #[test]
 fn tc_7_4_nonexistent_dir_graceful_degradation() {
     let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
         None,
         "/tmp",
         "test-model",
@@ -195,7 +197,7 @@ fn tc_7_5_memory_md_content_injected() {
     )
     .unwrap();
 
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         result.contains("user_role.md"),
@@ -226,7 +228,7 @@ fn tc_7_6_no_memory_md_shows_empty() {
     fs::create_dir_all(&mem_dir).unwrap();
     // No MEMORY.md created
 
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         result.contains("currently empty"),
@@ -249,7 +251,7 @@ fn tc_7_7_no_bb_brand_in_integrated_prompt() {
     )
     .unwrap();
 
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     assert!(
         !result.contains("~/.claude"),

--- a/crates/aion-agent/tests/memory_context_integration.rs
+++ b/crates/aion-agent/tests/memory_context_integration.rs
@@ -34,26 +34,18 @@ fn tc_7_1_memory_dir_with_content_injects_prompt() {
         false,
     );
 
-    // Should contain memory system sections
+    // Should contain minimal memory system sections
     assert!(
         result.contains("auto memory"),
         "should contain memory system display name"
     );
     assert!(
-        result.contains("Types of memory"),
-        "should contain type definitions"
+        result.contains("Memory types:"),
+        "should contain compact type summary"
     );
     assert!(
-        result.contains("What NOT to save"),
-        "should contain what-not-to-save section"
-    );
-    assert!(
-        result.contains("How to save memories"),
-        "should contain save instructions"
-    );
-    assert!(
-        result.contains("When to access memories"),
-        "should contain access guidance"
+        result.contains("MEMORY.md is the index"),
+        "should contain compact save guidance"
     );
 
     // Should contain MEMORY.md content

--- a/crates/aion-agent/tests/memory_context_integration.rs
+++ b/crates/aion-agent/tests/memory_context_integration.rs
@@ -23,7 +23,16 @@ fn tc_7_1_memory_dir_with_content_injects_prompt() {
     )
     .unwrap();
 
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        Some(&mem_dir),
+        false,
+    );
 
     // Should contain memory system sections
     assert!(
@@ -64,7 +73,16 @@ fn tc_7_1_memory_dir_with_content_injects_prompt() {
 
 #[test]
 fn tc_7_2_no_memory_dir_no_injection() {
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        false,
+    );
 
     assert!(
         !result.contains("auto memory"),
@@ -197,7 +215,16 @@ fn tc_7_5_memory_md_content_injected() {
     )
     .unwrap();
 
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        Some(&mem_dir),
+        false,
+    );
 
     assert!(
         result.contains("user_role.md"),
@@ -228,7 +255,16 @@ fn tc_7_6_no_memory_md_shows_empty() {
     fs::create_dir_all(&mem_dir).unwrap();
     // No MEMORY.md created
 
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        Some(&mem_dir),
+        false,
+    );
 
     assert!(
         result.contains("currently empty"),
@@ -251,7 +287,16 @@ fn tc_7_7_no_bb_brand_in_integrated_prompt() {
     )
     .unwrap();
 
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        Some(&mem_dir),
+        false,
+    );
 
     assert!(
         !result.contains("~/.claude"),

--- a/crates/aion-agent/tests/plan_prompt_file_test.rs
+++ b/crates/aion-agent/tests/plan_prompt_file_test.rs
@@ -62,7 +62,16 @@ fn tc_3_4_01_instructions_forbid_writes() {
 
 #[test]
 fn tc_3_4_03_system_prompt_includes_plan_instructions_when_active() {
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, true);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        true,
+    );
 
     // Should contain plan mode instructions
     assert!(
@@ -85,7 +94,16 @@ fn tc_3_4_03_system_prompt_includes_plan_instructions_when_active() {
 
 #[test]
 fn tc_3_4_04_system_prompt_excludes_plan_instructions_when_inactive() {
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        false,
+    );
 
     // Should NOT contain plan mode instructions
     assert!(
@@ -197,7 +215,16 @@ fn plan_instructions_appear_after_memory_before_skills() {
     std::fs::create_dir_all(&mem_dir).unwrap();
     std::fs::write(mem_dir.join("MEMORY.md"), "- [A](a.md) \u{2014} test\n").unwrap();
 
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), true);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        Some(&mem_dir),
+        true,
+    );
 
     let memory_pos = result
         .find("auto memory")

--- a/crates/aion-agent/tests/plan_prompt_file_test.rs
+++ b/crates/aion-agent/tests/plan_prompt_file_test.rs
@@ -5,7 +5,7 @@
 use std::fs;
 use std::path::Path;
 
-use aion_agent::context::build_system_prompt;
+use aion_agent::context::{SystemPromptCache, build_system_prompt};
 use aion_agent::plan::file::{plan_file_path, read_plan, write_plan};
 use aion_agent::plan::prompt::plan_mode_instructions;
 
@@ -62,7 +62,7 @@ fn tc_3_4_01_instructions_forbid_writes() {
 
 #[test]
 fn tc_3_4_03_system_prompt_includes_plan_instructions_when_active() {
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, true);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, true);
 
     // Should contain plan mode instructions
     assert!(
@@ -85,7 +85,7 @@ fn tc_3_4_03_system_prompt_includes_plan_instructions_when_active() {
 
 #[test]
 fn tc_3_4_04_system_prompt_excludes_plan_instructions_when_inactive() {
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
 
     // Should NOT contain plan mode instructions
     assert!(
@@ -197,7 +197,7 @@ fn plan_instructions_appear_after_memory_before_skills() {
     std::fs::create_dir_all(&mem_dir).unwrap();
     std::fs::write(mem_dir.join("MEMORY.md"), "- [A](a.md) \u{2014} test\n").unwrap();
 
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), true);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), true);
 
     let memory_pos = result
         .find("auto memory")

--- a/crates/aion-agent/tests/skills_e2e.rs
+++ b/crates/aion-agent/tests/skills_e2e.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use aion_agent::context::build_system_prompt;
+use aion_agent::context::{SystemPromptCache, build_system_prompt};
 use aion_agent::skill_tool::SkillTool;
 use aion_agent::skills::loader::load_all_skills;
 use aion_agent::skills::permissions::SkillPermissionChecker;
@@ -219,7 +219,7 @@ async fn e7_system_prompt_injection() {
     let cwd = root.to_string_lossy().to_string();
     let skills = load_all_skills(&root, &[], false, None).await;
 
-    let prompt = build_system_prompt(None, &cwd, "test-model", &skills, None, None, false);
+    let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, &cwd, "test-model", &skills, None, None, false);
     assert!(
         prompt.contains("greet"),
         "E7 FAIL: 'greet' not in system prompt"

--- a/crates/aion-agent/tests/skills_e2e.rs
+++ b/crates/aion-agent/tests/skills_e2e.rs
@@ -219,7 +219,16 @@ async fn e7_system_prompt_injection() {
     let cwd = root.to_string_lossy().to_string();
     let skills = load_all_skills(&root, &[], false, None).await;
 
-    let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, &cwd, "test-model", &skills, None, None, false);
+    let prompt = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        &cwd,
+        "test-model",
+        &skills,
+        None,
+        None,
+        false,
+    );
     assert!(
         prompt.contains("greet"),
         "E7 FAIL: 'greet' not in system prompt"

--- a/crates/aion-agent/tests/tool_guidance_prompt_test.rs
+++ b/crates/aion-agent/tests/tool_guidance_prompt_test.rs
@@ -5,7 +5,7 @@
 
 use std::fs;
 
-use aion_agent::context::build_system_prompt;
+use aion_agent::context::{SystemPromptCache, build_system_prompt};
 use aion_skills::types::{ExecutionContext, LoadedFrom, SkillMetadata, SkillSource};
 
 fn make_skill(name: &str, description: &str) -> SkillMetadata {
@@ -42,7 +42,7 @@ fn make_skill(name: &str, description: &str) -> SkillMetadata {
 
 #[test]
 fn tc_4_3_01_tool_guidance_section_exists() {
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
     assert!(
         result.contains("# Using your tools"),
         "system prompt should contain the tool guidance section heading"
@@ -55,7 +55,7 @@ fn tc_4_3_01_tool_guidance_section_exists() {
 
 #[test]
 fn tc_4_3_02_bash_prohibition_list() {
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
 
     // Glob replaces find/ls
     assert!(
@@ -90,7 +90,7 @@ fn tc_4_3_02_bash_prohibition_list() {
 
 #[test]
 fn tc_4_3_03_parallel_call_guidance() {
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
     assert!(
         result.contains("parallel"),
         "should contain parallel call guidance"
@@ -107,7 +107,7 @@ fn tc_4_3_03_parallel_call_guidance() {
 
 #[test]
 fn tc_4_3_04_edit_write_read_rules() {
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
     assert!(
         result.contains("Prefer Edit over Write"),
         "should contain Edit-over-Write preference"
@@ -125,6 +125,7 @@ fn tc_4_3_04_edit_write_read_rules() {
 #[test]
 fn tc_4_3_05_order_after_intro_before_custom() {
     let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
         Some("CUSTOM_PROMPT_MARKER"),
         "/tmp",
         "test-model",
@@ -161,7 +162,7 @@ fn tc_4_3_05_order_after_intro_before_custom() {
 #[test]
 fn tc_4_3_06_order_before_skills() {
     let skills = vec![make_skill("order-test-skill", "Order test")];
-    let result = build_system_prompt(None, "/tmp", "test-model", &skills, None, None, false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
 
     let guidance_pos = result
         .find("# Using your tools")
@@ -187,7 +188,7 @@ fn tc_4_3_06_order_before_memory() {
     )
     .unwrap();
 
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
 
     let guidance_pos = result
         .find("# Using your tools")
@@ -226,6 +227,7 @@ fn tc_4_3_07_all_sections_coexist() {
     let skills = vec![make_skill("coexist-skill", "Coexist test")];
 
     let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
         Some("CUSTOM_COEXIST"),
         &cwd.to_string_lossy(),
         "test-model",
@@ -279,7 +281,7 @@ fn tc_4_3_07_all_sections_coexist() {
 
 #[test]
 fn tc_4_3_08_guidance_in_plan_mode() {
-    let result = build_system_prompt(None, "/tmp", "test-model", &[], None, None, true);
+    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, true);
     assert!(
         result.contains("# Using your tools"),
         "tool guidance should be present even in plan mode"

--- a/crates/aion-agent/tests/tool_guidance_prompt_test.rs
+++ b/crates/aion-agent/tests/tool_guidance_prompt_test.rs
@@ -42,7 +42,16 @@ fn make_skill(name: &str, description: &str) -> SkillMetadata {
 
 #[test]
 fn tc_4_3_01_tool_guidance_section_exists() {
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        false,
+    );
     assert!(
         result.contains("# Using your tools"),
         "system prompt should contain the tool guidance section heading"
@@ -55,7 +64,16 @@ fn tc_4_3_01_tool_guidance_section_exists() {
 
 #[test]
 fn tc_4_3_02_bash_prohibition_list() {
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        false,
+    );
 
     // Glob replaces find/ls
     assert!(
@@ -90,7 +108,16 @@ fn tc_4_3_02_bash_prohibition_list() {
 
 #[test]
 fn tc_4_3_03_parallel_call_guidance() {
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        false,
+    );
     assert!(
         result.contains("parallel"),
         "should contain parallel call guidance"
@@ -107,7 +134,16 @@ fn tc_4_3_03_parallel_call_guidance() {
 
 #[test]
 fn tc_4_3_04_edit_write_read_rules() {
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        false,
+    );
     assert!(
         result.contains("Prefer Edit over Write"),
         "should contain Edit-over-Write preference"
@@ -162,7 +198,16 @@ fn tc_4_3_05_order_after_intro_before_custom() {
 #[test]
 fn tc_4_3_06_order_before_skills() {
     let skills = vec![make_skill("order-test-skill", "Order test")];
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &skills, None, None, false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &skills,
+        None,
+        None,
+        false,
+    );
 
     let guidance_pos = result
         .find("# Using your tools")
@@ -188,7 +233,16 @@ fn tc_4_3_06_order_before_memory() {
     )
     .unwrap();
 
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, Some(&mem_dir), false);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        Some(&mem_dir),
+        false,
+    );
 
     let guidance_pos = result
         .find("# Using your tools")
@@ -281,7 +335,16 @@ fn tc_4_3_07_all_sections_coexist() {
 
 #[test]
 fn tc_4_3_08_guidance_in_plan_mode() {
-    let result = build_system_prompt(&mut SystemPromptCache::new(), None, "/tmp", "test-model", &[], None, None, true);
+    let result = build_system_prompt(
+        &mut SystemPromptCache::new(),
+        None,
+        "/tmp",
+        "test-model",
+        &[],
+        None,
+        None,
+        true,
+    );
     assert!(
         result.contains("# Using your tools"),
         "tool guidance should be present even in plan mode"

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -236,7 +236,7 @@ async fn main() -> anyhow::Result<()> {
         match McpManager::connect_all(&config.mcp.servers).await {
             Ok(mgr) => {
                 let mgr = Arc::new(mgr);
-                register_mcp_tools(&mut registry, &mgr, &builtin_names);
+                register_mcp_tools(&mut registry, &mgr, &builtin_names, &config.mcp.servers);
                 Some(mgr)
             }
             Err(e) => {

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -252,7 +252,9 @@ async fn main() -> anyhow::Result<()> {
     let skills = load_all_skills(cwd_path, &[], false, mcp_manager.as_deref()).await;
 
     // Build system prompt with loaded skills
+    let mut prompt_cache = aion_agent::context::SystemPromptCache::new();
     let system_prompt = context::build_system_prompt(
+        &mut prompt_cache,
         config.system_prompt.as_deref(),
         &cwd,
         &config.model,

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -31,6 +31,7 @@ use aion_tools::glob::GlobTool;
 use aion_tools::grep::GrepTool;
 use aion_tools::read::ReadTool;
 use aion_tools::registry::ToolRegistry;
+use aion_tools::tool_search::ToolSearchTool;
 use aion_tools::write::WriteTool;
 
 #[derive(Parser)]
@@ -292,6 +293,10 @@ async fn main() -> anyhow::Result<()> {
             &plan_active_flag,
         ))));
     }
+
+    // Register ToolSearch (must be after all other tools to capture full snapshot)
+    let tool_defs_snapshot = registry.to_tool_defs();
+    registry.register(Box::new(ToolSearchTool::new(tool_defs_snapshot)));
 
     if cli.json_stream {
         return run_json_stream_mode(

--- a/crates/aion-config/src/compact.rs
+++ b/crates/aion-config/src/compact.rs
@@ -47,6 +47,12 @@ pub struct CompactConfig {
     /// (emergency truncation still applies).
     #[serde(default = "default_true")]
     pub enabled: bool,
+
+    /// Enable prompt cache diagnostics output to user.
+    /// When true, cache hit/miss info is shown via OutputSink.
+    /// Default: false.
+    #[serde(default)]
+    pub cache_diagnostics: bool,
 }
 
 impl Default for CompactConfig {
@@ -61,6 +67,7 @@ impl Default for CompactConfig {
             micro_gap_seconds: default_micro_gap_seconds(),
             compactable_tools: default_compactable_tools(),
             enabled: default_true(),
+            cache_diagnostics: false,
         }
     }
 }
@@ -177,6 +184,21 @@ context_window = 128000
         assert_eq!(cfg.micro_keep_recent, default.micro_keep_recent);
         assert_eq!(cfg.micro_gap_seconds, default.micro_gap_seconds);
         assert_eq!(cfg.enabled, default.enabled);
+    }
+
+    #[test]
+    fn cache_diagnostics_defaults_to_false() {
+        let cfg = CompactConfig::default();
+        assert!(!cfg.cache_diagnostics);
+    }
+
+    #[test]
+    fn toml_cache_diagnostics_override() {
+        let toml_str = r#"
+cache_diagnostics = true
+"#;
+        let cfg: CompactConfig = toml::from_str(toml_str).unwrap();
+        assert!(cfg.cache_diagnostics);
     }
 
     #[test]

--- a/crates/aion-config/src/config.rs
+++ b/crates/aion-config/src/config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::auth::{AuthConfig, OAuthManager};
 use crate::compact::CompactConfig;
 use crate::compat::ProviderCompat;
+use crate::debug::DebugConfig;
 use crate::file_cache::FileCacheConfig;
 use crate::hooks::HooksConfig;
 use crate::plan::PlanConfig;
@@ -103,6 +104,9 @@ pub struct ConfigFile {
 
     #[serde(default)]
     pub mcp: McpConfig,
+
+    #[serde(default)]
+    pub debug: DebugConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -258,6 +262,7 @@ pub struct Config {
     pub bedrock: Option<BedrockConfig>,
     pub vertex: Option<VertexConfig>,
     pub mcp: McpConfig,
+    pub debug: DebugConfig,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -395,6 +400,7 @@ impl Config {
             bedrock: merged.bedrock,
             vertex: merged.vertex,
             mcp: merged.mcp,
+            debug: merged.debug,
         })
     }
 }
@@ -684,6 +690,8 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
         global.compact
     };
 
+    let debug = DebugConfig::merge(global.debug, project.debug);
+
     ConfigFile {
         default,
         providers,
@@ -698,6 +706,7 @@ fn merge_config_files(global: ConfigFile, project: ConfigFile) -> ConfigFile {
         vertex,
         auth,
         mcp,
+        debug,
     }
 }
 

--- a/crates/aion-config/src/config.rs
+++ b/crates/aion-config/src/config.rs
@@ -59,6 +59,10 @@ pub struct McpServerConfig {
     pub url: Option<String>,
     /// HTTP headers for SSE/HTTP transports
     pub headers: Option<HashMap<String, String>>,
+    /// Whether tools from this server should be deferred (name-only stub sent to LLM).
+    /// Defaults to true when omitted — MCP tools are deferred by default to reduce
+    /// input token usage. Set to `false` to send full schemas eagerly.
+    pub deferred: Option<bool>,
 }
 
 /// Collection of MCP server configurations

--- a/crates/aion-config/src/debug.rs
+++ b/crates/aion-config/src/debug.rs
@@ -64,7 +64,10 @@ dump_request_path = "/tmp/aion_request.json"
             dump_request_path: Some("/tmp/project.json".into()),
         };
         let merged = DebugConfig::merge(global, project);
-        assert_eq!(merged.dump_request_path.as_deref(), Some("/tmp/project.json"));
+        assert_eq!(
+            merged.dump_request_path.as_deref(),
+            Some("/tmp/project.json")
+        );
     }
 
     #[test]
@@ -74,6 +77,9 @@ dump_request_path = "/tmp/aion_request.json"
         };
         let project = DebugConfig::default();
         let merged = DebugConfig::merge(global, project);
-        assert_eq!(merged.dump_request_path.as_deref(), Some("/tmp/global.json"));
+        assert_eq!(
+            merged.dump_request_path.as_deref(),
+            Some("/tmp/global.json")
+        );
     }
 }

--- a/crates/aion-config/src/debug.rs
+++ b/crates/aion-config/src/debug.rs
@@ -1,0 +1,79 @@
+use serde::{Deserialize, Serialize};
+
+/// Configuration for debug / diagnostic output.
+///
+/// All fields are optional — when absent, the corresponding feature is off.
+/// New debug knobs should be added here rather than relying on env vars.
+///
+/// ```toml
+/// [debug]
+/// dump_request_path = "/tmp/aion_request.json"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DebugConfig {
+    /// When set, every outgoing LLM request body is written (pretty-printed
+    /// JSON) to this path.  Each request overwrites the previous one.
+    #[serde(default)]
+    pub dump_request_path: Option<String>,
+}
+
+impl DebugConfig {
+    /// Merge project-level overrides onto global defaults.
+    /// Each `Some` field in `project` wins; `None` falls back to `global`.
+    pub fn merge(global: Self, project: Self) -> Self {
+        Self {
+            dump_request_path: project.dump_request_path.or(global.dump_request_path),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_all_off() {
+        let cfg = DebugConfig::default();
+        assert!(cfg.dump_request_path.is_none());
+    }
+
+    #[test]
+    fn toml_with_dump_path() {
+        let toml_str = r#"
+dump_request_path = "/tmp/aion_request.json"
+"#;
+        let cfg: DebugConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            cfg.dump_request_path.as_deref(),
+            Some("/tmp/aion_request.json")
+        );
+    }
+
+    #[test]
+    fn toml_empty_uses_defaults() {
+        let cfg: DebugConfig = toml::from_str("").unwrap();
+        assert!(cfg.dump_request_path.is_none());
+    }
+
+    #[test]
+    fn merge_project_overrides_global() {
+        let global = DebugConfig {
+            dump_request_path: Some("/tmp/global.json".into()),
+        };
+        let project = DebugConfig {
+            dump_request_path: Some("/tmp/project.json".into()),
+        };
+        let merged = DebugConfig::merge(global, project);
+        assert_eq!(merged.dump_request_path.as_deref(), Some("/tmp/project.json"));
+    }
+
+    #[test]
+    fn merge_falls_back_to_global() {
+        let global = DebugConfig {
+            dump_request_path: Some("/tmp/global.json".into()),
+        };
+        let project = DebugConfig::default();
+        let merged = DebugConfig::merge(global, project);
+        assert_eq!(merged.dump_request_path.as_deref(), Some("/tmp/global.json"));
+    }
+}

--- a/crates/aion-config/src/lib.rs
+++ b/crates/aion-config/src/lib.rs
@@ -4,6 +4,7 @@ pub mod auth;
 pub mod compact;
 pub mod compat;
 pub mod config;
+pub mod debug;
 pub mod file_cache;
 pub mod hooks;
 pub mod plan;

--- a/crates/aion-mcp/src/tool_proxy.rs
+++ b/crates/aion-mcp/src/tool_proxy.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::Value;
 
+use super::config::McpServerConfig;
 use super::manager::McpManager;
 use aion_protocol::events::ToolCategory;
 use aion_tools::Tool;
@@ -21,6 +23,8 @@ pub struct McpToolProxy {
     description: String,
     input_schema: JsonSchema,
     manager: Arc<McpManager>,
+    /// Whether this tool's schema should be deferred (sent as name-only stub).
+    deferred: bool,
 }
 
 impl McpToolProxy {
@@ -31,6 +35,7 @@ impl McpToolProxy {
         description: String,
         input_schema: JsonSchema,
         manager: Arc<McpManager>,
+        deferred: bool,
     ) -> Self {
         Self {
             display_name,
@@ -39,6 +44,7 @@ impl McpToolProxy {
             description,
             input_schema,
             manager,
+            deferred,
         }
     }
 }
@@ -60,6 +66,10 @@ impl Tool for McpToolProxy {
     fn is_concurrency_safe(&self, _input: &Value) -> bool {
         // MCP tools are assumed not concurrency-safe
         false
+    }
+
+    fn is_deferred(&self) -> bool {
+        self.deferred
     }
 
     async fn execute(&self, input: Value) -> ToolResult {
@@ -98,10 +108,14 @@ impl Tool for McpToolProxy {
 /// Strategy:
 /// - If tool name doesn't collide with built-in or other MCP tools → use as-is
 /// - If collision detected → prefix with "mcp__{server_name}__"
+///
+/// Each tool's deferred flag is read from the server's config:
+/// `McpServerConfig::deferred` — defaults to `true` when absent.
 pub fn register_mcp_tools(
     registry: &mut aion_tools::registry::ToolRegistry,
     manager: &Arc<McpManager>,
     builtin_names: &[String],
+    server_configs: &HashMap<String, McpServerConfig>,
 ) {
     let all_tools = manager.all_tools();
 
@@ -121,6 +135,12 @@ pub fn register_mcp_tools(
             original_name.clone()
         };
 
+        // MCP tools are deferred by default; server config can override.
+        let deferred = server_configs
+            .get(*server_name)
+            .and_then(|c| c.deferred)
+            .unwrap_or(true);
+
         let proxy = McpToolProxy::new(
             display_name,
             original_name.clone(),
@@ -128,8 +148,94 @@ pub fn register_mcp_tools(
             tool_def.description.clone().unwrap_or_default(),
             tool_def.input_schema.clone(),
             Arc::clone(manager),
+            deferred,
         );
 
         registry.register(Box::new(proxy));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aion_config::config::TransportType;
+    use serde_json::json;
+
+    fn make_proxy(deferred: bool) -> McpToolProxy {
+        // manager is only used during execute(), which we don't call in these
+        // tests, so we can construct one with no servers.
+        let manager = Arc::new(McpManager::new_for_test(vec![]));
+        McpToolProxy::new(
+            "test_tool".into(),
+            "test_tool".into(),
+            "test_server".into(),
+            "A test tool".into(),
+            json!({"type": "object"}),
+            manager,
+            deferred,
+        )
+    }
+
+    #[test]
+    fn proxy_deferred_true_returns_true() {
+        let proxy = make_proxy(true);
+        assert!(proxy.is_deferred());
+    }
+
+    #[test]
+    fn proxy_deferred_false_returns_false() {
+        let proxy = make_proxy(false);
+        assert!(!proxy.is_deferred());
+    }
+
+    fn make_server_config(deferred: Option<bool>) -> McpServerConfig {
+        McpServerConfig {
+            transport: TransportType::Stdio,
+            command: Some("echo".into()),
+            args: None,
+            env: None,
+            url: None,
+            headers: None,
+            deferred,
+        }
+    }
+
+    #[test]
+    fn register_defaults_to_deferred_when_config_omits_field() {
+        let manager = Arc::new(McpManager::new_for_test(vec![]));
+        let mut registry = aion_tools::registry::ToolRegistry::new();
+        // Empty server configs — deferred field absent
+        let configs = HashMap::new();
+
+        register_mcp_tools(&mut registry, &manager, &[], &configs);
+
+        // No tools registered because manager has no tools, but the logic
+        // is tested via the deferred default path. Test with a real config below.
+        assert!(registry.tool_names().is_empty());
+    }
+
+    #[test]
+    fn server_config_deferred_none_defaults_true() {
+        let config = make_server_config(None);
+        let deferred = config.deferred.unwrap_or(true);
+        assert!(deferred, "deferred should default to true when None");
+    }
+
+    #[test]
+    fn server_config_deferred_explicit_false() {
+        let config = make_server_config(Some(false));
+        let deferred = config.deferred.unwrap_or(true);
+        assert!(!deferred, "deferred should be false when explicitly set");
+    }
+
+    #[test]
+    fn server_config_deferred_explicit_true() {
+        let config = make_server_config(Some(true));
+        let deferred = config.deferred.unwrap_or(true);
+        assert!(deferred, "deferred should be true when explicitly set");
     }
 }

--- a/crates/aion-memory/src/prompt.rs
+++ b/crates/aion-memory/src/prompt.rs
@@ -625,11 +625,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let mem_dir = tmp.path().join("memory");
         std::fs::create_dir_all(&mem_dir).unwrap();
-        std::fs::write(
-            mem_dir.join(ENTRYPOINT_NAME),
-            "- [A](a.md) \u{2014} test\n",
-        )
-        .unwrap();
+        std::fs::write(mem_dir.join(ENTRYPOINT_NAME), "- [A](a.md) \u{2014} test\n").unwrap();
 
         let full = build_memory_prompt(&mem_dir);
         let minimal = build_memory_prompt_minimal(&mem_dir);

--- a/crates/aion-memory/src/prompt.rs
+++ b/crates/aion-memory/src/prompt.rs
@@ -190,9 +190,73 @@ Memory is one of several persistence mechanisms available to you as you assist t
 - When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.
 - When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.";
 
+// ---------------------------------------------------------------------------
+// Minimal memory prompt (lazy — saves ~2,500 tokens)
+// ---------------------------------------------------------------------------
+
+/// Compact summary of the memory system rules, without the full type taxonomy,
+/// examples, or detailed save/access instructions. Enough for the LLM to
+/// read existing memories and know the system exists; the full instructions
+/// are injected on-demand when the LLM first writes to the memory directory.
+const MINIMAL_RULES: &str = "\
+You should build up this memory system over time so that future conversations \
+can have a complete picture of who the user is, how they'd like to collaborate \
+with you, what behaviors to avoid or repeat, and the context behind the work \
+the user gives you.
+
+If the user explicitly asks you to remember something, save it immediately. \
+If they ask you to forget something, find and remove the relevant entry.
+
+Memory types: user, feedback, project, reference. Each memory is a Markdown file \
+with YAML frontmatter (name, description, type). MEMORY.md is the index — one \
+line per entry, never write content directly into it.
+
+Before saving, read existing memories to avoid duplicates. \
+Verify file/function names from memory still exist before recommending them.";
+
 // ===========================================================================
 // Public API
 // ===========================================================================
+
+/// Build a minimal memory prompt with just the path, compact rules,
+/// and MEMORY.md index content. Omits the full type taxonomy and examples
+/// to save ~2,500 tokens on the first turn.
+pub fn build_memory_prompt_minimal(memory_dir: &Path) -> String {
+    let dir_display = memory_dir.display();
+
+    let mut parts = vec![
+        format!("# {DISPLAY_NAME}"),
+        String::new(),
+        format!(
+            "You have a persistent, file-based memory system at `{dir_display}`. \
+             {DIR_EXISTS_GUIDANCE}"
+        ),
+        String::new(),
+        MINIMAL_RULES.to_owned(),
+        String::new(),
+    ];
+
+    // Append MEMORY.md index (same logic as the full version)
+    let entrypoint = memory_dir.join(ENTRYPOINT_NAME);
+    let raw = read_index(&entrypoint);
+    let trimmed = raw.trim();
+
+    if trimmed.is_empty() {
+        parts.push(format!("## {ENTRYPOINT_NAME}"));
+        parts.push(String::new());
+        parts.push(format!(
+            "Your {ENTRYPOINT_NAME} is currently empty. \
+             When you save new memories, they will appear here."
+        ));
+    } else {
+        let truncation = truncate_index(&raw);
+        parts.push(format!("## {ENTRYPOINT_NAME}"));
+        parts.push(String::new());
+        parts.push(truncation.content);
+    }
+
+    parts.join("\n")
+}
 
 /// Build the complete memory system prompt including behavioral instructions
 /// AND the current MEMORY.md content (or an empty-state message).
@@ -483,6 +547,120 @@ mod tests {
 
         let result = build_memory_prompt(&mem_dir);
         assert!(result.contains("WARNING"));
+    }
+
+    // -- build_memory_prompt_minimal -------------------------------------------
+
+    #[test]
+    fn minimal_prompt_contains_display_name() {
+        let result = build_memory_prompt_minimal(Path::new("/test/memory"));
+        assert!(result.contains(DISPLAY_NAME));
+    }
+
+    #[test]
+    fn minimal_prompt_contains_dir_path() {
+        let result = build_memory_prompt_minimal(Path::new("/custom/path/memory"));
+        assert!(result.contains("/custom/path/memory"));
+    }
+
+    #[test]
+    fn minimal_prompt_contains_compact_rules() {
+        let result = build_memory_prompt_minimal(Path::new("/test/memory"));
+        assert!(
+            result.contains("Memory types:"),
+            "should list memory types compactly"
+        );
+        assert!(
+            result.contains("MEMORY.md is the index"),
+            "should mention MEMORY.md role"
+        );
+    }
+
+    #[test]
+    fn minimal_prompt_omits_full_type_taxonomy() {
+        let result = build_memory_prompt_minimal(Path::new("/test/memory"));
+        assert!(
+            !result.contains("## Types of memory"),
+            "minimal prompt should NOT contain full type taxonomy heading"
+        );
+        assert!(
+            !result.contains("<types>"),
+            "minimal prompt should NOT contain XML type definitions"
+        );
+        assert!(
+            !result.contains("## What NOT to save"),
+            "minimal prompt should NOT contain what-not-to-save section"
+        );
+        assert!(
+            !result.contains("## How to save memories"),
+            "minimal prompt should NOT contain detailed save instructions"
+        );
+    }
+
+    #[test]
+    fn minimal_prompt_nonexistent_dir_shows_empty_state() {
+        let result = build_memory_prompt_minimal(Path::new("/nonexistent/memory/dir"));
+        assert!(result.contains("currently empty"));
+    }
+
+    #[test]
+    fn minimal_prompt_with_existing_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mem_dir = tmp.path().join("memory");
+        std::fs::create_dir_all(&mem_dir).unwrap();
+        std::fs::write(
+            mem_dir.join(ENTRYPOINT_NAME),
+            "- [Role](user_role.md) \u{2014} senior engineer\n",
+        )
+        .unwrap();
+
+        let result = build_memory_prompt_minimal(&mem_dir);
+        assert!(result.contains("user_role.md"));
+        assert!(result.contains("senior engineer"));
+        assert!(!result.contains("currently empty"));
+    }
+
+    #[test]
+    fn minimal_prompt_much_shorter_than_full() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mem_dir = tmp.path().join("memory");
+        std::fs::create_dir_all(&mem_dir).unwrap();
+        std::fs::write(
+            mem_dir.join(ENTRYPOINT_NAME),
+            "- [A](a.md) \u{2014} test\n",
+        )
+        .unwrap();
+
+        let full = build_memory_prompt(&mem_dir);
+        let minimal = build_memory_prompt_minimal(&mem_dir);
+
+        assert!(
+            minimal.len() < full.len() / 2,
+            "minimal ({} chars) should be less than half of full ({} chars)",
+            minimal.len(),
+            full.len()
+        );
+    }
+
+    #[test]
+    fn full_prompt_contains_full_taxonomy() {
+        let result = build_memory_prompt(Path::new("/test/memory"));
+        assert!(
+            result.contains("## Types of memory"),
+            "full prompt should contain type taxonomy"
+        );
+        assert!(
+            result.contains("<types>"),
+            "full prompt should contain XML type definitions"
+        );
+        assert!(
+            result.contains("## What NOT to save"),
+            "full prompt should contain what-not-to-save"
+        );
+        assert!(
+            result.contains("## How to save memories"),
+            "full prompt should contain save instructions"
+        );
     }
 
     // -- no hardcoded platform paths -----------------------------------------

--- a/crates/aion-providers/src/anthropic.rs
+++ b/crates/aion-providers/src/anthropic.rs
@@ -6,8 +6,9 @@ use tokio::sync::mpsc;
 use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 
 use super::anthropic_shared;
-use crate::{LlmProvider, ProviderError};
+use crate::{LlmProvider, ProviderError, dump_request_body};
 use aion_config::compat::ProviderCompat;
+use aion_config::debug::DebugConfig;
 
 pub struct AnthropicProvider {
     client: reqwest::Client,
@@ -15,16 +16,18 @@ pub struct AnthropicProvider {
     base_url: String,
     cache_enabled: bool,
     compat: ProviderCompat,
+    debug: DebugConfig,
 }
 
 impl AnthropicProvider {
-    pub fn new(api_key: &str, base_url: &str, compat: ProviderCompat) -> Self {
+    pub fn new(api_key: &str, base_url: &str, compat: ProviderCompat, debug: DebugConfig) -> Self {
         Self {
             client: reqwest::Client::new(),
             api_key: api_key.to_string(),
             base_url: base_url.to_string(),
             cache_enabled: true,
             compat,
+            debug,
         }
     }
 
@@ -97,6 +100,8 @@ impl LlmProvider for AnthropicProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = format!("{}/v1/messages", self.base_url);
         let body = self.build_request_body(request);
+
+        dump_request_body(&self.debug, &body);
 
         let response = self
             .client

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 
 use aion_types::llm::LlmEvent;
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
-use aion_types::tool::ToolDef;
+use aion_types::tool::{ToolDef, truncate_deferred_description};
 
 use super::ProviderError;
 use aion_config::compat::ProviderCompat;
@@ -160,11 +160,11 @@ pub fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
         .iter()
         .map(|t| {
             if t.deferred {
+                let short_desc = truncate_deferred_description(&t.description);
                 json!({
                     "name": t.name,
                     "description": format!(
-                        "(Deferred) {} — Use ToolSearch to load full schema before calling.",
-                        t.description
+                        "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
                     ),
                     "input_schema": {
                         "type": "object",

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -622,10 +622,19 @@ mod tests {
         let result = build_tools(&tools);
 
         // Core tool has full input_schema
-        assert!(result[0]["input_schema"]["properties"].get("path").is_some());
+        assert!(
+            result[0]["input_schema"]["properties"]
+                .get("path")
+                .is_some()
+        );
 
         // Deferred tool has empty input_schema and modified description
-        assert!(result[1]["input_schema"]["properties"].as_object().unwrap().is_empty());
+        assert!(
+            result[1]["input_schema"]["properties"]
+                .as_object()
+                .unwrap()
+                .is_empty()
+        );
         let desc = result[1]["description"].as_str().unwrap();
         assert!(desc.contains("ToolSearch"));
     }

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -152,16 +152,32 @@ fn generate_tool_id() -> String {
     format!("toolu_{:x}_{:08x}", ts, rand)
 }
 
-/// Convert internal ToolDef format to Anthropic API tool format
+/// Convert internal ToolDef format to Anthropic API tool format.
+/// Deferred tools emit a minimal schema to reduce input token usage;
+/// the caller must invoke ToolSearch to retrieve the full schema.
 pub fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
     tools
         .iter()
         .map(|t| {
-            json!({
-                "name": t.name,
-                "description": t.description,
-                "input_schema": t.input_schema
-            })
+            if t.deferred {
+                json!({
+                    "name": t.name,
+                    "description": format!(
+                        "(Deferred) {} — Use ToolSearch to load full schema before calling.",
+                        t.description
+                    ),
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                })
+            } else {
+                json!({
+                    "name": t.name,
+                    "description": t.description,
+                    "input_schema": t.input_schema
+                })
+            }
         })
         .collect()
 }
@@ -585,6 +601,33 @@ mod tests {
         let result = build_tools(&tools);
         // assert
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_build_tools_deferred_has_empty_schema() {
+        let tools = vec![
+            ToolDef {
+                name: "Read".into(),
+                description: "Read a file".into(),
+                input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+                deferred: false,
+            },
+            ToolDef {
+                name: "SpawnTool".into(),
+                description: "Spawn sub-agents".into(),
+                input_schema: json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
+                deferred: true,
+            },
+        ];
+        let result = build_tools(&tools);
+
+        // Core tool has full input_schema
+        assert!(result[0]["input_schema"]["properties"].get("path").is_some());
+
+        // Deferred tool has empty input_schema and modified description
+        assert!(result[1]["input_schema"]["properties"].as_object().unwrap().is_empty());
+        let desc = result[1]["description"].as_str().unwrap();
+        assert!(desc.contains("ToolSearch"));
     }
 
     // --- parse_sse_data tests ---

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -566,6 +566,7 @@ mod tests {
             name: "bash".to_string(),
             description: "Run a shell command".to_string(),
             input_schema: schema.clone(),
+            deferred: false,
         }];
         // act
         let result = build_tools(&tools);

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -18,8 +18,9 @@ use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 use aion_types::message::{StopReason, TokenUsage};
 
 use super::anthropic_shared;
-use crate::{LlmProvider, ProviderError};
+use crate::{LlmProvider, ProviderError, dump_request_body};
 use aion_config::compat::{self, ProviderCompat};
+use aion_config::debug::DebugConfig;
 
 pub struct BedrockProvider {
     client: reqwest::Client,
@@ -27,6 +28,7 @@ pub struct BedrockProvider {
     credentials: AwsCredentials,
     cache_enabled: bool,
     compat: ProviderCompat,
+    debug: DebugConfig,
 }
 
 #[derive(Debug, Clone)]
@@ -46,6 +48,7 @@ impl BedrockProvider {
         credentials: AwsCredentials,
         cache_enabled: bool,
         compat: ProviderCompat,
+        debug: DebugConfig,
     ) -> Self {
         Self {
             client: reqwest::Client::new(),
@@ -53,6 +56,7 @@ impl BedrockProvider {
             credentials,
             cache_enabled,
             compat,
+            debug,
         }
     }
 
@@ -247,6 +251,9 @@ impl LlmProvider for BedrockProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = self.build_url(&request.model);
         let body = self.build_request_body(request);
+
+        dump_request_body(&self.debug, &body);
+
         let body_bytes = serde_json::to_vec(&body)
             .map_err(|e| ProviderError::Connection(format!("JSON serialize error: {}", e)))?;
 

--- a/crates/aion-providers/src/lib.rs
+++ b/crates/aion-providers/src/lib.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 use aion_config::config::{Config, ProviderType};
+use aion_config::debug::DebugConfig;
 use aion_types::llm::{LlmEvent, LlmRequest};
 
 /// Unified interface for LLM API providers
@@ -45,19 +46,32 @@ impl ProviderError {
     }
 }
 
+/// Write the request body to the configured dump path (if set).
+///
+/// This is a shared helper called by each provider's `stream()` method.
+/// Errors are silently ignored — debug output must never break requests.
+pub fn dump_request_body(debug: &DebugConfig, body: &serde_json::Value) {
+    if let Some(path) = &debug.dump_request_path {
+        let pretty = serde_json::to_string_pretty(body).unwrap_or_default();
+        let _ = std::fs::write(path, &pretty);
+    }
+}
+
 /// Create a provider from resolved config
 pub fn create_provider(config: &Config) -> Arc<dyn LlmProvider> {
     let compat = config.compat.clone();
+    let debug = config.debug.clone();
 
     match config.provider {
         ProviderType::Anthropic => Arc::new(
-            anthropic::AnthropicProvider::new(&config.api_key, &config.base_url, compat)
+            anthropic::AnthropicProvider::new(&config.api_key, &config.base_url, compat, debug)
                 .with_cache(config.prompt_caching),
         ),
         ProviderType::OpenAI => Arc::new(openai::OpenAIProvider::new(
             &config.api_key,
             &config.base_url,
             compat,
+            debug,
         )),
         ProviderType::Bedrock => {
             let bc = config.bedrock.clone().unwrap_or_default();
@@ -73,6 +87,7 @@ pub fn create_provider(config: &Config) -> Arc<dyn LlmProvider> {
                 credentials,
                 config.prompt_caching,
                 compat,
+                debug,
             ))
         }
         ProviderType::Vertex => {
@@ -89,6 +104,7 @@ pub fn create_provider(config: &Config) -> Arc<dyn LlmProvider> {
                 auth,
                 config.prompt_caching,
                 compat,
+                debug,
             ))
         }
     }

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -206,14 +206,31 @@ impl OpenAIProvider {
         tools
             .iter()
             .map(|t| {
-                json!({
-                    "type": "function",
-                    "function": {
-                        "name": t.name,
-                        "description": t.description,
-                        "parameters": t.input_schema
-                    }
-                })
+                if t.deferred {
+                    json!({
+                        "type": "function",
+                        "function": {
+                            "name": t.name,
+                            "description": format!(
+                                "(Deferred) {} — Use ToolSearch to load full schema before calling.",
+                                t.description
+                            ),
+                            "parameters": {
+                                "type": "object",
+                                "properties": {}
+                            }
+                        }
+                    })
+                } else {
+                    json!({
+                        "type": "function",
+                        "function": {
+                            "name": t.name,
+                            "description": t.description,
+                            "parameters": t.input_schema
+                        }
+                    })
+                }
             })
             .collect()
     }
@@ -871,5 +888,34 @@ mod tests {
             }
             other => panic!("expected Done, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_build_tools_deferred_has_empty_parameters() {
+        let tools = vec![
+            ToolDef {
+                name: "Read".into(),
+                description: "Read a file".into(),
+                input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+                deferred: false,
+            },
+            ToolDef {
+                name: "SpawnTool".into(),
+                description: "Spawn sub-agents".into(),
+                input_schema: json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
+                deferred: true,
+            },
+        ];
+        let result = OpenAIProvider::build_tools(&tools);
+
+        // Core tool has full parameters
+        let read_params = &result[0]["function"]["parameters"];
+        assert!(read_params["properties"].get("path").is_some());
+
+        // Deferred tool has empty parameters and modified description
+        let spawn_params = &result[1]["function"]["parameters"];
+        assert!(spawn_params["properties"].as_object().unwrap().is_empty());
+        let spawn_desc = result[1]["function"]["description"].as_str().unwrap();
+        assert!(spawn_desc.contains("ToolSearch"));
     }
 }

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 
 use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
-use aion_types::tool::ToolDef;
+use aion_types::tool::{ToolDef, truncate_deferred_description};
 
 use crate::{LlmProvider, ProviderError, dump_request_body};
 use aion_config::compat::ProviderCompat;
@@ -210,13 +210,13 @@ impl OpenAIProvider {
             .iter()
             .map(|t| {
                 if t.deferred {
+                    let short_desc = truncate_deferred_description(&t.description);
                     json!({
                         "type": "function",
                         "function": {
                             "name": t.name,
                             "description": format!(
-                                "(Deferred) {} — Use ToolSearch to load full schema before calling.",
-                                t.description
+                                "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
                             ),
                             "parameters": {
                                 "type": "object",

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -7,23 +7,26 @@ use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 use aion_types::tool::ToolDef;
 
-use crate::{LlmProvider, ProviderError};
+use crate::{LlmProvider, ProviderError, dump_request_body};
 use aion_config::compat::ProviderCompat;
+use aion_config::debug::DebugConfig;
 
 pub struct OpenAIProvider {
     client: reqwest::Client,
     api_key: String,
     base_url: String,
     compat: ProviderCompat,
+    debug: DebugConfig,
 }
 
 impl OpenAIProvider {
-    pub fn new(api_key: &str, base_url: &str, compat: ProviderCompat) -> Self {
+    pub fn new(api_key: &str, base_url: &str, compat: ProviderCompat, debug: DebugConfig) -> Self {
         Self {
             client: reqwest::Client::new(),
             api_key: api_key.to_string(),
             base_url: base_url.to_string(),
             compat,
+            debug,
         }
     }
 
@@ -450,6 +453,8 @@ impl LlmProvider for OpenAIProvider {
         let url = format!("{}{}", self.base_url, self.compat.api_path());
         let body = self.build_request_body(request);
 
+        dump_request_body(&self.debug, &body);
+
         let response = self
             .client
             .post(&url)
@@ -629,6 +634,7 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aion_config::debug::DebugConfig;
 
     fn no_compat() -> ProviderCompat {
         ProviderCompat::default()
@@ -642,7 +648,12 @@ mod tests {
 
     #[test]
     fn test_max_tokens_field_default() {
-        let provider = OpenAIProvider::new("key", "http://localhost", openai_compat());
+        let provider = OpenAIProvider::new(
+            "key",
+            "http://localhost",
+            openai_compat(),
+            DebugConfig::default(),
+        );
         let req = LlmRequest {
             model: "gpt-4o".into(),
             system: String::new(),
@@ -663,7 +674,8 @@ mod tests {
             max_tokens_field: Some("max_completion_tokens".into()),
             ..Default::default()
         };
-        let provider = OpenAIProvider::new("key", "http://localhost", compat);
+        let provider =
+            OpenAIProvider::new("key", "http://localhost", compat, DebugConfig::default());
         let req = LlmRequest {
             model: "gpt-4o".into(),
             system: String::new(),

--- a/crates/aion-providers/src/vertex.rs
+++ b/crates/aion-providers/src/vertex.rs
@@ -13,8 +13,9 @@ use tokio::sync::mpsc;
 use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 
 use super::anthropic_shared;
-use crate::{LlmProvider, ProviderError};
+use crate::{LlmProvider, ProviderError, dump_request_body};
 use aion_config::compat::ProviderCompat;
+use aion_config::debug::DebugConfig;
 
 pub struct VertexProvider {
     client: reqwest::Client,
@@ -23,6 +24,7 @@ pub struct VertexProvider {
     auth: GcpAuth,
     cache_enabled: bool,
     compat: ProviderCompat,
+    debug: DebugConfig,
     /// Cached access token
     cached_token: Mutex<Option<CachedToken>>,
 }
@@ -46,6 +48,7 @@ impl VertexProvider {
         auth: GcpAuth,
         cache_enabled: bool,
         compat: ProviderCompat,
+        debug: DebugConfig,
     ) -> Self {
         Self {
             client: reqwest::Client::new(),
@@ -54,6 +57,7 @@ impl VertexProvider {
             auth,
             cache_enabled,
             compat,
+            debug,
             cached_token: Mutex::new(None),
         }
     }
@@ -258,6 +262,9 @@ impl LlmProvider for VertexProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = self.build_url(&request.model);
         let body = self.build_request_body(request);
+
+        dump_request_body(&self.debug, &body);
+
         let access_token = self.get_access_token().await?;
 
         let mut headers = HeaderMap::new();

--- a/crates/aion-providers/tests/provider_anthropic_test.rs
+++ b/crates/aion-providers/tests/provider_anthropic_test.rs
@@ -4,6 +4,7 @@ use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use aion_config::compat::ProviderCompat;
+use aion_config::debug::DebugConfig;
 use aion_providers::anthropic::AnthropicProvider;
 use aion_providers::{LlmProvider, ProviderError};
 use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
@@ -80,6 +81,7 @@ async fn test_anthropic_stream_text_response() {
         "test-api-key",
         &server.uri(),
         ProviderCompat::anthropic_defaults(),
+        DebugConfig::default(),
     )
     .with_cache(false);
     let request = minimal_request();
@@ -155,6 +157,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         "test-api-key",
         &server.uri(),
         ProviderCompat::anthropic_defaults(),
+        DebugConfig::default(),
     )
     .with_cache(false);
     let request = minimal_request();
@@ -241,6 +244,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         "test-api-key",
         &server.uri(),
         ProviderCompat::anthropic_defaults(),
+        DebugConfig::default(),
     )
     .with_cache(false);
 
@@ -299,6 +303,7 @@ async fn test_anthropic_auth_error() {
         "bad-api-key",
         &server.uri(),
         ProviderCompat::anthropic_defaults(),
+        DebugConfig::default(),
     )
     .with_cache(false);
     let request = minimal_request();
@@ -341,6 +346,7 @@ async fn test_anthropic_rate_limit_retryable() {
         "test-api-key",
         &server.uri(),
         ProviderCompat::anthropic_defaults(),
+        DebugConfig::default(),
     )
     .with_cache(false);
     let request = minimal_request();
@@ -386,6 +392,7 @@ async fn test_anthropic_request_headers() {
         "my-secret-key",
         &server.uri(),
         ProviderCompat::anthropic_defaults(),
+        DebugConfig::default(),
     )
     .with_cache(false);
     let request = minimal_request();
@@ -429,6 +436,7 @@ async fn test_anthropic_prompt_caching_header() {
         "test-api-key",
         &server.uri(),
         ProviderCompat::anthropic_defaults(),
+        DebugConfig::default(),
     )
     .with_cache(true);
     let request = minimal_request();
@@ -468,6 +476,7 @@ async fn test_anthropic_no_prompt_caching_header_when_disabled() {
         "test-api-key",
         &server.uri(),
         ProviderCompat::anthropic_defaults(),
+        DebugConfig::default(),
     )
     .with_cache(false);
     let request = minimal_request();

--- a/crates/aion-providers/tests/provider_openai_test.rs
+++ b/crates/aion-providers/tests/provider_openai_test.rs
@@ -1,4 +1,5 @@
 use aion_config::compat::ProviderCompat;
+use aion_config::debug::DebugConfig;
 use aion_providers::LlmProvider;
 use aion_providers::openai::OpenAIProvider;
 use aion_types::llm::{LlmEvent, LlmRequest};
@@ -111,8 +112,12 @@ async fn test_openai_stream_text_response() {
         .mount(&server)
         .await;
 
-    let provider =
-        OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new(
+        "test-key",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -215,8 +220,12 @@ async fn test_openai_stream_tool_call_aggregation() {
         .mount(&server)
         .await;
 
-    let provider =
-        OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new(
+        "test-key",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -320,8 +329,12 @@ async fn test_openai_multiple_tool_calls() {
         .mount(&server)
         .await;
 
-    let provider =
-        OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new(
+        "test-key",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -411,8 +424,12 @@ async fn test_openai_stream_state_transitions() {
         .mount(&server)
         .await;
 
-    let provider =
-        OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new(
+        "test-key",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -453,7 +470,12 @@ async fn test_openai_api_error_non_success_status() {
         .mount(&server)
         .await;
 
-    let provider = OpenAIProvider::new("bad-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new(
+        "bad-key",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
     let result = provider.stream(&make_request()).await;
 
     assert!(result.is_err());
@@ -480,8 +502,12 @@ async fn test_openai_rate_limited() {
         .mount(&server)
         .await;
 
-    let provider =
-        OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new(
+        "test-key",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
     let result = provider.stream(&make_request()).await;
 
     assert!(result.is_err());
@@ -536,8 +562,12 @@ async fn test_openai_stream_max_tokens_stop_reason() {
         .mount(&server)
         .await;
 
-    let provider =
-        OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new(
+        "test-key",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -606,8 +636,12 @@ async fn test_openai_stream_empty_content_delta_skipped() {
         .mount(&server)
         .await;
 
-    let provider =
-        OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new(
+        "test-key",
+        &server.uri(),
+        ProviderCompat::openai_defaults(),
+        DebugConfig::default(),
+    );
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 

--- a/crates/aion-tools/src/lib.rs
+++ b/crates/aion-tools/src/lib.rs
@@ -56,6 +56,12 @@ pub trait Tool: Send + Sync {
     /// Tool category for protocol classification
     fn category(&self) -> ToolCategory;
 
+    /// Whether this tool's schema should be deferred (sent as name-only stub).
+    /// Override to `true` for tools with large schemas or infrequent use.
+    fn is_deferred(&self) -> bool {
+        false
+    }
+
     /// Human-readable description of what the tool will do with the given input
     fn describe(&self, input: &Value) -> String {
         format!(

--- a/crates/aion-tools/src/lib.rs
+++ b/crates/aion-tools/src/lib.rs
@@ -5,6 +5,7 @@ pub mod glob;
 pub mod grep;
 pub mod read;
 pub mod registry;
+pub mod tool_search;
 pub mod write;
 
 use async_trait::async_trait;

--- a/crates/aion-tools/src/registry.rs
+++ b/crates/aion-tools/src/registry.rs
@@ -41,7 +41,7 @@ impl ToolRegistry {
                 name: t.name().to_string(),
                 description: t.description().to_string(),
                 input_schema: t.input_schema(),
-                deferred: false,
+                deferred: t.is_deferred(),
             })
             .collect()
     }
@@ -60,7 +60,7 @@ impl ToolRegistry {
                 name: t.name().to_string(),
                 description: t.description().to_string(),
                 input_schema: t.input_schema(),
-                deferred: false,
+                deferred: t.is_deferred(),
             })
             .collect()
     }
@@ -278,5 +278,64 @@ mod tests {
         let registry = ToolRegistry::new();
         let defs = registry.to_tool_defs_filtered(|_| true);
         assert!(defs.is_empty());
+    }
+
+    // --- deferred flag tests ---
+
+    /// A minimal Tool that overrides is_deferred() to return true
+    struct DeferredMockTool {
+        tool_name: String,
+    }
+
+    #[async_trait]
+    impl Tool for DeferredMockTool {
+        fn name(&self) -> &str {
+            &self.tool_name
+        }
+
+        fn description(&self) -> &str {
+            "a deferred tool"
+        }
+
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {"x": {"type": "string"}}})
+        }
+
+        fn is_concurrency_safe(&self, _input: &serde_json::Value) -> bool {
+            true
+        }
+
+        fn is_deferred(&self) -> bool {
+            true
+        }
+
+        async fn execute(&self, _input: serde_json::Value) -> ToolResult {
+            ToolResult {
+                content: "ok".to_string(),
+                is_error: false,
+            }
+        }
+
+        fn category(&self) -> ToolCategory {
+            ToolCategory::Info
+        }
+    }
+
+    #[test]
+    fn to_tool_defs_includes_deferred_flag() {
+        let mut registry = ToolRegistry::new();
+        registry.register(make_tool("core_tool", "a core tool"));
+        let defs = registry.to_tool_defs();
+        assert!(!defs[0].deferred, "default tools should not be deferred");
+    }
+
+    #[test]
+    fn to_tool_defs_deferred_tool_flagged() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Box::new(DeferredMockTool {
+            tool_name: "lazy_tool".to_string(),
+        }));
+        let defs = registry.to_tool_defs();
+        assert!(defs[0].deferred, "deferred tool should have deferred=true");
     }
 }

--- a/crates/aion-tools/src/registry.rs
+++ b/crates/aion-tools/src/registry.rs
@@ -41,6 +41,7 @@ impl ToolRegistry {
                 name: t.name().to_string(),
                 description: t.description().to_string(),
                 input_schema: t.input_schema(),
+                deferred: false,
             })
             .collect()
     }
@@ -59,6 +60,7 @@ impl ToolRegistry {
                 name: t.name().to_string(),
                 description: t.description().to_string(),
                 input_schema: t.input_schema(),
+                deferred: false,
             })
             .collect()
     }

--- a/crates/aion-tools/src/tool_search.rs
+++ b/crates/aion-tools/src/tool_search.rs
@@ -1,23 +1,21 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use aion_protocol::events::ToolCategory;
-use aion_types::tool::{JsonSchema, ToolResult};
+use aion_types::tool::{JsonSchema, ToolDef, ToolResult};
 
 use crate::Tool;
-use crate::registry::ToolRegistry;
 
 /// Built-in tool that searches for deferred tools and loads their full schema.
 /// Core tool (never deferred itself) — always available to the LLM.
 pub struct ToolSearchTool {
-    registry: Arc<ToolRegistry>,
+    /// Snapshot of all tool definitions (taken at construction time).
+    tool_defs: Vec<ToolDef>,
 }
 
 impl ToolSearchTool {
-    pub fn new(registry: Arc<ToolRegistry>) -> Self {
-        Self { registry }
+    pub fn new(tool_defs: Vec<ToolDef>) -> Self {
+        Self { tool_defs }
     }
 }
 
@@ -59,8 +57,8 @@ impl Tool for ToolSearchTool {
         }
 
         let query_lower = query.to_lowercase();
-        let defs = self.registry.to_tool_defs();
-        let matches: Vec<Value> = defs
+        let matches: Vec<Value> = self
+            .tool_defs
             .iter()
             .filter(|d| d.deferred)
             .filter(|d| {
@@ -98,50 +96,32 @@ impl Tool for ToolSearchTool {
 mod tests {
     use super::*;
 
-    struct MockDeferred {
-        tool_name: String,
-        tool_description: String,
-        deferred: bool,
-    }
-
-    #[async_trait]
-    impl Tool for MockDeferred {
-        fn name(&self) -> &str { &self.tool_name }
-        fn description(&self) -> &str { &self.tool_description }
-        fn input_schema(&self) -> JsonSchema {
-            json!({"type": "object", "properties": {"x": {"type": "string"}}})
-        }
-        fn is_concurrency_safe(&self, _input: &Value) -> bool { true }
-        fn is_deferred(&self) -> bool { self.deferred }
-        async fn execute(&self, _input: Value) -> ToolResult {
-            ToolResult { content: "ok".into(), is_error: false }
-        }
-        fn category(&self) -> ToolCategory { ToolCategory::Info }
-    }
-
-    fn build_registry() -> Arc<ToolRegistry> {
-        let mut reg = ToolRegistry::new();
-        reg.register(Box::new(MockDeferred {
-            tool_name: "Read".into(),
-            tool_description: "Read a file".into(),
-            deferred: false,
-        }));
-        reg.register(Box::new(MockDeferred {
-            tool_name: "SpawnTool".into(),
-            tool_description: "Spawn sub-agents".into(),
-            deferred: true,
-        }));
-        reg.register(Box::new(MockDeferred {
-            tool_name: "EnterPlanMode".into(),
-            tool_description: "Enter plan mode".into(),
-            deferred: true,
-        }));
-        Arc::new(reg)
+    fn build_tool_defs() -> Vec<ToolDef> {
+        vec![
+            ToolDef {
+                name: "Read".into(),
+                description: "Read a file".into(),
+                input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}}),
+                deferred: false,
+            },
+            ToolDef {
+                name: "SpawnTool".into(),
+                description: "Spawn sub-agents".into(),
+                input_schema: json!({"type": "object", "properties": {"agents": {"type": "array"}}}),
+                deferred: true,
+            },
+            ToolDef {
+                name: "EnterPlanMode".into(),
+                description: "Enter plan mode".into(),
+                input_schema: json!({"type": "object", "properties": {}}),
+                deferred: true,
+            },
+        ]
     }
 
     #[tokio::test]
     async fn search_by_exact_name() {
-        let tool = ToolSearchTool::new(build_registry());
+        let tool = ToolSearchTool::new(build_tool_defs());
         let result = tool.execute(json!({"query": "SpawnTool"})).await;
         assert!(!result.is_error);
         assert!(result.content.contains("SpawnTool"));
@@ -151,7 +131,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_case_insensitive() {
-        let tool = ToolSearchTool::new(build_registry());
+        let tool = ToolSearchTool::new(build_tool_defs());
         let result = tool.execute(json!({"query": "spawntool"})).await;
         assert!(!result.is_error);
         assert!(result.content.contains("SpawnTool"));
@@ -159,7 +139,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_by_description_keyword() {
-        let tool = ToolSearchTool::new(build_registry());
+        let tool = ToolSearchTool::new(build_tool_defs());
         let result = tool.execute(json!({"query": "plan"})).await;
         assert!(!result.is_error);
         assert!(result.content.contains("EnterPlanMode"));
@@ -167,7 +147,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_excludes_non_deferred() {
-        let tool = ToolSearchTool::new(build_registry());
+        let tool = ToolSearchTool::new(build_tool_defs());
         let result = tool.execute(json!({"query": "Read"})).await;
         // "Read" is not deferred, should not appear in results
         assert!(
@@ -178,7 +158,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_no_match() {
-        let tool = ToolSearchTool::new(build_registry());
+        let tool = ToolSearchTool::new(build_tool_defs());
         let result = tool.execute(json!({"query": "nonexistent"})).await;
         assert!(!result.is_error);
         assert!(result.content.contains("No deferred tools"));
@@ -186,7 +166,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_empty_query_returns_error() {
-        let tool = ToolSearchTool::new(build_registry());
+        let tool = ToolSearchTool::new(build_tool_defs());
         let result = tool.execute(json!({"query": ""})).await;
         assert!(result.is_error);
     }

--- a/crates/aion-tools/src/tool_search.rs
+++ b/crates/aion-tools/src/tool_search.rs
@@ -1,0 +1,193 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use aion_protocol::events::ToolCategory;
+use aion_types::tool::{JsonSchema, ToolResult};
+
+use crate::Tool;
+use crate::registry::ToolRegistry;
+
+/// Built-in tool that searches for deferred tools and loads their full schema.
+/// Core tool (never deferred itself) — always available to the LLM.
+pub struct ToolSearchTool {
+    registry: Arc<ToolRegistry>,
+}
+
+impl ToolSearchTool {
+    pub fn new(registry: Arc<ToolRegistry>) -> Self {
+        Self { registry }
+    }
+}
+
+#[async_trait]
+impl Tool for ToolSearchTool {
+    fn name(&self) -> &str {
+        "ToolSearch"
+    }
+
+    fn description(&self) -> &str {
+        "Search for deferred tools and load their full schema. \
+         Use this before calling any deferred tool."
+    }
+
+    fn input_schema(&self) -> JsonSchema {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Tool name or keyword to search for"
+                }
+            },
+            "required": ["query"]
+        })
+    }
+
+    fn is_concurrency_safe(&self, _input: &Value) -> bool {
+        true
+    }
+
+    async fn execute(&self, input: Value) -> ToolResult {
+        let query = input["query"].as_str().unwrap_or("");
+        if query.is_empty() {
+            return ToolResult {
+                content: "Error: query is required".to_string(),
+                is_error: true,
+            };
+        }
+
+        let query_lower = query.to_lowercase();
+        let defs = self.registry.to_tool_defs();
+        let matches: Vec<Value> = defs
+            .iter()
+            .filter(|d| d.deferred)
+            .filter(|d| {
+                d.name.to_lowercase().contains(&query_lower)
+                    || d.description.to_lowercase().contains(&query_lower)
+            })
+            .map(|d| {
+                json!({
+                    "name": d.name,
+                    "description": d.description,
+                    "parameters": d.input_schema
+                })
+            })
+            .collect();
+
+        if matches.is_empty() {
+            return ToolResult {
+                content: format!("No deferred tools matching \"{}\" found.", query),
+                is_error: false,
+            };
+        }
+
+        ToolResult {
+            content: serde_json::to_string_pretty(&matches).unwrap_or_default(),
+            is_error: false,
+        }
+    }
+
+    fn category(&self) -> ToolCategory {
+        ToolCategory::Info
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockDeferred {
+        tool_name: String,
+        tool_description: String,
+        deferred: bool,
+    }
+
+    #[async_trait]
+    impl Tool for MockDeferred {
+        fn name(&self) -> &str { &self.tool_name }
+        fn description(&self) -> &str { &self.tool_description }
+        fn input_schema(&self) -> JsonSchema {
+            json!({"type": "object", "properties": {"x": {"type": "string"}}})
+        }
+        fn is_concurrency_safe(&self, _input: &Value) -> bool { true }
+        fn is_deferred(&self) -> bool { self.deferred }
+        async fn execute(&self, _input: Value) -> ToolResult {
+            ToolResult { content: "ok".into(), is_error: false }
+        }
+        fn category(&self) -> ToolCategory { ToolCategory::Info }
+    }
+
+    fn build_registry() -> Arc<ToolRegistry> {
+        let mut reg = ToolRegistry::new();
+        reg.register(Box::new(MockDeferred {
+            tool_name: "Read".into(),
+            tool_description: "Read a file".into(),
+            deferred: false,
+        }));
+        reg.register(Box::new(MockDeferred {
+            tool_name: "SpawnTool".into(),
+            tool_description: "Spawn sub-agents".into(),
+            deferred: true,
+        }));
+        reg.register(Box::new(MockDeferred {
+            tool_name: "EnterPlanMode".into(),
+            tool_description: "Enter plan mode".into(),
+            deferred: true,
+        }));
+        Arc::new(reg)
+    }
+
+    #[tokio::test]
+    async fn search_by_exact_name() {
+        let tool = ToolSearchTool::new(build_registry());
+        let result = tool.execute(json!({"query": "SpawnTool"})).await;
+        assert!(!result.is_error);
+        assert!(result.content.contains("SpawnTool"));
+        assert!(result.content.contains("Spawn sub-agents"));
+        assert!(result.content.contains("parameters"));
+    }
+
+    #[tokio::test]
+    async fn search_case_insensitive() {
+        let tool = ToolSearchTool::new(build_registry());
+        let result = tool.execute(json!({"query": "spawntool"})).await;
+        assert!(!result.is_error);
+        assert!(result.content.contains("SpawnTool"));
+    }
+
+    #[tokio::test]
+    async fn search_by_description_keyword() {
+        let tool = ToolSearchTool::new(build_registry());
+        let result = tool.execute(json!({"query": "plan"})).await;
+        assert!(!result.is_error);
+        assert!(result.content.contains("EnterPlanMode"));
+    }
+
+    #[tokio::test]
+    async fn search_excludes_non_deferred() {
+        let tool = ToolSearchTool::new(build_registry());
+        let result = tool.execute(json!({"query": "Read"})).await;
+        // "Read" is not deferred, should not appear in results
+        assert!(
+            !result.content.contains("\"name\": \"Read\"")
+                || result.content.contains("No deferred tools")
+        );
+    }
+
+    #[tokio::test]
+    async fn search_no_match() {
+        let tool = ToolSearchTool::new(build_registry());
+        let result = tool.execute(json!({"query": "nonexistent"})).await;
+        assert!(!result.is_error);
+        assert!(result.content.contains("No deferred tools"));
+    }
+
+    #[tokio::test]
+    async fn search_empty_query_returns_error() {
+        let tool = ToolSearchTool::new(build_registry());
+        let result = tool.execute(json!({"query": ""})).await;
+        assert!(result.is_error);
+    }
+}

--- a/crates/aion-types/src/tool.rs
+++ b/crates/aion-types/src/tool.rs
@@ -9,6 +9,8 @@ pub struct ToolDef {
     pub name: String,
     pub description: String,
     pub input_schema: JsonSchema,
+    /// Whether this tool's full schema is deferred (only name + stub sent to LLM).
+    pub deferred: bool,
 }
 
 /// Result from executing a tool
@@ -40,6 +42,7 @@ mod tests {
             name: "bash".to_string(),
             description: "Run a shell command".to_string(),
             input_schema: schema.clone(),
+            deferred: false,
         };
         // assert
         assert_eq!(tool.name, "bash");
@@ -54,6 +57,7 @@ mod tests {
             name: "noop".to_string(),
             description: "Does nothing".to_string(),
             input_schema: json!({}),
+            deferred: false,
         };
         // assert
         assert_eq!(tool.input_schema, json!({}));
@@ -97,5 +101,27 @@ mod tests {
         // assert
         assert!(result.content.is_empty());
         assert!(result.is_error);
+    }
+
+    #[test]
+    fn test_tool_def_deferred_defaults_to_false() {
+        let tool = ToolDef {
+            name: "test".to_string(),
+            description: "desc".to_string(),
+            input_schema: json!({}),
+            deferred: false,
+        };
+        assert!(!tool.deferred);
+    }
+
+    #[test]
+    fn test_tool_def_deferred_true() {
+        let tool = ToolDef {
+            name: "spawn".to_string(),
+            description: "desc".to_string(),
+            input_schema: json!({}),
+            deferred: true,
+        };
+        assert!(tool.deferred);
     }
 }

--- a/crates/aion-types/src/tool.rs
+++ b/crates/aion-types/src/tool.rs
@@ -3,6 +3,33 @@ use serde_json::Value;
 /// Schema for a tool parameter, in JSON Schema format
 pub type JsonSchema = Value;
 
+/// Maximum chars kept from a deferred tool's description.
+const DEFERRED_DESC_MAX_CHARS: usize = 200;
+
+/// Truncate a description for a deferred tool stub.
+///
+/// Keeps up to the first blank line or `DEFERRED_DESC_MAX_CHARS` characters
+/// (whichever is shorter). If the text was trimmed, an ellipsis is appended.
+pub fn truncate_deferred_description(desc: &str) -> String {
+    // Find first blank line (double newline)
+    let end_at_blank = desc.find("\n\n").unwrap_or(desc.len());
+    let limit = end_at_blank.min(DEFERRED_DESC_MAX_CHARS);
+
+    if limit >= desc.len() {
+        return desc.to_string();
+    }
+
+    // Avoid cutting in the middle of a UTF-8 char boundary
+    let safe_end = desc
+        .char_indices()
+        .take_while(|(i, _)| *i < limit)
+        .last()
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(0);
+
+    format!("{}…", &desc[..safe_end])
+}
+
 /// Definition of a tool for the API
 #[derive(Debug, Clone)]
 pub struct ToolDef {
@@ -123,5 +150,69 @@ mod tests {
             deferred: true,
         };
         assert!(tool.deferred);
+    }
+
+    // --- truncate_deferred_description tests ---
+
+    #[test]
+    fn truncate_short_description_unchanged() {
+        let desc = "Search for issues in Sentry.";
+        assert_eq!(truncate_deferred_description(desc), desc);
+    }
+
+    #[test]
+    fn truncate_at_blank_line() {
+        let desc = "First paragraph here.\n\nSecond paragraph with details.";
+        assert_eq!(
+            truncate_deferred_description(desc),
+            "First paragraph here.…"
+        );
+    }
+
+    #[test]
+    fn truncate_at_200_chars_before_blank_line() {
+        let desc = format!("{}. More text after.", "A".repeat(200));
+        let result = truncate_deferred_description(&desc);
+        assert!(result.len() <= 200 + '…'.len_utf8());
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_blank_line_before_200_chars() {
+        let desc = "Short first paragraph.\n\nLong second paragraph that goes on and on.";
+        let result = truncate_deferred_description(desc);
+        assert_eq!(result, "Short first paragraph.…");
+    }
+
+    #[test]
+    fn truncate_empty_string() {
+        assert_eq!(truncate_deferred_description(""), "");
+    }
+
+    #[test]
+    fn truncate_exactly_200_chars() {
+        let desc = "X".repeat(200);
+        assert_eq!(truncate_deferred_description(&desc), desc);
+    }
+
+    #[test]
+    fn truncate_201_chars() {
+        let desc = "X".repeat(201);
+        let result = truncate_deferred_description(&desc);
+        assert!(result.ends_with('…'));
+        // 200 X's + ellipsis
+        assert_eq!(result.len(), 200 + '…'.len_utf8());
+    }
+
+    #[test]
+    fn truncate_multibyte_chars_safe() {
+        // 100 two-byte chars = 200 bytes, but only 100 char positions
+        let desc: String = "é".repeat(150);
+        let result = truncate_deferred_description(&desc);
+        // Should not panic and should be valid UTF-8
+        assert!(result.ends_with('…'));
+        // Should be at most 200 chars (counting code points)
+        let char_count = result.chars().count();
+        assert!(char_count <= 201); // 200 chars + ellipsis
     }
 }

--- a/tests/provider_anthropic_test.rs
+++ b/tests/provider_anthropic_test.rs
@@ -5,6 +5,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use aionrs::provider::anthropic::AnthropicProvider;
 use aionrs::provider::compat::ProviderCompat;
+use aionrs::provider::debug::DebugConfig;
 use aionrs::provider::{LlmProvider, ProviderError};
 use aionrs::types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 use aionrs::types::message::{ContentBlock, Message, Role, StopReason};
@@ -77,7 +78,7 @@ async fn test_anthropic_stream_text_response() {
         .await;
 
     let provider =
-        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults()).with_cache(false);
+        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults(), DebugConfig::default()).with_cache(false);
     let request = minimal_request();
 
     // Act
@@ -148,7 +149,7 @@ data: {\"type\":\"message_stop\"}\n\n";
         .await;
 
     let provider =
-        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults()).with_cache(false);
+        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults(), DebugConfig::default()).with_cache(false);
     let request = minimal_request();
 
     // Act
@@ -228,7 +229,7 @@ data: {\"type\":\"message_stop\"}\n\n";
     request.thinking = Some(ThinkingConfig::Enabled { budget_tokens: 5000 });
 
     let provider =
-        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults()).with_cache(false);
+        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults(), DebugConfig::default()).with_cache(false);
 
     // Act
     let rx = provider.stream(&request).await.expect("stream should succeed");
@@ -273,7 +274,7 @@ async fn test_anthropic_auth_error() {
         .await;
 
     let provider =
-        AnthropicProvider::new("bad-api-key", &server.uri(), ProviderCompat::anthropic_defaults()).with_cache(false);
+        AnthropicProvider::new("bad-api-key", &server.uri(), ProviderCompat::anthropic_defaults(), DebugConfig::default()).with_cache(false);
     let request = minimal_request();
 
     // Act
@@ -311,7 +312,7 @@ async fn test_anthropic_rate_limit_retryable() {
         .await;
 
     let provider =
-        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults()).with_cache(false);
+        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults(), DebugConfig::default()).with_cache(false);
     let request = minimal_request();
 
     // Act
@@ -353,7 +354,7 @@ async fn test_anthropic_request_headers() {
         .await;
 
     let provider =
-        AnthropicProvider::new("my-secret-key", &server.uri(), ProviderCompat::anthropic_defaults()).with_cache(false);
+        AnthropicProvider::new("my-secret-key", &server.uri(), ProviderCompat::anthropic_defaults(), DebugConfig::default()).with_cache(false);
     let request = minimal_request();
 
     // Act — should succeed because the headers are correct
@@ -393,7 +394,7 @@ async fn test_anthropic_prompt_caching_header() {
 
     // with_cache(true) — default, but explicit here for clarity
     let provider =
-        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults()).with_cache(true);
+        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults(), DebugConfig::default()).with_cache(true);
     let request = minimal_request();
 
     let result = provider.stream(&request).await;
@@ -429,7 +430,7 @@ async fn test_anthropic_no_prompt_caching_header_when_disabled() {
         .await;
 
     let provider =
-        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults()).with_cache(false);
+        AnthropicProvider::new("test-api-key", &server.uri(), ProviderCompat::anthropic_defaults(), DebugConfig::default()).with_cache(false);
     let request = minimal_request();
 
     let result = provider.stream(&request).await;

--- a/tests/provider_openai_test.rs
+++ b/tests/provider_openai_test.rs
@@ -1,5 +1,6 @@
 use aionrs::provider::LlmProvider;
 use aionrs::provider::compat::ProviderCompat;
+use aionrs::provider::debug::DebugConfig;
 use aionrs::provider::openai::OpenAIProvider;
 use aionrs::types::llm::{LlmEvent, LlmRequest};
 use aionrs::types::message::{ContentBlock, Message, Role, StopReason};
@@ -114,7 +115,7 @@ async fn test_openai_stream_text_response() {
         .mount(&server)
         .await;
 
-    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults(), DebugConfig::default());
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -220,7 +221,7 @@ async fn test_openai_stream_tool_call_aggregation() {
         .mount(&server)
         .await;
 
-    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults(), DebugConfig::default());
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -327,7 +328,7 @@ async fn test_openai_multiple_tool_calls() {
         .mount(&server)
         .await;
 
-    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults(), DebugConfig::default());
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -420,7 +421,7 @@ async fn test_openai_stream_state_transitions() {
         .mount(&server)
         .await;
 
-    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults(), DebugConfig::default());
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -463,7 +464,7 @@ async fn test_openai_api_error_non_success_status() {
         .mount(&server)
         .await;
 
-    let provider = OpenAIProvider::new("bad-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new("bad-key", &server.uri(), ProviderCompat::openai_defaults(), DebugConfig::default());
     let result = provider.stream(&make_request()).await;
 
     assert!(result.is_err());
@@ -490,7 +491,7 @@ async fn test_openai_rate_limited() {
         .mount(&server)
         .await;
 
-    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults(), DebugConfig::default());
     let result = provider.stream(&make_request()).await;
 
     assert!(result.is_err());
@@ -548,7 +549,7 @@ async fn test_openai_stream_max_tokens_stop_reason() {
         .mount(&server)
         .await;
 
-    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults(), DebugConfig::default());
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 
@@ -620,7 +621,7 @@ async fn test_openai_stream_empty_content_delta_skipped() {
         .mount(&server)
         .await;
 
-    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let provider = OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults(), DebugConfig::default());
     let rx = provider.stream(&make_request()).await.unwrap();
     let events = collect_events(rx).await;
 

--- a/tests/skills_e2e.rs
+++ b/tests/skills_e2e.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use aionrs::context::build_system_prompt;
+use aionrs::context::{SystemPromptCache, build_system_prompt};
 use aionrs::skills::loader::load_all_skills;
 use aionrs::skills::permissions::SkillPermissionChecker;
 use aionrs::skills::types::SkillMetadata;
@@ -210,7 +210,7 @@ async fn e7_system_prompt_injection() {
     let cwd = root.to_string_lossy().to_string();
     let skills = load_all_skills(&root, &[], false, None).await;
 
-    let prompt = build_system_prompt(None, &cwd, "test-model", &skills, None, None, false);
+    let prompt = build_system_prompt(&mut SystemPromptCache::new(), None, &cwd, "test-model", &skills, None, None, false);
     assert!(prompt.contains("greet"), "E7 FAIL: 'greet' not in system prompt");
     assert!(prompt.contains("db:migrate"), "E7 FAIL: 'db:migrate' not in system prompt");
     assert!(prompt.contains("system-reminder"), "E7 FAIL: missing <system-reminder> wrapper");


### PR DESCRIPTION
## Summary

- **Deferred tool infrastructure**: Tools marked as `deferred` send only a name + truncated description stub to the LLM, with full schema retrievable via `ToolSearch` on demand
- **MCP tools default to deferred**: All MCP server tools are deferred by default (configurable per-server via `deferred: false` in config), eliminating ~10K tokens of unused tool schemas per request
- **Description truncation**: Deferred tool descriptions are truncated to first blank line or 200 chars (whichever is shorter), with UTF-8 safe boundary handling
- **Minimal memory prompt**: Memory system instructions reduced from ~13K chars to ~600 chars, omitting full type taxonomy and examples while preserving all operational rules
- **SystemPromptCache**: Section-level caching for system prompt assembly, with targeted invalidation on config/memory changes
- **CacheBreakDetector**: Diagnostic tool that pairs request-side prompt hashes with response-side cache tokens to detect and attribute prompt cache breaks
- **Debug config**: `[debug]` config section with `dump_request_path` for inspecting raw API request bodies

### Token reduction breakdown (measured)

| Component | Before | After | Savings |
|-----------|--------|-------|---------|
| Tools schema (20 MCP tools) | ~11,518 | ~1,500 | ~87% |
| System prompt (memory section) | ~3,700 | ~700 | ~81% |
| **Total first-turn estimate** | **~14,500** | **~4,200** | **~71%** |

## Test plan

- [ ] `cargo test` — all 500+ tests pass, 0 failures
- [ ] `cargo clippy --all-targets` — zero warnings
- [ ] Verify ToolSearch returns full untruncated schemas for deferred tools
- [ ] Verify MCP tools with `deferred: false` config send full schemas
- [ ] Verify minimal memory prompt includes MEMORY.md index content
- [ ] E2E: send a message with MCP tools configured, check input_tokens reduced