### PR TITLE
chore: add worktree and superset dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@
 # Temporary files
 .tmp/
 
+# Git worktrees
+.worktree/
+worktree/
+
 # aionrs session data
 .aionrs/
 
@@ -39,3 +43,6 @@ coverage/
 # Superpowers brainstorm tool (runtime files, session data)
 .superpowers/
 docs/superpowers/
+
+# Superset
+.superset/


### PR DESCRIPTION
## Summary

- Add `.worktree/` and `worktree/` directories to gitignore (git worktree artifacts)
- Add `.superset/` directory to gitignore (Superset application data)

## Test plan

- [x] Verify `.gitignore` entries are correctly grouped and commented