### PR TITLE
docs: sync documentation with v0.1.8–v0.1.12 code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ A Rust-based LLM tool-use agent for the command line. It connects to LLM APIs, a
 - **Reasoning model support** — OpenAI `o1`/`o3` reasoning models with `reasoning_effort` control
 - **7 built-in tools** — Read, Write, Edit, Bash, Grep, Glob, Spawn (sub-agents)
 - **MCP client** — Connect to any [Model Context Protocol](https://modelcontextprotocol.io/) server (stdio / SSE / streamable-http)
+- **Dynamic MCP injection** — Host clients can inject MCP servers at runtime via the [JSON stream protocol](docs/json-stream-protocol.md)
 - **Skills** — Named prompt snippets with variable substitution, shell expansion, conditional activation, and per-skill model/permission overrides (see [docs/skills.md](docs/skills.md))
 - **Hook system** — Event-driven automation on tool lifecycle (auto-format, lint, audit)
 - **Sub-agent spawning** — Parallel task execution via the Spawn tool
 - **Session persistence** — Save and resume conversation history
+- **Persistent memory** — Project-specific memory with auto-indexing across sessions (see [docs/advanced.md](docs/advanced.md#memory-system))
+- **Plan mode** — Read-only exploration mode for designing implementation plans before coding (see [docs/advanced.md](docs/advanced.md#plan-mode))
+- **Context compression** — Three-tier automatic compaction: microcompact, autocompact, emergency (see [docs/advanced.md](docs/advanced.md#context-compression))
+- **Output compaction** — Configurable output compression (off/safe/full) with TOON encoding (see [docs/advanced.md](docs/advanced.md#output-compaction))
+- **File state cache** — LRU cache with read deduplication and write tracking
 - **Prompt caching** — Anthropic cache_control for up to 90% cost reduction
 - **Profile inheritance** — Named profiles with `extends` for quick provider/model switching
 - **OAuth login** — Use Claude.ai subscription directly, no API key needed
@@ -49,12 +55,17 @@ aionrs --help
 ├──────────────────┼───────────────────────┼───────────────────┤
 │  Providers       │  Tool Registry        │  Hook Executor    │
 │  ├ Anthropic     │  ├ Built-in (7)       │  ├ pre_tool_use   │
-│  ├ OpenAI        │  └ MCP tools (N)      │  ├ post_tool_use  │
-│  ├ Bedrock       │                       │  └ stop           │
-│  └ Vertex AI     │  MCP Client           │                   │
-│                  │  ├ Stdio transport    │  Sub-Agent        │
-│  ProviderCompat  │  ├ SSE transport      │  Spawner          │
-│  (compat layer)  │  └ HTTP transport     │                   │
+│  ├ OpenAI        │  ├ MCP tools (N)      │  ├ post_tool_use  │
+│  ├ Bedrock       │  └ Plan Mode tools    │  └ stop           │
+│  └ Vertex AI     │                       │                   │
+│                  │  MCP Client           │  Memory System    │
+│  ProviderCompat  │  ├ Stdio transport    │  (per-project)    │
+│  (compat layer)  │  ├ SSE transport      │                   │
+│                  │  └ HTTP transport     │  Sub-Agent        │
+│  Compact Engine  │                       │  Spawner          │
+│  ├ Microcompact  │  File State Cache     │                   │
+│  ├ Autocompact   │  (LRU)               │  Output Compactor │
+│  └ Emergency     │                       │  (off/safe/full)  │
 └──────────────────┴───────────────────────┴───────────────────┘
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,5 +6,6 @@
 - **[Built-in Tools](tools.md)** — Read, Write, Edit, Bash, Grep, Glob, Spawn — detailed reference and concurrency notes
 - **[MCP Integration](mcp.md)** — Model Context Protocol client: stdio, SSE, and streamable-http transports
 - **[Providers & Auth](providers.md)** — Multi-provider configuration, profile inheritance, AWS Bedrock, Google Vertex AI, OAuth login
-- **[Advanced Features](advanced.md)** — Sub-agent spawning, hook system, prompt caching, VCR recording/replay, AGENTS.md auto-loading
+- **[Advanced Features](advanced.md)** — Sub-agent spawning, hook system, prompt caching, VCR recording/replay, AGENTS.md auto-loading, memory system, plan mode, context compression, file state cache, output compaction
+- **[JSON Stream Protocol](json-stream-protocol.md)** — Host integration protocol specification (`--json-stream` mode)
 - **[Troubleshooting](troubleshooting.md)** — Common errors, diagnostics, and solutions

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -146,3 +146,188 @@ If an `AGENTS.md` file exists in the current working directory, its contents are
 - Project-specific coding standards
 - Architecture descriptions
 - Special working constraints
+
+---
+
+## Memory System
+
+Persistent, file-based memory that allows the agent to retain project-specific knowledge across sessions. Memory is automatically loaded into the system prompt at conversation start.
+
+### Memory Types
+
+| Type | Purpose |
+|------|---------|
+| `user` | User's role, goals, preferences, knowledge |
+| `feedback` | Corrections and confirmations on work approach |
+| `project` | Ongoing work context not derivable from code/git |
+| `reference` | Pointers to external systems and resources |
+
+### Storage
+
+Memory files live in a per-project directory under the global config:
+
+```
+<config_dir>/aionrs/projects/<sanitized-project-path>/memory/
+├── MEMORY.md              # Index (auto-loaded into prompt, max 200 lines)
+├── user_role.md
+├── feedback_testing.md
+└── project_auth_rewrite.md
+```
+
+Each memory file uses YAML frontmatter:
+
+```markdown
+---
+name: auth rewrite
+description: Auth middleware rewrite driven by compliance
+type: project
+---
+
+Auth middleware rewrite is driven by legal/compliance requirements.
+```
+
+### Configuration
+
+Memory is enabled by default with no configuration required. The memory directory is auto-resolved from the current working directory.
+
+Override the base directory via environment variable:
+
+```bash
+export AIONRS_MEMORY_DIR=/custom/path
+```
+
+### How It Works
+
+1. Agent starts → memory directory resolved from project path
+2. `MEMORY.md` index loaded into system prompt (truncated at 200 lines / 25 KB)
+3. Agent reads/writes memory files using standard Read/Write tools
+4. Agent maintains the `MEMORY.md` index as memories are added or removed
+
+---
+
+## Plan Mode
+
+A read-only exploration mode where the agent focuses on understanding the codebase and producing an implementation plan before making any changes.
+
+### How It Works
+
+1. Agent calls `EnterPlanMode` → tool access restricted to read-only (Read, Grep, Glob)
+2. Agent explores code, designs approach, writes a structured plan in its response
+3. Agent calls `ExitPlanMode` → full tool access restored, plan optionally saved to disk
+
+### Configuration
+
+```toml
+[plan]
+enabled = true                    # Register Plan Mode tools (default: true)
+plan_directory = ".aionrs/plans"  # Where plan files are saved
+```
+
+### Workflow Phases
+
+When in plan mode, the agent follows a structured 4-phase process:
+
+1. **Understand** — Explore the codebase with read-only tools
+2. **Design** — Identify files to modify, code to reuse
+3. **Write the plan** — Compose a clear, actionable implementation plan
+4. **Submit** — Call `ExitPlanMode` to restore full tool access
+
+---
+
+## Context Compression
+
+A three-tier automatic compaction strategy that prevents context window overflow during long conversations.
+
+### Tiers
+
+| Tier | Trigger | Method | LLM Call |
+|------|---------|--------|----------|
+| **Microcompact** | Tool result count exceeds threshold or time gap | Clears old tool result content, keeping the N most recent | No |
+| **Autocompact** | Input tokens approach context limit | LLM summarizes the conversation | Yes |
+| **Emergency** | Input tokens near absolute limit | Blocks further API calls, asks user to start fresh | No |
+
+### How It Works
+
+- **Microcompact** runs automatically: replaces old Read/Bash/Grep/Glob/Write/Edit results with `[Tool result cleared]`, keeping the 5 most recent results intact. Triggered by count (>10 compactable results) or time (>1 hour since last assistant message).
+
+- **Autocompact** triggers when input tokens reach `context_window - output_reserve - autocompact_buffer` (default: 200,000 - 20,000 - 13,000 = 167,000 tokens). The agent calls the LLM to produce a conversation summary, then replaces history with a compact boundary marker. A circuit breaker stops retrying after 3 consecutive failures.
+
+- **Emergency** is the last safety net at `context_window - emergency_buffer` (default: 197,000 tokens). Always active regardless of config. Blocks API calls and prompts the user to compact or start a new conversation.
+
+### Configuration
+
+```toml
+[compact]
+enabled = true              # Enable compaction system (default: true)
+context_window = 200000     # Context window in tokens
+output_reserve = 20000      # Reserved for output generation
+autocompact_buffer = 13000  # Buffer before autocompact triggers
+emergency_buffer = 3000     # Buffer before emergency block
+max_failures = 3            # Circuit breaker threshold
+micro_keep_recent = 5       # Keep N most recent tool results
+```
+
+---
+
+## File State Cache
+
+An LRU cache that tracks files the agent has recently accessed, enabling read deduplication and automatic cache updates on writes.
+
+- **Read dedup**: When the agent reads a file it has already seen (and the file hasn't changed), the cache provides the content without re-reading from disk.
+- **Write/Edit auto-update**: After Write or Edit operations, the cache is updated immediately with the new content.
+- **Dual eviction**: Entries are evicted when either the entry count limit or the total byte size limit is reached.
+
+### Configuration
+
+```toml
+[file_cache]
+enabled = true                # Enable file state caching (default: true)
+max_entries = 100             # Maximum cached files
+max_size_bytes = 26214400     # Max total cache size (25 MB)
+```
+
+---
+
+## Output Compaction
+
+Post-processes tool output to reduce token usage. Three levels from lightest to heaviest:
+
+| Level | Transformations |
+|-------|----------------|
+| `off` | No transformation |
+| `safe` (default) | Strip ANSI escape codes, merge consecutive blank lines, collapse carriage-return progress bars |
+| `full` | Everything in `safe`, plus: fold repeated lines, compact JSON indentation |
+
+### TOON Encoding
+
+When enabled alongside `full` compaction, TOON (Token-Oriented Object Notation) encodes uniform JSON arrays as compact tables:
+
+```
+[2]{id,name,role}:
+  1,Alice,admin
+  2,Bob,user
+```
+
+This is equivalent to:
+
+```json
+[{"id":1,"name":"Alice","role":"admin"},{"id":2,"name":"Bob","role":"user"}]
+```
+
+TOON instructions are injected into the system prompt so the LLM understands the format.
+
+### Configuration
+
+```toml
+[compact]
+compaction = "safe"   # off | safe | full (default: safe)
+toon = false          # Enable TOON encoding (default: false)
+```
+
+### Runtime Control
+
+In `--json-stream` mode, the compaction level can be changed at runtime via `set_config`:
+
+```json
+{"type": "set_config", "compaction": "full"}
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,6 +21,19 @@ aionrs [OPTIONS] [PROMPT]...
 
 > For the full list of CLI parameters, run `aionrs --help`.
 
+### Key Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--provider <name>` | Provider: `anthropic`, `openai`, `bedrock`, `vertex`, or a custom alias |
+| `--model <id>` | Model name |
+| `--profile <name>` | Named profile from config file |
+| `--compaction <level>` | Output compaction: `off`, `safe` (default), `full` |
+| `--toon` | Enable TOON tabular encoding (with `full` compaction) |
+| `--auto-approve` | Skip all tool confirmations |
+| `--json-stream` | JSON Lines mode for host integration |
+| `--resume <id>` | Resume a previous session |
+
 ---
 
 ## Configuration
@@ -92,6 +105,18 @@ allow_list = ["Read", "Grep", "Glob"]
 enabled = true
 directory = ".aionrs/sessions"
 max_sessions = 20
+
+[compact]
+compaction = "safe"   # off | safe | full
+toon = false          # Enable TOON encoding for JSON arrays
+
+[file_cache]
+enabled = true
+max_entries = 100
+
+[plan]
+enabled = true
+plan_directory = ".aionrs/plans"
 ```
 
 ### API Key Resolution Order

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -38,6 +38,7 @@ Emitted once after initialization completes. Client MUST wait for this before se
     "effort": false,
     "effort_levels": [],
     "modes": ["default", "auto_edit", "yolo"],
+    "current_mode": "default",
     "mcp": true
   }
 }
@@ -52,6 +53,7 @@ Emitted once after initialization completes. Client MUST wait for this before se
 | `capabilities.effort` | bool | Whether current provider supports reasoning_effort |
 | `capabilities.effort_levels` | string[] | Valid effort values (e.g., `["low", "medium", "high"]`). Empty when effort is false |
 | `capabilities.modes` | string[] | Available approval modes for `set_mode` command |
+| `capabilities.current_mode` | string | Currently active approval mode |
 | `capabilities.mcp` | bool | Whether MCP tools are available |
 
 ### 1.2 `stream_start`
@@ -264,12 +266,30 @@ Emitted after a `set_config` command is processed. Contains the updated capabili
     "effort": true,
     "effort_levels": ["low", "medium", "high"],
     "modes": ["default", "auto_edit", "yolo"],
+    "current_mode": "default",
     "mcp": true
   }
 }
 ```
 
 Clients should update their UI controls (e.g., enable/disable thinking toggle, populate effort dropdown) based on the new capabilities.
+
+### 1.13 `mcp_ready`
+
+Emitted after a dynamically injected MCP server has connected and its tools are registered.
+
+```json
+{
+  "type": "mcp_ready",
+  "name": "my-tools",
+  "tools": ["tool_a", "tool_b"]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Server name (as provided in `add_mcp_server`) |
+| `tools` | string[] | List of tool names registered from this server |
 
 ## 2. Client → Agent Commands (stdin)
 
@@ -283,7 +303,7 @@ Send a user message. Agent responds with a stream of events.
 {
   "type": "message",
   "msg_id": "abc-123",
-  "input": "Read the file src/main.rs and explain the code",
+  "content": "Read the file src/main.rs and explain the code",
   "files": ["/path/to/attached/file.png"]
 }
 ```
@@ -291,7 +311,7 @@ Send a user message. Agent responds with a stream of events.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `msg_id` | string | yes | Client-generated unique message ID |
-| `input` | string | yes | User's message text |
+| `content` | string | yes | User's message text |
 | `files` | string[] | no | Attached file paths (images, documents) |
 
 ### 2.2 `stop`
@@ -385,7 +405,8 @@ Update model, thinking, or effort configuration at runtime.
   "model": "claude-opus-4",
   "thinking": "enabled",
   "thinking_budget": 16000,
-  "effort": "high"
+  "effort": "high",
+  "compaction": "safe"
 }
 ```
 
@@ -395,10 +416,59 @@ Update model, thinking, or effort configuration at runtime.
 | `thinking` | string | no | `"enabled"` or `"disabled"` |
 | `thinking_budget` | number | no | Token budget for thinking (default: 10000) |
 | `effort` | string | no | Reasoning effort level (e.g., `"low"`, `"medium"`, `"high"`) |
+| `compaction` | string | no | Output compaction level: `"off"`, `"safe"`, `"full"` |
 
 All fields are optional. Only provided fields are updated.
 
 > **Validation**: The agent validates `thinking` and `effort` values against the current provider's capabilities. If the provider does not support a feature, the change is rejected with a descriptive message in the `info` event. After processing, a `config_changed` event is always emitted with the updated capabilities.
+
+### 2.8 `add_mcp_server`
+
+Dynamically inject an MCP server before the conversation starts. This command is only accepted during the **pre-message phase** — after the `ready` event and before the first `message` command. Any `add_mcp_server` sent after the first `message` is rejected with an error.
+
+```json
+{
+  "type": "add_mcp_server",
+  "name": "my-tools",
+  "transport": "stdio",
+  "command": "node",
+  "args": ["bridge.js", "--port", "9000"],
+  "env": {"TOKEN": "abc123"}
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Unique server name |
+| `transport` | string | yes | `"stdio"`, `"sse"`, or `"streamable-http"` |
+| `command` | string | stdio only | Executable to launch |
+| `args` | string[] | no | Command arguments |
+| `env` | object | no | Environment variables for the subprocess |
+| `url` | string | sse/http only | Server URL |
+| `headers` | object | no | HTTP headers (for sse/http) |
+
+**Lifecycle:**
+
+```
+Agent  → stdout: {"type":"ready",...}
+Client → stdin:  {"type":"add_mcp_server","name":"tools","transport":"stdio","command":"node","args":["bridge.js"]}
+Agent  → stdout: {"type":"mcp_ready","name":"tools","tools":["tool_a","tool_b"]}
+Client → stdin:  {"type":"message","msg_id":"m1","content":"Hello"}
+                  ↑ first message ends the injection window
+```
+
+After the first `message`, any further `add_mcp_server` commands are rejected:
+
+```json
+{
+  "type": "error",
+  "error": {
+    "code": "protocol_error",
+    "message": "AddMcpServer 'name': rejected — only allowed before first Message",
+    "retryable": false
+  }
+}
+```
 
 ## 3. Lifecycle
 
@@ -419,6 +489,10 @@ Environment variables set by client:
 Agent initializes → stdout: {"type":"ready","session_id":"a1b2c3",...}
 ```
 
+**Pre-message phase (optional):**
+
+Between receiving `ready` and sending the first `message`, the client may inject MCP servers via `add_mcp_server` commands. The agent connects each server and emits `mcp_ready` when ready. This phase ends when the first `message` is sent.
+
 **Session lifecycle flags** (mutually exclusive):
 
 | Flag | Description |
@@ -437,7 +511,7 @@ aionrs --json-stream --resume my-conv-123 --provider openai --model gpt-4o
 ### 3.2 Message Turn
 
 ```
-Client → stdin:  {"type":"message","msg_id":"m1","input":"Hello"}
+Client → stdin:  {"type":"message","msg_id":"m1","content":"Hello"}
 Agent  → stdout: {"type":"stream_start","msg_id":"m1"}
 Agent  → stdout: {"type":"text_delta","text":"Hi! ","msg_id":"m1"}
 Agent  → stdout: {"type":"text_delta","text":"How can I help?","msg_id":"m1"}
@@ -447,7 +521,7 @@ Agent  → stdout: {"type":"stream_end","msg_id":"m1","usage":{...}}
 ### 3.3 Tool Approval Flow
 
 ```
-Client → stdin:  {"type":"message","msg_id":"m2","input":"Create a hello.rs file"}
+Client → stdin:  {"type":"message","msg_id":"m2","content":"Create a hello.rs file"}
 Agent  → stdout: {"type":"stream_start","msg_id":"m2"}
 Agent  → stdout: {"type":"text_delta","text":"I'll create the file.","msg_id":"m2"}
 Agent  → stdout: {"type":"tool_request","msg_id":"m2","call_id":"t1","tool":{"name":"Write","category":"edit",...}}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -41,6 +41,25 @@ headers = { Authorization = "Bearer xxx" }
 | `sse` | GET for SSE event stream, POST for requests | Remote MCP servers |
 | `streamable-http` | HTTP POST, supports SSE streaming responses | Remote MCP servers |
 
+## Deferred Loading
+
+MCP tools can be registered as "deferred" — their full schema is not loaded into the system prompt at startup, reducing initial token usage. The LLM discovers deferred tools via the `ToolSearch` tool when needed.
+
+```toml
+[mcp.servers.large-toolset]
+transport = "stdio"
+command = "npx"
+args = ["-y", "my-mcp-server"]
+deferred = true    # Don't load tool schemas at startup
+```
+
+| `deferred` | Behavior |
+|------------|----------|
+| `false` (default for config servers) | Tool schemas included in system prompt at startup |
+| `true` | Tools registered but schemas loaded on-demand via ToolSearch |
+
+Use `deferred = true` for MCP servers with many tools to keep the initial system prompt small.
+
 ## Tool Naming
 
 - MCP tool names are used directly when there's no conflict

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,6 +11,7 @@ The agent has 7 built-in tools. The LLM automatically selects and invokes them b
 | **Grep** | Regex search file contents (via ripgrep) | Yes |
 | **Glob** | Find files by pattern matching | Yes |
 | **Spawn** | Spawn sub-agents for parallel tasks | No |
+| **ToolSearch** | Load schemas for deferred tools | Yes |
 
 ---
 
@@ -64,6 +65,14 @@ Find files matching a glob pattern.
 
 See [Sub-Agent Spawning](advanced.md#sub-agent-spawning) in the Advanced Features guide.
 
+## ToolSearch
+
+Load full schemas for deferred tools so the LLM can invoke them. Deferred tools (from MCP servers with `deferred = true`) are registered by name only — their parameter schemas are not loaded until the LLM calls ToolSearch.
+
+- Query by exact name: `"select:Read,Edit,Grep"`
+- Keyword search: `"slack send"` returns best matches
+- Returns up to 5 results by default
+
 ---
 
 ## How It Works
@@ -80,3 +89,8 @@ User input → Build request (system prompt + history + tool definitions)
 - Concurrent-safe tools (Read, Grep, Glob) execute in parallel
 - Non-concurrent tools (Write, Edit, Bash) execute sequentially
 - Tool output is auto-truncated to prevent context window overflow
+- Tool output can be compacted (see [Output Compaction](advanced.md#output-compaction))
+
+## Tool Descriptions
+
+Each built-in tool includes a detailed description and usage guidance that is injected into the system prompt. These descriptions help the LLM select the right tool and use it effectively — for example, preferring Grep over Bash for content search, or using Edit instead of Write for modifications.


### PR DESCRIPTION
## Summary

- Update `docs/json-stream-protocol.md`: fix `message` field name (`input` → `content`), add `current_mode` to capabilities, add `compaction` to `set_config`, document `add_mcp_server` command and `mcp_ready` event with pre-message phase
- Update `docs/advanced.md`: add Memory System, Plan Mode, Context Compression, File State Cache, and Output Compaction sections
- Update `docs/getting-started.md`: add `--compaction`/`--toon` CLI params and `[compact]`/`[file_cache]`/`[plan]` config sections
- Update `README.md`: add 6 new features to list, update architecture diagram with new components
- Update `docs/mcp.md`: document `deferred` field for lazy tool schema loading
- Update `docs/tools.md`: add ToolSearch tool reference and enhanced descriptions note
- Update `docs/README.md`: expand Advanced Features description, add JSON Stream Protocol entry

## Test plan

- [ ] All documentation field names, default values, and config section names verified against source code
- [ ] Markdown renders correctly (no broken links or formatting)
- [ ] CI passes (docs-only, no code changes)