### PR TITLE
feat(cli): add team mode support with dynamic MCP server injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aion-agent",
  "aion-config",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aion-types",
  "anyhow",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aion-config",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aion-types",
  "rstest",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -194,6 +194,14 @@ impl AgentEngine {
         &self.compat
     }
 
+    pub fn tool_names(&self) -> Vec<String> {
+        self.tools.tool_names()
+    }
+
+    pub fn registry_mut(&mut self) -> &mut ToolRegistry {
+        &mut self.tools
+    }
+
     /// Initialize a new session for this engine run
     pub fn init_session(
         &mut self,

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -519,7 +519,9 @@ async fn run_json_stream_mode(
     let mut cmd_rx = spawn_stdin_reader();
 
     // --- Pre-message phase: accept AddMcpServer commands ---
-    let mut mcp_manager = mcp_manager;
+    // Dynamic servers get their own McpManager instances because the initial
+    // mcp_manager Arc may already be shared by tool proxies (Arc::get_mut fails).
+    let mut dynamic_managers: Vec<Arc<McpManager>> = Vec::new();
     let mut first_cmd: Option<ProtocolCommand> = None;
 
     while let Some(cmd) = cmd_rx.recv().await {
@@ -533,6 +535,7 @@ async fn run_json_stream_mode(
                 url,
                 headers,
             } => {
+                eprintln!("[mcp] AddMcpServer received: name={name}, transport={transport}, command={command:?}");
                 let config =
                     match to_mcp_server_config(&transport, command, args, env, url, headers) {
                         Ok(c) => c,
@@ -542,41 +545,35 @@ async fn run_json_stream_mode(
                         }
                     };
 
-                if mcp_manager.is_none() {
-                    match McpManager::connect_all(&HashMap::new()).await {
-                        Ok(m) => {
-                            mcp_manager = Some(Arc::new(m));
-                        }
-                        Err(e) => {
-                            output.emit_error(&format!("AddMcpServer '{name}': init failed: {e}"));
-                            continue;
-                        }
+                let mut single_configs = HashMap::new();
+                single_configs.insert(name.clone(), config.clone());
+                eprintln!("[mcp] Connecting to '{name}'...");
+                match McpManager::connect_all(&single_configs).await {
+                    Ok(mgr) => {
+                        let tool_names: Vec<String> = mgr
+                            .all_tools()
+                            .iter()
+                            .map(|(_, t)| t.name.clone())
+                            .collect();
+                        eprintln!("[mcp] Connected to '{name}': {} tools", tool_names.len());
+                        let mgr_arc = Arc::new(mgr);
+                        let builtin_names = engine.tool_names();
+                        register_single_server_tools(
+                            engine.registry_mut(),
+                            &mgr_arc,
+                            &name,
+                            &builtin_names,
+                            config.deferred.unwrap_or(true),
+                        );
+                        dynamic_managers.push(mgr_arc);
+                        let _ = writer.emit(&ProtocolEvent::McpReady {
+                            name,
+                            tools: tool_names,
+                        });
                     }
-                }
-
-                let mgr_arc = mcp_manager.as_mut().unwrap();
-                match Arc::get_mut(mgr_arc) {
-                    Some(mgr) => match mgr.connect_one(name.clone(), &config).await {
-                        Ok(tool_names) => {
-                            let builtin_names = engine.tool_names();
-                            register_single_server_tools(
-                                engine.registry_mut(),
-                                mgr_arc,
-                                &name,
-                                &builtin_names,
-                                config.deferred.unwrap_or(true),
-                            );
-                            let _ = writer.emit(&ProtocolEvent::McpReady {
-                                name,
-                                tools: tool_names,
-                            });
-                        }
-                        Err(e) => {
-                            output.emit_error(&format!("AddMcpServer '{name}' failed: {e}"));
-                        }
-                    },
-                    None => {
-                        output.emit_error("AddMcpServer: McpManager is shared, cannot add server");
+                    Err(e) => {
+                        eprintln!("[mcp] connect_one failed for '{name}': {e}");
+                        output.emit_error(&format!("AddMcpServer '{name}' failed: {e}"));
                     }
                 }
             }
@@ -588,7 +585,7 @@ async fn run_json_stream_mode(
         }
     }
 
-    let has_mcp = mcp_manager.is_some();
+    let has_mcp = mcp_manager.is_some() || !dynamic_managers.is_empty();
     let mut pending_cmd = first_cmd;
 
     loop {
@@ -762,6 +759,9 @@ async fn run_json_stream_mode(
 
     engine.run_stop_hooks().await;
     if let Some(mgr) = &mcp_manager {
+        mgr.shutdown().await;
+    }
+    for mgr in &dynamic_managers {
         mgr.shutdown().await;
     }
 

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -15,10 +16,11 @@ use aion_agent::skill_tool::SkillTool;
 use aion_agent::spawn_tool::SpawnTool;
 use aion_agent::spawner::AgentSpawner;
 use aion_config::auth;
-use aion_config::config::{self, CliArgs, Config};
+use aion_config::config::{self, CliArgs, Config, McpServerConfig, TransportType};
 use aion_mcp::manager::McpManager;
-use aion_mcp::tool_proxy::register_mcp_tools;
+use aion_mcp::tool_proxy::{register_mcp_tools, register_single_server_tools};
 use aion_protocol::commands::{ApprovalScope, ProtocolCommand};
+use aion_protocol::events::ProtocolEvent;
 use aion_protocol::reader::spawn_stdin_reader;
 use aion_protocol::writer::ProtocolWriter;
 use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
@@ -443,6 +445,31 @@ fn print_skills_paths() {
     }
 }
 
+fn to_mcp_server_config(
+    transport: &str,
+    command: Option<String>,
+    args: Option<Vec<String>>,
+    env: Option<HashMap<String, String>>,
+    url: Option<String>,
+    headers: Option<HashMap<String, String>>,
+) -> Result<McpServerConfig, String> {
+    let transport_type = match transport {
+        "stdio" => TransportType::Stdio,
+        "sse" => TransportType::Sse,
+        "streamable-http" | "streamable_http" => TransportType::StreamableHttp,
+        other => return Err(format!("unknown transport: {other}")),
+    };
+    Ok(McpServerConfig {
+        transport: transport_type,
+        command,
+        args,
+        env,
+        url,
+        headers,
+        deferred: Some(false),
+    })
+}
+
 /// Pending config fields: (model, thinking, thinking_budget, effort)
 type PendingConfig = (Option<String>, Option<String>, Option<u32>, Option<String>);
 
@@ -459,7 +486,7 @@ async fn run_json_stream_mode(
     let protocol_sink = Arc::new(ProtocolSink::new(writer.clone()));
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let output: Arc<dyn OutputSink> = protocol_sink.clone();
-    let has_mcp = mcp_manager.is_some();
+    let initial_has_mcp = mcp_manager.is_some();
 
     let provider_name = config.provider_label.clone();
     let cwd = std::env::current_dir()?.to_string_lossy().to_string();
@@ -481,7 +508,7 @@ async fn run_json_stream_mode(
     let sid = engine.current_session_id();
     protocol_sink.emit_ready(
         engine.compat(),
-        has_mcp,
+        initial_has_mcp,
         sid,
         &approval_manager.current_mode(),
     );
@@ -491,7 +518,89 @@ async fn run_json_stream_mode(
 
     let mut cmd_rx = spawn_stdin_reader();
 
+    // --- Pre-message phase: accept AddMcpServer commands ---
+    let mut mcp_manager = mcp_manager;
+    let mut first_cmd: Option<ProtocolCommand> = None;
+
     while let Some(cmd) = cmd_rx.recv().await {
+        match cmd {
+            ProtocolCommand::AddMcpServer {
+                name,
+                transport,
+                command,
+                args,
+                env,
+                url,
+                headers,
+            } => {
+                let config =
+                    match to_mcp_server_config(&transport, command, args, env, url, headers) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            output.emit_error(&format!("AddMcpServer '{name}': {e}"));
+                            continue;
+                        }
+                    };
+
+                if mcp_manager.is_none() {
+                    match McpManager::connect_all(&HashMap::new()).await {
+                        Ok(m) => {
+                            mcp_manager = Some(Arc::new(m));
+                        }
+                        Err(e) => {
+                            output.emit_error(&format!("AddMcpServer '{name}': init failed: {e}"));
+                            continue;
+                        }
+                    }
+                }
+
+                let mgr_arc = mcp_manager.as_mut().unwrap();
+                match Arc::get_mut(mgr_arc) {
+                    Some(mgr) => match mgr.connect_one(name.clone(), &config).await {
+                        Ok(tool_names) => {
+                            let builtin_names = engine.tool_names();
+                            register_single_server_tools(
+                                engine.registry_mut(),
+                                mgr_arc,
+                                &name,
+                                &builtin_names,
+                                config.deferred.unwrap_or(true),
+                            );
+                            let _ = writer.emit(&ProtocolEvent::McpReady {
+                                name,
+                                tools: tool_names,
+                            });
+                        }
+                        Err(e) => {
+                            output.emit_error(&format!("AddMcpServer '{name}' failed: {e}"));
+                        }
+                    },
+                    None => {
+                        output.emit_error("AddMcpServer: McpManager is shared, cannot add server");
+                    }
+                }
+            }
+            ProtocolCommand::Stop => return Ok(()),
+            other => {
+                first_cmd = Some(other);
+                break;
+            }
+        }
+    }
+
+    let has_mcp = mcp_manager.is_some();
+    let mut pending_cmd = first_cmd;
+
+    loop {
+        let cmd = if let Some(c) = pending_cmd.take() {
+            c
+        } else {
+            match cmd_rx.recv().await {
+                Some(c) => c,
+                None => break,
+            }
+        };
+
         match cmd {
             ProtocolCommand::Message {
                 msg_id,
@@ -642,6 +751,11 @@ async fn run_json_stream_mode(
                     has_mcp,
                     &approval_manager.current_mode(),
                 );
+            }
+            ProtocolCommand::AddMcpServer { name, .. } => {
+                output.emit_error(&format!(
+                    "AddMcpServer '{name}': rejected — only allowed before first Message"
+                ));
             }
         }
     }

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -604,7 +604,7 @@ async fn run_json_stream_mode(
         match cmd {
             ProtocolCommand::Message {
                 msg_id,
-                input,
+                content,
                 files: _,
             } => {
                 let mut stopped = false;
@@ -612,7 +612,7 @@ async fn run_json_stream_mode(
                 let mut mode_changed = false;
 
                 {
-                    let engine_fut = engine.run(&input, &msg_id);
+                    let engine_fut = engine.run(&content, &msg_id);
                     tokio::pin!(engine_fut);
 
                     loop {

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -535,7 +535,9 @@ async fn run_json_stream_mode(
                 url,
                 headers,
             } => {
-                eprintln!("[mcp] AddMcpServer received: name={name}, transport={transport}, command={command:?}");
+                eprintln!(
+                    "[mcp] AddMcpServer received: name={name}, transport={transport}, command={command:?}"
+                );
                 let config =
                     match to_mcp_server_config(&transport, command, args, env, url, headers) {
                         Ok(c) => c,

--- a/crates/aion-mcp/src/manager.rs
+++ b/crates/aion-mcp/src/manager.rs
@@ -60,6 +60,25 @@ impl McpManager {
         })
     }
 
+    /// Connect a single additional MCP server after initial setup.
+    /// Returns the list of tool names exposed by the server.
+    pub async fn connect_one(
+        &mut self,
+        name: String,
+        config: &McpServerConfig,
+    ) -> Result<Vec<String>, McpError> {
+        let server = Self::connect_server(&name, config).await?;
+        let tool_names: Vec<String> = server.tools.iter().map(|t| t.name.clone()).collect();
+        eprintln!(
+            "[mcp] Connected to '{}': {} tools, resources={}",
+            name,
+            server.tools.len(),
+            server.supports_resources,
+        );
+        self.servers.insert(name, server);
+        Ok(tool_names)
+    }
+
     /// Connect to a single MCP server: create transport, initialize, discover tools
     async fn connect_server(name: &str, config: &McpServerConfig) -> Result<McpServer, McpError> {
         let empty_map = HashMap::new();

--- a/crates/aion-mcp/src/tool_proxy.rs
+++ b/crates/aion-mcp/src/tool_proxy.rs
@@ -155,6 +155,46 @@ pub fn register_mcp_tools(
     }
 }
 
+/// Register tools from a single newly-connected MCP server.
+/// Uses the same collision-detection logic as `register_mcp_tools`.
+pub fn register_single_server_tools(
+    registry: &mut aion_tools::registry::ToolRegistry,
+    manager: &Arc<McpManager>,
+    server_name: &str,
+    builtin_names: &[String],
+    deferred: bool,
+) {
+    let all_tools = manager.all_tools();
+    let server_tools: Vec<_> = all_tools
+        .iter()
+        .filter(|(sn, _)| *sn == server_name)
+        .collect();
+
+    for (_, tool_def) in &server_tools {
+        let original_name = &tool_def.name;
+        let collides_builtin = builtin_names.iter().any(|n| n == original_name);
+        let cross_server_collision = manager.tool_name_count(original_name) > 1;
+
+        let display_name = if collides_builtin || cross_server_collision {
+            format!("mcp__{}_{}", server_name, original_name)
+        } else {
+            original_name.clone()
+        };
+
+        let proxy = McpToolProxy::new(
+            display_name,
+            original_name.clone(),
+            server_name.to_string(),
+            tool_def.description.clone().unwrap_or_default(),
+            tool_def.input_schema.clone(),
+            Arc::clone(manager),
+            deferred,
+        );
+
+        registry.register(Box::new(proxy));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/crates/aion-protocol/src/commands.rs
+++ b/crates/aion-protocol/src/commands.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 pub enum ProtocolCommand {
     Message {
         msg_id: String,
-        input: String,
+        content: String,
         #[serde(default)]
         files: Vec<String>,
     },

--- a/crates/aion-protocol/src/commands.rs
+++ b/crates/aion-protocol/src/commands.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
+
 use serde::Deserialize;
 
 /// Commands sent from the client to the agent (Client -> Agent)
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum ProtocolCommand {
@@ -37,6 +39,20 @@ pub enum ProtocolCommand {
         thinking_budget: Option<u32>,
         #[serde(default)]
         effort: Option<String>,
+    },
+    AddMcpServer {
+        name: String,
+        transport: String,
+        #[serde(default)]
+        command: Option<String>,
+        #[serde(default)]
+        args: Option<Vec<String>>,
+        #[serde(default)]
+        env: Option<HashMap<String, String>>,
+        #[serde(default)]
+        url: Option<String>,
+        #[serde(default)]
+        headers: Option<HashMap<String, String>>,
     },
 }
 
@@ -125,5 +141,67 @@ mod tests {
         };
         let dbg = format!("{cmd:?}");
         assert!(dbg.contains("SetConfig"));
+    }
+
+    #[test]
+    fn add_mcp_server_stdio_deserialize() {
+        let json = r#"{
+            "type": "add_mcp_server",
+            "name": "team-tools",
+            "transport": "stdio",
+            "command": "node",
+            "args": ["bridge.js", "--port", "9000"],
+            "env": {"TOKEN": "abc123"}
+        }"#;
+        let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+        match cmd {
+            ProtocolCommand::AddMcpServer {
+                name,
+                transport,
+                command,
+                args,
+                env,
+                url,
+                headers,
+            } => {
+                assert_eq!(name, "team-tools");
+                assert_eq!(transport, "stdio");
+                assert_eq!(command.unwrap(), "node");
+                assert_eq!(args.unwrap(), vec!["bridge.js", "--port", "9000"]);
+                assert_eq!(env.unwrap().get("TOKEN").unwrap(), "abc123");
+                assert!(url.is_none());
+                assert!(headers.is_none());
+            }
+            _ => panic!("expected AddMcpServer"),
+        }
+    }
+
+    #[test]
+    fn add_mcp_server_sse_deserialize() {
+        let json = r#"{
+            "type": "add_mcp_server",
+            "name": "remote-tools",
+            "transport": "sse",
+            "url": "http://localhost:8080/sse",
+            "headers": {"Authorization": "Bearer tok"}
+        }"#;
+        let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+        match cmd {
+            ProtocolCommand::AddMcpServer {
+                name,
+                transport,
+                command,
+                url,
+                headers,
+                ..
+            } => {
+                assert_eq!(name, "remote-tools");
+                assert_eq!(transport, "sse");
+                assert!(command.is_none());
+                assert_eq!(url.unwrap(), "http://localhost:8080/sse");
+                assert_eq!(headers.unwrap().get("Authorization").unwrap(), "Bearer tok");
+            }
+            _ => panic!("expected AddMcpServer"),
+        }
     }
 }

--- a/crates/aion-protocol/src/events.rs
+++ b/crates/aion-protocol/src/events.rs
@@ -65,6 +65,10 @@ pub enum ProtocolEvent {
     ConfigChanged {
         capabilities: Capabilities,
     },
+    McpReady {
+        name: String,
+        tools: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -289,6 +293,20 @@ mod tests {
         assert_eq!(json["capabilities"]["effort"], true);
         assert_eq!(json["capabilities"]["effort_levels"][0], "low");
         assert_eq!(json["capabilities"]["modes"][2], "yolo");
+    }
+
+    #[test]
+    fn test_mcp_ready_event_serialization() {
+        let event = ProtocolEvent::McpReady {
+            name: "team-tools".to_string(),
+            tools: vec!["team_send_message".into(), "team_task_create".into()],
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "mcp_ready");
+        assert_eq!(json["name"], "team-tools");
+        assert_eq!(json["tools"][0], "team_send_message");
+        assert_eq!(json["tools"][1], "team_task_create");
+        assert_eq!(json["tools"].as_array().unwrap().len(), 2);
     }
 
     #[test]

--- a/crates/aion-protocol/tests/commands_test.rs
+++ b/crates/aion-protocol/tests/commands_test.rs
@@ -3,18 +3,18 @@ use rstest::rstest;
 
 #[rstest]
 #[case(
-    r#"{"type":"message","msg_id":"m1","input":"Hello"}"#,
+    r#"{"type":"message","msg_id":"m1","content":"Hello"}"#,
     ProtocolCommand::Message {
         msg_id: "m1".to_string(),
-        input: "Hello".to_string(),
+        content: "Hello".to_string(),
         files: vec![],
     }
 )]
 #[case(
-    r#"{"type":"message","msg_id":"m2","input":"Read this","files":["/tmp/a.rs"]}"#,
+    r#"{"type":"message","msg_id":"m2","content":"Read this","files":["/tmp/a.rs"]}"#,
     ProtocolCommand::Message {
         msg_id: "m2".to_string(),
-        input: "Read this".to_string(),
+        content: "Read this".to_string(),
         files: vec!["/tmp/a.rs".to_string()],
     }
 )]

--- a/crates/aion-protocol/tests/set_config.rs
+++ b/crates/aion-protocol/tests/set_config.rs
@@ -51,7 +51,7 @@ fn parse_set_config_unknown_fields_ignored() {
 #[test]
 fn existing_commands_still_parse() {
     // AC-7: Verify SetConfig addition doesn't break existing variants
-    let message = r#"{"type":"message","msg_id":"m1","input":"hello"}"#;
+    let message = r#"{"type":"message","msg_id":"m1","content":"hello"}"#;
     assert!(serde_json::from_str::<ProtocolCommand>(message).is_ok());
 
     let stop = r#"{"type":"stop"}"#;

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -136,12 +136,6 @@ impl OpenAIProvider {
                         .join("");
                     let text = strip_patterns_from_text(&text, compat);
 
-                    if !text.is_empty() {
-                        msg_json["content"] = json!(text);
-                    } else {
-                        msg_json["content"] = Value::Null;
-                    }
-
                     let tool_calls: Vec<Value> = msg
                         .content
                         .iter()
@@ -160,6 +154,12 @@ impl OpenAIProvider {
                             }
                         })
                         .collect();
+
+                    if !text.is_empty() {
+                        msg_json["content"] = json!(text);
+                    } else if tool_calls.is_empty() {
+                        msg_json["content"] = json!("");
+                    }
 
                     if !tool_calls.is_empty() {
                         msg_json["tool_calls"] = json!(tool_calls);


### PR DESCRIPTION
## Summary

- Add `AddMcpServer` protocol command and `McpReady` event for dynamic MCP server injection before first message
- Handle pre-message phase in JSON stream mode: accept `AddMcpServer` commands, connect each as an independent `McpManager` instance (avoids `Arc::get_mut` failure when tool proxies hold shared references)
- Add `connect_one()` to McpManager and `register_single_server_tools()` for registering tools from a single dynamically added server
- Rename protocol `Message.input` to `Message.content` for ACP consistency
- Fix OpenAI provider: omit `content` field for assistant messages with `tool_calls` instead of setting `null` (some providers reject `content: null`)

## Test plan

- [ ] Verify `cargo fmt --all -- --check` passes
- [ ] Verify `cargo clippy` passes with no warnings
- [ ] Verify `cargo test` passes
- [ ] Create a team in AionUi with aionrs as leader, confirm MCP injection succeeds (McpReady event in logs)
- [ ] Send message to aionrs team member, verify no `content: null` API error on second turn
- [ ] Verify solo aionrs chat still works correctly with `content` field