### PR TITLE
feat: hierarchical AGENTS.md loading with @include support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Rust-based LLM tool-use agent for the command line. It connects to LLM APIs, a
 - **Prompt caching** — Anthropic cache_control for up to 90% cost reduction
 - **Profile inheritance** — Named profiles with `extends` for quick provider/model switching
 - **OAuth login** — Use Claude.ai subscription directly, no API key needed
-- **AGENTS.md injection** — Auto-load project-specific system prompts
+- **AGENTS.md injection** — Hierarchical loading of project instructions with @include support
 
 ## Quick Start
 

--- a/crates/aion-agent/Cargo.toml
+++ b/crates/aion-agent/Cargo.toml
@@ -26,6 +26,7 @@ anyhow.workspace      = true
 thiserror.workspace   = true
 glob.workspace        = true
 chrono.workspace      = true
+dirs.workspace        = true
 crossterm.workspace   = true
 is-terminal.workspace = true
 

--- a/crates/aion-agent/src/agents_md.rs
+++ b/crates/aion-agent/src/agents_md.rs
@@ -35,10 +35,10 @@ pub fn collect_agents_md(cwd: &str) -> Vec<AgentsMdFile> {
     let mut files = Vec::new();
 
     // 1. Global: <config_dir>/aionrs/AGENTS.md
-    if let Some(global_path) = app_config_dir().map(|d| d.join("AGENTS.md")) {
-        if let Some(file) = read_agents_md(&global_path, true) {
-            files.push(file);
-        }
+    if let Some(global_path) = app_config_dir().map(|d| d.join("AGENTS.md"))
+        && let Some(file) = read_agents_md(&global_path, true)
+    {
+        files.push(file);
     }
 
     // 2. Walk up from cwd to stop_boundary, collect AGENTS.md paths

--- a/crates/aion-agent/src/agents_md.rs
+++ b/crates/aion-agent/src/agents_md.rs
@@ -1,0 +1,490 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use aion_config::config::app_config_dir;
+use aion_skills::paths::stop_boundary;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+pub struct AgentsMdFile {
+    pub path: PathBuf,
+    pub content: String,
+    pub is_global: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_INCLUDE_DEPTH: u8 = 5;
+
+const ALLOWED_EXTENSIONS: &[&str] = &[".md", ".txt", ".json", ".yaml", ".yml", ".toml"];
+
+const INSTRUCTION_PREAMBLE: &str = "Codebase and user instructions are shown below. \
+Be sure to adhere to these instructions. IMPORTANT: These instructions OVERRIDE any \
+default behavior and you MUST follow them exactly as written.";
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+pub fn collect_agents_md(cwd: &str) -> Vec<AgentsMdFile> {
+    let cwd_path = Path::new(cwd);
+    let mut files = Vec::new();
+
+    // 1. Global: <config_dir>/aionrs/AGENTS.md
+    if let Some(global_path) = app_config_dir().map(|d| d.join("AGENTS.md")) {
+        if let Some(file) = read_agents_md(&global_path, true) {
+            files.push(file);
+        }
+    }
+
+    // 2. Walk up from cwd to stop_boundary, collect AGENTS.md paths
+    let boundary = stop_boundary(cwd_path);
+    let mut project_paths = Vec::new();
+    let mut current = cwd_path.to_path_buf();
+
+    loop {
+        let candidate = current.join("AGENTS.md");
+        if candidate.is_file() {
+            project_paths.push(candidate);
+        }
+
+        if Some(&current) == boundary.as_ref() || current.parent().is_none() {
+            break;
+        }
+
+        match current.parent() {
+            Some(parent) if parent != current.as_path() => {
+                current = parent.to_path_buf();
+            }
+            _ => break,
+        }
+    }
+
+    // Reverse: collected deepest-first, we want root-first
+    project_paths.reverse();
+
+    for path in project_paths {
+        if let Some(file) = read_agents_md(&path, false) {
+            files.push(file);
+        }
+    }
+
+    files
+}
+
+fn read_agents_md(path: &Path, is_global: bool) -> Option<AgentsMdFile> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    if raw.trim().is_empty() {
+        return None;
+    }
+    let base_dir = path.parent()?;
+    let mut seen = HashSet::new();
+    if let Ok(canonical) = path.canonicalize() {
+        seen.insert(canonical);
+    }
+    let content = expand_includes(&raw, base_dir, 0, &mut seen);
+    Some(AgentsMdFile {
+        path: path.to_path_buf(),
+        content,
+        is_global,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+pub fn format_agents_md_section(files: &[AgentsMdFile]) -> String {
+    if files.is_empty() {
+        return String::new();
+    }
+
+    let mut parts = vec![INSTRUCTION_PREAMBLE.to_string()];
+
+    for file in files {
+        let description = if file.is_global {
+            "(user's global instructions for all projects)"
+        } else {
+            "(project instructions)"
+        };
+        let header = format!("Contents of {} {}:", file.path.display(), description);
+        parts.push(format!("{header}\n\n{}", file.content.trim()));
+    }
+
+    parts.join("\n\n")
+}
+
+// ---------------------------------------------------------------------------
+// @include expansion
+// ---------------------------------------------------------------------------
+
+fn is_allowed_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| {
+            let dotted = format!(".{e}");
+            ALLOWED_EXTENSIONS.contains(&dotted.as_str())
+        })
+        .unwrap_or(false)
+}
+
+fn resolve_include_path(raw: &str, base_dir: &Path) -> Option<PathBuf> {
+    let path_str = raw.trim();
+    if path_str.is_empty() {
+        return None;
+    }
+
+    let resolved = if let Some(rest) = path_str.strip_prefix("~/") {
+        dirs::home_dir()?.join(rest)
+    } else if let Some(rest) = path_str.strip_prefix("./") {
+        base_dir.join(rest)
+    } else if path_str.starts_with('/') {
+        PathBuf::from(path_str)
+    } else {
+        base_dir.join(path_str)
+    };
+
+    Some(resolved)
+}
+
+fn expand_includes(
+    content: &str,
+    base_dir: &Path,
+    depth: u8,
+    seen: &mut HashSet<PathBuf>,
+) -> String {
+    let mut result = Vec::new();
+    let mut in_code_block = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            in_code_block = !in_code_block;
+            result.push(line.to_string());
+            continue;
+        }
+
+        if in_code_block {
+            result.push(line.to_string());
+            continue;
+        }
+
+        let standalone = line.trim();
+        if standalone.starts_with('@') && !standalone.contains('`') {
+            let path_str = &standalone[1..];
+            // Strip fragment identifiers
+            let path_str = match path_str.find('#') {
+                Some(i) => &path_str[..i],
+                None => path_str,
+            };
+
+            if let Some(resolved) = resolve_include_path(path_str, base_dir) {
+                if !is_allowed_extension(&resolved) {
+                    continue;
+                }
+                let canonical = resolved.canonicalize().unwrap_or_else(|_| resolved.clone());
+                if seen.contains(&canonical) || depth >= MAX_INCLUDE_DEPTH {
+                    continue;
+                }
+                if let Ok(included) = std::fs::read_to_string(&resolved) {
+                    seen.insert(canonical);
+                    let expanded = expand_includes(
+                        &included,
+                        resolved.parent().unwrap_or(base_dir),
+                        depth + 1,
+                        seen,
+                    );
+                    result.push(expanded);
+                }
+                continue;
+            }
+        }
+
+        result.push(line.to_string());
+    }
+
+    result.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // --- @include expansion tests ---
+
+    #[test]
+    fn test_no_includes_passthrough() {
+        let tmp = TempDir::new().unwrap();
+        let mut seen = HashSet::new();
+        let input = "Hello world\nNo includes here.";
+        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_simple_include() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("other.md"), "INCLUDED_CONTENT").unwrap();
+        let mut seen = HashSet::new();
+        let input = "@other.md";
+        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        assert!(result.contains("INCLUDED_CONTENT"));
+        assert!(!result.contains("@other.md"));
+    }
+
+    #[test]
+    fn test_include_relative_dot() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("sub.md"), "SUB_CONTENT").unwrap();
+        let mut seen = HashSet::new();
+        let input = "@./sub.md";
+        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        assert!(result.contains("SUB_CONTENT"));
+    }
+
+    #[test]
+    fn test_include_inside_code_block_ignored() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("skip.md"), "SHOULD_NOT_APPEAR").unwrap();
+        let mut seen = HashSet::new();
+        let input = "```\n@skip.md\n```";
+        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        assert!(!result.contains("SHOULD_NOT_APPEAR"));
+        assert!(result.contains("@skip.md"));
+    }
+
+    #[test]
+    fn test_include_missing_file_silently_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let mut seen = HashSet::new();
+        let input = "before\n@nonexistent.md\nafter";
+        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        assert!(result.contains("before"));
+        assert!(result.contains("after"));
+        assert!(!result.contains("@nonexistent.md"));
+    }
+
+    #[test]
+    fn test_include_circular_reference() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("a.md"), "A_CONTENT\n@b.md").unwrap();
+        fs::write(tmp.path().join("b.md"), "B_CONTENT\n@a.md").unwrap();
+        let mut seen = HashSet::new();
+        let result = expand_includes("@a.md", tmp.path(), 0, &mut seen);
+        assert!(result.contains("A_CONTENT"));
+        assert!(result.contains("B_CONTENT"));
+        // @a.md in b.md should be skipped (circular)
+    }
+
+    #[test]
+    fn test_include_max_depth() {
+        let tmp = TempDir::new().unwrap();
+        // Chain: d0 → d1 → d2 → d3 → d4 → d5 → d6
+        // With MAX_INCLUDE_DEPTH=5, expansion from the outer call:
+        // outer(0) expands @d0 at depth 0 → d0 content expanded at depth 1
+        // depth 1 expands @d1 → d1 at depth 2 → ... → d3 at depth 4
+        // depth 4 expands @d4 → d4 at depth 5 → depth 5 >= MAX, @d5 NOT expanded
+        for i in 0..7 {
+            let content = if i < 6 {
+                format!("DEPTH_{i}\n@d{}.md", i + 1)
+            } else {
+                format!("DEPTH_{i}")
+            };
+            fs::write(tmp.path().join(format!("d{i}.md")), content).unwrap();
+        }
+        let mut seen = HashSet::new();
+        let result = expand_includes("@d0.md", tmp.path(), 0, &mut seen);
+        assert!(result.contains("DEPTH_0"));
+        assert!(result.contains("DEPTH_3"));
+        assert!(result.contains("DEPTH_4"));
+        // DEPTH_5 should NOT appear — depth limit reached
+        assert!(!result.contains("DEPTH_5"));
+    }
+
+    #[test]
+    fn test_include_disallowed_extension() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("image.png"), "BINARY_DATA").unwrap();
+        let mut seen = HashSet::new();
+        let input = "@image.png";
+        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        assert!(!result.contains("BINARY_DATA"));
+    }
+
+    #[test]
+    fn test_include_with_surrounding_text() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("inc.md"), "MIDDLE").unwrap();
+        let mut seen = HashSet::new();
+        let input = "TOP\n@inc.md\nBOTTOM";
+        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        assert_eq!(result, "TOP\nMIDDLE\nBOTTOM");
+    }
+
+    #[test]
+    fn test_is_allowed_extension() {
+        assert!(is_allowed_extension(Path::new("file.md")));
+        assert!(is_allowed_extension(Path::new("file.txt")));
+        assert!(is_allowed_extension(Path::new("file.yaml")));
+        assert!(is_allowed_extension(Path::new("file.yml")));
+        assert!(is_allowed_extension(Path::new("file.toml")));
+        assert!(is_allowed_extension(Path::new("file.json")));
+        assert!(!is_allowed_extension(Path::new("file.png")));
+        assert!(!is_allowed_extension(Path::new("file.rs")));
+        assert!(!is_allowed_extension(Path::new("file")));
+    }
+
+    #[test]
+    fn test_inline_code_span_not_expanded() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("x.md"), "SHOULD_NOT_APPEAR").unwrap();
+        let mut seen = HashSet::new();
+        let input = "Use `@x.md` for config";
+        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        assert!(!result.contains("SHOULD_NOT_APPEAR"));
+    }
+
+    #[test]
+    fn test_home_path_expansion() {
+        let tmp = TempDir::new().unwrap();
+        let mut seen = HashSet::new();
+        let input = "@~/nonexistent-test-file.md";
+        let result = expand_includes(input, tmp.path(), 0, &mut seen);
+        assert!(!result.contains("@~/"));
+    }
+
+    // --- Discovery tests ---
+
+    #[test]
+    fn test_collect_no_agents_md_anywhere() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path();
+        fs::create_dir(cwd.join(".git")).unwrap();
+        let files = collect_agents_md(&cwd.to_string_lossy());
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_collect_cwd_only() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path();
+        fs::create_dir(cwd.join(".git")).unwrap();
+        fs::write(cwd.join("AGENTS.md"), "CWD_RULES").unwrap();
+
+        let files = collect_agents_md(&cwd.to_string_lossy());
+        assert_eq!(files.len(), 1);
+        assert!(files[0].content.contains("CWD_RULES"));
+        assert!(!files[0].is_global);
+    }
+
+    #[test]
+    fn test_collect_hierarchical_ordering() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(root.join("AGENTS.md"), "ROOT_RULES").unwrap();
+
+        let sub = root.join("packages").join("server");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(sub.join("AGENTS.md"), "SUB_RULES").unwrap();
+
+        let files = collect_agents_md(&sub.to_string_lossy());
+        assert_eq!(files.len(), 2);
+        assert!(files[0].content.contains("ROOT_RULES"));
+        assert!(files[1].content.contains("SUB_RULES"));
+    }
+
+    #[test]
+    fn test_collect_stops_at_git_root() {
+        let tmp = TempDir::new().unwrap();
+        let above_git = tmp.path();
+        fs::write(above_git.join("AGENTS.md"), "ABOVE_GIT_SHOULD_NOT_APPEAR").unwrap();
+
+        let repo = above_git.join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::create_dir(repo.join(".git")).unwrap();
+        fs::write(repo.join("AGENTS.md"), "REPO_RULES").unwrap();
+
+        let files = collect_agents_md(&repo.to_string_lossy());
+        assert_eq!(files.len(), 1);
+        assert!(files[0].content.contains("REPO_RULES"));
+    }
+
+    #[test]
+    fn test_collect_skips_empty_agents_md() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path();
+        fs::create_dir(cwd.join(".git")).unwrap();
+        fs::write(cwd.join("AGENTS.md"), "   \n  ").unwrap();
+
+        let files = collect_agents_md(&cwd.to_string_lossy());
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_collect_with_include_expanded() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path();
+        fs::create_dir(cwd.join(".git")).unwrap();
+        fs::write(cwd.join("AGENTS.md"), "@rules.md").unwrap();
+        fs::write(cwd.join("rules.md"), "INCLUDED_RULES").unwrap();
+
+        let files = collect_agents_md(&cwd.to_string_lossy());
+        assert_eq!(files.len(), 1);
+        assert!(files[0].content.contains("INCLUDED_RULES"));
+    }
+
+    // --- Formatting tests ---
+
+    #[test]
+    fn test_format_empty() {
+        let files: Vec<AgentsMdFile> = vec![];
+        let result = format_agents_md_section(&files);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_format_single_project() {
+        let files = vec![AgentsMdFile {
+            path: PathBuf::from("/workspace/AGENTS.md"),
+            content: "My rules".to_string(),
+            is_global: false,
+        }];
+        let result = format_agents_md_section(&files);
+        assert!(result.contains("Be sure to adhere to these instructions"));
+        assert!(result.contains("Contents of /workspace/AGENTS.md (project instructions):"));
+        assert!(result.contains("My rules"));
+    }
+
+    #[test]
+    fn test_format_global_and_project() {
+        let files = vec![
+            AgentsMdFile {
+                path: PathBuf::from("/home/user/.config/aionrs/AGENTS.md"),
+                content: "Global rules".to_string(),
+                is_global: true,
+            },
+            AgentsMdFile {
+                path: PathBuf::from("/workspace/AGENTS.md"),
+                content: "Project rules".to_string(),
+                is_global: false,
+            },
+        ];
+        let result = format_agents_md_section(&files);
+        let global_pos = result.find("Global rules").unwrap();
+        let project_pos = result.find("Project rules").unwrap();
+        assert!(global_pos < project_pos, "global before project");
+        assert!(result.contains("(user's global instructions for all projects)"));
+        assert!(result.contains("(project instructions)"));
+    }
+}

