### PR TITLE
fix(openai): handle empty function name in SSE deltas + add response dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aion-agent",
  "aion-config",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aion-types",
  "anyhow",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aion-config",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aion-types",
  "rstest",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -522,6 +522,9 @@ async fn run_json_stream_mode(
                                     }
                                     Err(e) => {
                                         output.emit_error(&e.to_string());
+                                        // Always emit stream_end so the client
+                                        // can leave the "running" state.
+                                        output.emit_stream_end(&msg_id, 0, 0, 0, 0, 0);
                                     }
                                 }
                                 break;

--- a/crates/aion-config/src/debug.rs
+++ b/crates/aion-config/src/debug.rs
@@ -15,6 +15,11 @@ pub struct DebugConfig {
     /// JSON) to this path.  Each request overwrites the previous one.
     #[serde(default)]
     pub dump_request_path: Option<String>,
+    /// When set, raw SSE chunks from the LLM response are appended to this
+    /// file.  The file is truncated at the start of each request so it only
+    /// contains the most recent exchange.
+    #[serde(default)]
+    pub dump_response_path: Option<String>,
 }
 
 impl DebugConfig {
@@ -23,6 +28,7 @@ impl DebugConfig {
     pub fn merge(global: Self, project: Self) -> Self {
         Self {
             dump_request_path: project.dump_request_path.or(global.dump_request_path),
+            dump_response_path: project.dump_response_path.or(global.dump_response_path),
         }
     }
 }
@@ -59,9 +65,11 @@ dump_request_path = "/tmp/aion_request.json"
     fn merge_project_overrides_global() {
         let global = DebugConfig {
             dump_request_path: Some("/tmp/global.json".into()),
+            ..Default::default()
         };
         let project = DebugConfig {
             dump_request_path: Some("/tmp/project.json".into()),
+            ..Default::default()
         };
         let merged = DebugConfig::merge(global, project);
         assert_eq!(
@@ -74,12 +82,42 @@ dump_request_path = "/tmp/aion_request.json"
     fn merge_falls_back_to_global() {
         let global = DebugConfig {
             dump_request_path: Some("/tmp/global.json".into()),
+            ..Default::default()
         };
         let project = DebugConfig::default();
         let merged = DebugConfig::merge(global, project);
         assert_eq!(
             merged.dump_request_path.as_deref(),
             Some("/tmp/global.json")
+        );
+    }
+
+    #[test]
+    fn merge_response_dump_path() {
+        let global = DebugConfig {
+            dump_response_path: Some("/tmp/global_resp.jsonl".into()),
+            ..Default::default()
+        };
+        let project = DebugConfig {
+            dump_response_path: Some("/tmp/project_resp.jsonl".into()),
+            ..Default::default()
+        };
+        let merged = DebugConfig::merge(global, project);
+        assert_eq!(
+            merged.dump_response_path.as_deref(),
+            Some("/tmp/project_resp.jsonl")
+        );
+    }
+
+    #[test]
+    fn toml_with_response_dump_path() {
+        let toml_str = r#"
+dump_response_path = "/tmp/aion_response.jsonl"
+"#;
+        let cfg: DebugConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            cfg.dump_response_path.as_deref(),
+            Some("/tmp/aion_response.jsonl")
         );
     }
 }

--- a/crates/aion-providers/src/anthropic.rs
+++ b/crates/aion-providers/src/anthropic.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 
 use super::anthropic_shared;
-use crate::{LlmProvider, ProviderError, dump_request_body};
+use crate::{LlmProvider, ProviderError, dump_request_body, reset_response_dump};
 use aion_config::compat::ProviderCompat;
 use aion_config::debug::DebugConfig;
 
@@ -102,6 +102,7 @@ impl LlmProvider for AnthropicProvider {
         let body = self.build_request_body(request);
 
         dump_request_body(&self.debug, &body);
+        reset_response_dump(&self.debug);
 
         let response = self
             .client
@@ -126,9 +127,10 @@ impl LlmProvider for AnthropicProvider {
         }
 
         let (tx, rx) = mpsc::channel(64);
+        let debug = self.debug.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = anthropic_shared::process_sse_stream(response, &tx).await {
+            if let Err(e) = anthropic_shared::process_sse_stream(response, &tx, &debug).await {
                 let _ = tx.send(LlmEvent::Error(e.to_string())).await;
             }
         });

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -9,7 +9,9 @@ use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 use aion_types::tool::{ToolDef, truncate_deferred_description};
 
 use super::ProviderError;
+use crate::dump_response_chunk;
 use aion_config::compat::ProviderCompat;
+use aion_config::debug::DebugConfig;
 
 /// Convert internal Message format to Anthropic API message format.
 /// Compat flags control merging and alternation behavior.
@@ -227,6 +229,7 @@ impl StreamState {
 pub async fn process_sse_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
+    debug: &DebugConfig,
 ) -> Result<(), ProviderError> {
     use futures::StreamExt;
 
@@ -249,6 +252,7 @@ pub async fn process_sse_stream(
                 if let Some(event_type) = line.strip_prefix("event: ") {
                     current_event_type = event_type.to_string();
                 } else if let Some(data) = line.strip_prefix("data: ") {
+                    dump_response_chunk(debug, data);
                     let events = parse_sse_data(&current_event_type, data, &mut state);
                     for event in events {
                         if tx.send(event).await.is_err() {

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -18,7 +18,9 @@ use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 use aion_types::message::{StopReason, TokenUsage};
 
 use super::anthropic_shared;
-use crate::{LlmProvider, ProviderError, dump_request_body, dump_response_chunk, reset_response_dump};
+use crate::{
+    LlmProvider, ProviderError, dump_request_body, dump_response_chunk, reset_response_dump,
+};
 use aion_config::compat::{self, ProviderCompat};
 use aion_config::debug::DebugConfig;
 

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -18,7 +18,7 @@ use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 use aion_types::message::{StopReason, TokenUsage};
 
 use super::anthropic_shared;
-use crate::{LlmProvider, ProviderError, dump_request_body};
+use crate::{LlmProvider, ProviderError, dump_request_body, dump_response_chunk, reset_response_dump};
 use aion_config::compat::{self, ProviderCompat};
 use aion_config::debug::DebugConfig;
 
@@ -253,6 +253,7 @@ impl LlmProvider for BedrockProvider {
         let body = self.build_request_body(request);
 
         dump_request_body(&self.debug, &body);
+        reset_response_dump(&self.debug);
 
         let body_bytes = serde_json::to_vec(&body)
             .map_err(|e| ProviderError::Connection(format!("JSON serialize error: {}", e)))?;
@@ -289,10 +290,11 @@ impl LlmProvider for BedrockProvider {
         }
 
         let (tx, rx) = mpsc::channel(64);
+        let debug = self.debug.clone();
 
         // AWS event stream uses binary framing
         tokio::spawn(async move {
-            if let Err(e) = process_aws_event_stream(response, &tx).await {
+            if let Err(e) = process_aws_event_stream(response, &tx, &debug).await {
                 let _ = tx.send(LlmEvent::Error(e.to_string())).await;
             }
         });
@@ -305,6 +307,7 @@ impl LlmProvider for BedrockProvider {
 async fn process_aws_event_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
+    debug: &DebugConfig,
 ) -> Result<(), ProviderError> {
     use futures::StreamExt;
 
@@ -328,6 +331,7 @@ async fn process_aws_event_stream(
                         && let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(b64)
                         && let Ok(inner) = String::from_utf8(decoded)
                     {
+                        dump_response_chunk(debug, &inner);
                         // Inner payload is JSON with event type hints
                         if let Ok(json_val) = serde_json::from_str::<Value>(&inner) {
                             let event_type = json_val["type"].as_str().unwrap_or("");

--- a/crates/aion-providers/src/lib.rs
+++ b/crates/aion-providers/src/lib.rs
@@ -57,6 +57,23 @@ pub fn dump_request_body(debug: &DebugConfig, body: &serde_json::Value) {
     }
 }
 
+/// Truncate the response dump file at the start of a new request.
+pub fn reset_response_dump(debug: &DebugConfig) {
+    if let Some(path) = &debug.dump_response_path {
+        let _ = std::fs::write(path, "");
+    }
+}
+
+/// Append a raw SSE line to the response dump file.
+pub fn dump_response_chunk(debug: &DebugConfig, chunk: &str) {
+    if let Some(path) = &debug.dump_response_path {
+        use std::io::Write;
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+            let _ = writeln!(f, "{chunk}");
+        }
+    }
+}
+
 /// Create a provider from resolved config
 pub fn create_provider(config: &Config) -> Arc<dyn LlmProvider> {
     let compat = config.compat.clone();

--- a/crates/aion-providers/src/lib.rs
+++ b/crates/aion-providers/src/lib.rs
@@ -68,7 +68,11 @@ pub fn reset_response_dump(debug: &DebugConfig) {
 pub fn dump_response_chunk(debug: &DebugConfig, chunk: &str) {
     if let Some(path) = &debug.dump_response_path {
         use std::io::Write;
-        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
             let _ = writeln!(f, "{chunk}");
         }
     }

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -7,7 +7,7 @@ use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 use aion_types::tool::{ToolDef, truncate_deferred_description};
 
-use crate::{LlmProvider, ProviderError, dump_request_body};
+use crate::{LlmProvider, ProviderError, dump_request_body, dump_response_chunk, reset_response_dump};
 use aion_config::compat::ProviderCompat;
 use aion_config::debug::DebugConfig;
 
@@ -454,6 +454,7 @@ impl LlmProvider for OpenAIProvider {
         let body = self.build_request_body(request);
 
         dump_request_body(&self.debug, &body);
+        reset_response_dump(&self.debug);
 
         let response = self
             .client
@@ -478,9 +479,10 @@ impl LlmProvider for OpenAIProvider {
         }
 
         let (tx, rx) = mpsc::channel(64);
+        let debug = self.debug.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = process_sse_stream(response, &tx).await {
+            if let Err(e) = process_sse_stream(response, &tx, &debug).await {
                 let _ = tx.send(LlmEvent::Error(e.to_string())).await;
             }
         });
@@ -492,6 +494,7 @@ impl LlmProvider for OpenAIProvider {
 async fn process_sse_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
+    debug: &DebugConfig,
 ) -> Result<(), ProviderError> {
     use futures::StreamExt;
 
@@ -514,6 +517,7 @@ async fn process_sse_stream(
             }
 
             if let Some(data) = line.strip_prefix("data: ") {
+                dump_response_chunk(debug, data);
                 if data == "[DONE]" {
                     // Flush the deferred Done event now that the final
                     // usage-only chunk (choices:[]) has updated token counts.
@@ -583,7 +587,12 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
             if let Some(id) = tc["id"].as_str() {
                 acc.id = id.to_string();
             }
-            if let Some(name) = tc["function"]["name"].as_str() {
+            // Only overwrite when non-empty — some third-party APIs send `"name":""`
+            // in every delta chunk which would erase the real name from the first chunk.
+            if let Some(name) = tc["function"]["name"]
+                .as_str()
+                .filter(|n| !n.is_empty())
+            {
                 acc.name = name.to_string();
             }
             if let Some(args) = tc["function"]["arguments"].as_str() {

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -7,7 +7,9 @@ use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 use aion_types::tool::{ToolDef, truncate_deferred_description};
 
-use crate::{LlmProvider, ProviderError, dump_request_body, dump_response_chunk, reset_response_dump};
+use crate::{
+    LlmProvider, ProviderError, dump_request_body, dump_response_chunk, reset_response_dump,
+};
 use aion_config::compat::ProviderCompat;
 use aion_config::debug::DebugConfig;
 
@@ -589,10 +591,7 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
             }
             // Only overwrite when non-empty — some third-party APIs send `"name":""`
             // in every delta chunk which would erase the real name from the first chunk.
-            if let Some(name) = tc["function"]["name"]
-                .as_str()
-                .filter(|n| !n.is_empty())
-            {
+            if let Some(name) = tc["function"]["name"].as_str().filter(|n| !n.is_empty()) {
                 acc.name = name.to_string();
             }
             if let Some(args) = tc["function"]["arguments"].as_str() {

--- a/crates/aion-providers/src/vertex.rs
+++ b/crates/aion-providers/src/vertex.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 
 use super::anthropic_shared;
-use crate::{LlmProvider, ProviderError, dump_request_body};
+use crate::{LlmProvider, ProviderError, dump_request_body, reset_response_dump};
 use aion_config::compat::ProviderCompat;
 use aion_config::debug::DebugConfig;
 
@@ -264,6 +264,7 @@ impl LlmProvider for VertexProvider {
         let body = self.build_request_body(request);
 
         dump_request_body(&self.debug, &body);
+        reset_response_dump(&self.debug);
 
         let access_token = self.get_access_token().await?;
 
@@ -298,10 +299,11 @@ impl LlmProvider for VertexProvider {
         }
 
         let (tx, rx) = mpsc::channel(64);
+        let debug = self.debug.clone();
 
         // Vertex uses standard SSE (same as Anthropic)
         tokio::spawn(async move {
-            if let Err(e) = anthropic_shared::process_sse_stream(response, &tx).await {
+            if let Err(e) = anthropic_shared::process_sse_stream(response, &tx, &debug).await {
                 let _ = tx.send(LlmEvent::Error(e.to_string())).await;
             }
         });


### PR DESCRIPTION
## Summary

- **fix(openai)**: Third-party OpenAI-compatible APIs (e.g. laoni) send `"name":""` in every streaming delta chunk after the first one. This caused the parser to overwrite the real function name with an empty string, resulting in "Unknown tool" errors. Fixed by filtering out empty names with `.filter(|n| !n.is_empty())`.
- **fix(cli)**: Emit `stream_end` after provider errors so the client can leave the "running" state.
- **feat(debug)**: Add `dump_response_path` to DebugConfig. When set, raw SSE response chunks are appended to this file (truncated per request). Covers all four providers (OpenAI, Anthropic, Bedrock, Vertex).

## Root Cause

The laoni API returns SSE chunks like:
```json
// chunk 1: name is correct
{"delta":{"tool_calls":[{"index":0,"id":"call_xxx","function":{"name":"Glob","arguments":""}}]}}
// chunk 2+: name is empty string (non-standard)
{"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"..."}}]}}
```

Standard OpenAI API does not include `name` in subsequent chunks at all. The empty string `""` passed the `as_str()` check and overwrote the correct name.

## Test plan

- [ ] Verify `cargo test` passes for all affected crates
- [ ] Test with a third-party OpenAI-compatible API that sends empty name in deltas
- [ ] Configure `dump_response_path` and verify SSE chunks are logged correctly
- [ ] Verify standard OpenAI API still works correctly