### PR TITLE
fix(orchestration): guide LLM to ToolSearch when deferred tool fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "regex",
  "serde",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aion-config",
  "chrono",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aion-types",
  "rstest",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-agent/src/orchestration.rs
+++ b/crates/aion-agent/src/orchestration.rs
@@ -595,4 +595,209 @@ mod tests {
         let result = maybe_append_deferred_hint("validation failed", schema, &input);
         assert!(result.contains("ToolSearch"));
     }
+
+    // -- execute_single integration tests (deferred tool hint) ----------------
+
+    use aion_tools::Tool;
+    use aion_tools::registry::ToolRegistry;
+
+    struct MockDeferredTool {
+        schema: serde_json::Value,
+    }
+
+    #[async_trait::async_trait]
+    impl Tool for MockDeferredTool {
+        fn name(&self) -> &str {
+            "MockDeferred"
+        }
+        fn description(&self) -> &str {
+            "A mock deferred tool for testing"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            self.schema.clone()
+        }
+        fn is_concurrency_safe(&self, _input: &serde_json::Value) -> bool {
+            true
+        }
+        fn is_deferred(&self) -> bool {
+            true
+        }
+        async fn execute(&self, input: serde_json::Value) -> aion_types::tool::ToolResult {
+            if input.get("tasks").is_none() {
+                return aion_types::tool::ToolResult {
+                    content: "Missing or invalid 'tasks' array".to_string(),
+                    is_error: true,
+                };
+            }
+            aion_types::tool::ToolResult {
+                content: "ok".to_string(),
+                is_error: false,
+            }
+        }
+        fn category(&self) -> aion_protocol::events::ToolCategory {
+            aion_protocol::events::ToolCategory::Exec
+        }
+    }
+
+    struct MockNonDeferredTool;
+
+    #[async_trait::async_trait]
+    impl Tool for MockNonDeferredTool {
+        fn name(&self) -> &str {
+            "MockNonDeferred"
+        }
+        fn description(&self) -> &str {
+            "A mock non-deferred tool"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            json!({
+                "type": "object",
+                "properties": { "cmd": { "type": "string" } },
+                "required": ["cmd"]
+            })
+        }
+        fn is_concurrency_safe(&self, _input: &serde_json::Value) -> bool {
+            true
+        }
+        async fn execute(&self, input: serde_json::Value) -> aion_types::tool::ToolResult {
+            if input.get("cmd").is_none() {
+                return aion_types::tool::ToolResult {
+                    content: "Missing cmd".to_string(),
+                    is_error: true,
+                };
+            }
+            aion_types::tool::ToolResult {
+                content: "ok".to_string(),
+                is_error: false,
+            }
+        }
+        fn category(&self) -> aion_protocol::events::ToolCategory {
+            aion_protocol::events::ToolCategory::Exec
+        }
+    }
+
+    fn make_registry_with_deferred() -> ToolRegistry {
+        let mut registry = ToolRegistry::new();
+        registry.register(Box::new(MockDeferredTool {
+            schema: json!({
+                "type": "object",
+                "properties": { "tasks": { "type": "array" } },
+                "required": ["tasks"]
+            }),
+        }));
+        registry.register(Box::new(MockNonDeferredTool));
+        registry
+    }
+
+    #[tokio::test]
+    async fn execute_single_deferred_tool_error_missing_required_appends_hint() {
+        let registry = make_registry_with_deferred();
+        let call = ContentBlock::ToolUse {
+            id: "call_1".into(),
+            name: "MockDeferred".into(),
+            input: json!({}),
+        };
+        let (result, _) = execute_single(
+            &registry,
+            &call,
+            None,
+            aion_compact::CompactionLevel::Off,
+            false,
+        )
+        .await;
+        if let ContentBlock::ToolResult {
+            content, is_error, ..
+        } = &result
+        {
+            assert!(is_error);
+            assert!(content.contains("Missing or invalid 'tasks' array"));
+            assert!(content.contains("ToolSearch"));
+        } else {
+            panic!("expected ToolResult");
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_single_deferred_tool_error_with_required_present_no_hint() {
+        let registry = make_registry_with_deferred();
+        // tasks is present but wrong type — tool still fails, but required field exists
+        let call = ContentBlock::ToolUse {
+            id: "call_2".into(),
+            name: "MockDeferred".into(),
+            input: json!({"tasks": "not_an_array"}),
+        };
+        let (result, _) = execute_single(
+            &registry,
+            &call,
+            None,
+            aion_compact::CompactionLevel::Off,
+            false,
+        )
+        .await;
+        if let ContentBlock::ToolResult {
+            content, is_error, ..
+        } = &result
+        {
+            // Tool succeeds because input.get("tasks") is Some
+            assert!(!is_error);
+            assert!(!content.contains("ToolSearch"));
+        } else {
+            panic!("expected ToolResult");
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_single_deferred_tool_success_no_hint() {
+        let registry = make_registry_with_deferred();
+        let call = ContentBlock::ToolUse {
+            id: "call_3".into(),
+            name: "MockDeferred".into(),
+            input: json!({"tasks": [{"name": "t1", "prompt": "do x"}]}),
+        };
+        let (result, _) = execute_single(
+            &registry,
+            &call,
+            None,
+            aion_compact::CompactionLevel::Off,
+            false,
+        )
+        .await;
+        if let ContentBlock::ToolResult {
+            content, is_error, ..
+        } = &result
+        {
+            assert!(!is_error);
+            assert_eq!(content, "ok");
+        } else {
+            panic!("expected ToolResult");
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_single_non_deferred_tool_error_no_hint() {
+        let registry = make_registry_with_deferred();
+        let call = ContentBlock::ToolUse {
+            id: "call_4".into(),
+            name: "MockNonDeferred".into(),
+            input: json!({}),
+        };
+        let (result, _) = execute_single(
+            &registry,
+            &call,
+            None,
+            aion_compact::CompactionLevel::Off,
+            false,
+        )
+        .await;
+        if let ContentBlock::ToolResult {
+            content, is_error, ..
+        } = &result
+        {
+            assert!(is_error);
+            assert!(content.contains("Missing cmd"));
+            assert!(!content.contains("ToolSearch"));
+        } else {
+            panic!("expected ToolResult");
+        }
+    }
 }

--- a/crates/aion-agent/src/orchestration.rs
+++ b/crates/aion-agent/src/orchestration.rs
@@ -174,7 +174,12 @@ async fn execute_single(
             } else {
                 tool.context_modifier_for(input)
             };
-            let content = truncate_result(&r.content, max_size);
+            let error_content = if r.is_error && tool.is_deferred() {
+                maybe_append_deferred_hint(&r.content, tool.input_schema(), input)
+            } else {
+                r.content.clone()
+            };
+            let content = truncate_result(&error_content, max_size);
             let content = aion_compact::compact_output(&content, compaction_level);
             let content = if toon_enabled {
                 aion_compact::compact_output_toon(&content)
@@ -368,6 +373,37 @@ fn block_is_error(block: &ContentBlock) -> bool {
     matches!(block, ContentBlock::ToolResult { is_error: true, .. })
 }
 
+/// When a deferred tool fails AND the input is missing required fields from
+/// its full schema, append a hint telling the LLM to call ToolSearch first.
+/// If required fields are all present (or the schema has none), the original
+/// error is returned unchanged — the failure is a runtime issue, not a
+/// missing-schema problem.
+fn maybe_append_deferred_hint(
+    original_error: &str,
+    schema: serde_json::Value,
+    input: &serde_json::Value,
+) -> String {
+    let missing: Vec<&str> = schema["required"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .filter(|key| input.get(key).is_none())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if missing.is_empty() {
+        return original_error.to_string();
+    }
+
+    format!(
+        "{}\n\nThis is a deferred tool — its full parameter schema was not loaded. \
+         Call ToolSearch to load the schema, then retry.",
+        original_error
+    )
+}
+
 fn truncate_result(content: &str, max_chars: usize) -> String {
     if content.len() <= max_chars {
         return content.to_string();
@@ -441,6 +477,7 @@ fn partition<'a>(registry: &ToolRegistry, calls: &'a [ContentBlock]) -> Vec<Batc
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     // -- truncate_display -----------------------------------------------------
 
@@ -491,5 +528,71 @@ mod tests {
         let mixed = "Hello你好World世界Test测试".repeat(100);
         let result = truncate_result(&mixed, 200);
         assert!(result.contains("truncated"));
+    }
+
+    // -- maybe_append_deferred_hint -------------------------------------------
+
+    #[test]
+    fn deferred_hint_appended_when_required_field_missing() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "tasks": { "type": "array" } },
+            "required": ["tasks"]
+        });
+        let input = json!({});
+        let result = maybe_append_deferred_hint("Missing or invalid 'tasks' array", schema, &input);
+        assert!(result.contains("Missing or invalid 'tasks' array"));
+        assert!(result.contains("ToolSearch"));
+    }
+
+    #[test]
+    fn deferred_hint_not_appended_when_required_fields_present() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "tasks": { "type": "array" } },
+            "required": ["tasks"]
+        });
+        let input = json!({"tasks": [{"name": "t1", "prompt": "do x"}]});
+        let result = maybe_append_deferred_hint("Some runtime error", schema, &input);
+        assert_eq!(result, "Some runtime error");
+        assert!(!result.contains("ToolSearch"));
+    }
+
+    #[test]
+    fn deferred_hint_not_appended_when_no_required_field() {
+        let schema = json!({
+            "type": "object",
+            "properties": {}
+        });
+        let input = json!({});
+        let result = maybe_append_deferred_hint("some error", schema, &input);
+        assert_eq!(result, "some error");
+    }
+
+    #[test]
+    fn deferred_hint_not_appended_when_required_is_empty() {
+        let schema = json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        });
+        let input = json!({});
+        let result = maybe_append_deferred_hint("some error", schema, &input);
+        assert_eq!(result, "some error");
+    }
+
+    #[test]
+    fn deferred_hint_appended_for_partial_missing_fields() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" },
+                "b": { "type": "string" }
+            },
+            "required": ["a", "b"]
+        });
+        let input = json!({"a": "present"});
+        let result = maybe_append_deferred_hint("validation failed", schema, &input);
+        assert!(result.contains("ToolSearch"));
     }
 }