--- a/crates/aion-agent/src/context.rs
+++ b/crates/aion-agent/src/context.rs
@@ -6,6 +6,7 @@ use aion_skills::prompt::format_skills_within_budget;
 use aion_skills::types::SkillMetadata;
 use aion_types::message::{ContentBlock, Message, Role};
 
+use crate::agents_md;
 use crate::plan::prompt as plan_prompt;
 
 /// Session-scoped cache for system prompt sections.
@@ -144,15 +145,10 @@ pub fn build_system_prompt(
         parts.push(custom_cached.clone());
     }
 
-    // Section: AGENTS.md (session permanent)
+    // Section: AGENTS.md (session permanent, hierarchical)
     let agents_section = cache.sections.entry("agents_md").or_insert_with(|| {
-        let agents_md = Path::new(cwd).join("AGENTS.md");
-        if agents_md.exists()
-            && let Ok(content) = std::fs::read_to_string(&agents_md)
-        {
-            return format!("# Project Instructions (AGENTS.md)\n\n{content}");
-        }
-        String::new()
+        let files = agents_md::collect_agents_md(cwd);
+        agents_md::format_agents_md_section(&files)
     });
     if !agents_section.is_empty() {
         parts.push(agents_section.clone());
@@ -688,8 +684,12 @@ mod tests {
             "should NOT load CLAUDE.md content"
         );
         assert!(
-            result.contains("Project Instructions (AGENTS.md)"),
-            "header should reference AGENTS.md"
+            result.contains("(project instructions)"),
+            "header should indicate project instructions"
+        );
+        assert!(
+            result.contains("AGENTS.md"),
+            "header should contain AGENTS.md filename"
         );
     }
 
@@ -718,7 +718,7 @@ mod tests {
             "CLAUDE.md should be ignored"
         );
         assert!(
-            !result.contains("Project Instructions"),
+            !result.contains("(project instructions)"),
             "no project instructions should be injected"
         );
     }

--- a/crates/aion-agent/src/lib.rs
+++ b/crates/aion-agent/src/lib.rs
@@ -1,5 +1,6 @@
 // Core agent infrastructure: engine, session, orchestration, output sinks.
 
+pub mod agents_md;
 pub mod cache_diagnostics;
 pub mod compact;
 pub mod confirm;

--- a/crates/aion-skills/src/paths.rs
+++ b/crates/aion-skills/src/paths.rs
@@ -103,7 +103,7 @@ fn walk_up_dirs(cwd: &Path, subdir: &str) -> Vec<PathBuf> {
 
 /// Determine where to stop walking up. Stops at git root if found,
 /// otherwise at the user home directory.
-fn stop_boundary(cwd: &Path) -> Option<PathBuf> {
+pub fn stop_boundary(cwd: &Path) -> Option<PathBuf> {
     find_git_root(cwd).or_else(dirs::home_dir)
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,6 @@
 - **[Built-in Tools](tools.md)** — Read, Write, Edit, Bash, Grep, Glob, Spawn — detailed reference and concurrency notes
 - **[MCP Integration](mcp.md)** — Model Context Protocol client: stdio, SSE, and streamable-http transports
 - **[Providers & Auth](providers.md)** — Multi-provider configuration, profile inheritance, AWS Bedrock, Google Vertex AI, OAuth login
-- **[Advanced Features](advanced.md)** — Sub-agent spawning, hook system, prompt caching, VCR recording/replay, AGENTS.md auto-loading, memory system, plan mode, context compression, file state cache, output compaction
+- **[Advanced Features](advanced.md)** — Sub-agent spawning, hook system, prompt caching, VCR recording/replay, AGENTS.md hierarchical loading, memory system, plan mode, context compression, file state cache, output compaction
 - **[JSON Stream Protocol](json-stream-protocol.md)** — Host integration protocol specification (`--json-stream` mode)
 - **[Troubleshooting](troubleshooting.md)** — Common errors, diagnostics, and solutions

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -139,13 +139,39 @@ VCR_MODE=replay VCR_CASSETTE=tests/cassettes/my_test.json \
 
 ---
 
-## AGENTS.md Auto-Loading
+## AGENTS.md Hierarchical Loading
 
-If an `AGENTS.md` file exists in the current working directory, its contents are automatically injected into the system prompt. Use this for:
+AGENTS.md files provide project-specific instructions that are automatically injected into the system prompt. Files are discovered hierarchically and merged from remote to near:
 
-- Project-specific coding standards
-- Architecture descriptions
-- Special working constraints
+1. **Global**: `<config_dir>/aionrs/AGENTS.md` — user-level instructions for all projects
+2. **Project hierarchy**: Walk up from cwd to the git root (or home directory), collecting every `AGENTS.md` found along the way
+
+Files closer to the working directory appear later in the prompt and take precedence (via LLM recency bias). Each file is annotated with its absolute path for traceability.
+
+### @include Directive
+
+AGENTS.md files can include other files using `@` syntax:
+
+- `@FILENAME` or `@./relative/path` — relative to the AGENTS.md file's directory
+- `@~/path` — relative to home directory
+- `@/absolute/path` — absolute path
+
+Paths inside fenced code blocks are ignored. Includes are recursive (up to depth 5) with circular reference detection. Non-existent files and non-text files are silently skipped.
+
+### Example
+
+Given this structure:
+
+```
+my-workspace/
+├── .git/
+├── AGENTS.md          ← workspace rules
+└── packages/
+    └── server/
+        └── AGENTS.md  ← server-specific rules
+```
+
+Running aion in `packages/server/` produces a system prompt containing both files, workspace first, then server.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace single-file AGENTS.md loading with Claude Code-style hierarchical discovery: global (`<config_dir>/aionrs/AGENTS.md`) → walk up directory tree to git root → merge all files from remote to near
- Add `@include` directive support (`@file.md`, `@./path`, `@~/path`, `@/abs/path`) with fenced code block skipping, circular reference detection, max depth 5, and text-only extension allowlist
- Format output matches Claude Code: preamble instruction + `Contents of <path> (<description>):` per file

## Changes

- **New**: `crates/aion-agent/src/agents_md.rs` — discovery, @include expansion, formatting (21 tests)
- **Modified**: `crates/aion-agent/src/context.rs` — delegate to new `agents_md` module
- **Modified**: `crates/aion-skills/src/paths.rs` — expose `stop_boundary` as pub
- **Docs**: Updated `docs/advanced.md`, `README.md`, `docs/README.md`

## Test plan

- [ ] All 21 new unit tests pass (include expansion, discovery, formatting)
- [ ] All existing tests pass (309+ in aion-agent)
- [ ] Full workspace test suite passes
- [ ] Clippy clean with `-D warnings`
- [ ] Manual: create nested AGENTS.md files, verify prompt contains both
- [ ] Manual: verify `@include` expands referenced files