### PR DESCRIPTION
## Summary

- When a deferred tool fails AND the input is missing required fields from its full schema, append a hint to the error message guiding the LLM to call `ToolSearch` first
- No execution blocking — tools always run normally; the hint is only appended post-failure when required fields are absent
- Zero cross-module state — uses only existing `tool.is_deferred()` and `tool.input_schema()` from the `Tool` trait

## Context

Sentry issue ELECTRON-W1: user reported "aion cli sub-agent not working" on v1.9.18. Logs show the `Spawn` tool (a deferred tool) failing repeatedly with `"Missing or invalid 'tasks' array"` because the LLM skipped `ToolSearch` and called `Spawn` without loading its full parameter schema.

## Design

The fix adds a single helper `maybe_append_deferred_hint()` in `orchestration.rs`. It checks `schema["required"]` against the actual input keys — purely JSON comparison, no shared state, no session tracking, unaffected by context compaction.

Three conditions must ALL be true for the hint to appear:
1. Tool execution returned `is_error: true`
2. `tool.is_deferred()` is true
3. At least one `required` field from the full schema is missing in the input

This means:
- Tools with `required: []` (EnterPlanMode, ExitPlanMode) are never affected
- Deferred tools that received correct params but had runtime errors get their original error unchanged
- No false positives from schema-less tools (no `required` key → hint skipped)

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `cargo test` — all 1600+ tests pass, 5 new tests added:
  - `deferred_hint_appended_when_required_field_missing`
  - `deferred_hint_not_appended_when_required_fields_present`
  - `deferred_hint_not_appended_when_no_required_field`
  - `deferred_hint_not_appended_when_required_is_empty`
  - `deferred_hint_appended_for_partial_missing_fields`