### PR TITLE
fix: UTF-8 panic in tool describe + autocompact skip logging

### DIFF
--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -602,9 +602,9 @@ impl AgentEngine {
 
         // 2. Autocompact (LLM summarization)
         let mut compacted = false;
-        if auto::should_autocompact(self.compact_state.last_input_tokens, &self.compact_config)
-            && !self.compact_state.is_circuit_broken(&self.compact_config)
-        {
+        let should_compact =
+            auto::should_autocompact(self.compact_state.last_input_tokens, &self.compact_config);
+        if should_compact && !self.compact_state.is_circuit_broken(&self.compact_config) {
             let provider = Arc::clone(&self.provider);
             match auto::autocompact(
                 provider.as_ref(),
@@ -630,6 +630,25 @@ impl AgentEngine {
                     self.output
                         .emit_error(&format!("Autocompact failed: {}", e));
                 }
+            }
+        } else if should_compact {
+            self.output.emit_info(&format!(
+                "Autocompact: skipped (circuit breaker tripped after {} consecutive failures, \
+                 last_input_tokens={})",
+                self.compact_state.consecutive_failures, self.compact_state.last_input_tokens
+            ));
+        } else if !self.compact_config.enabled {
+            let threshold = self
+                .compact_config
+                .context_window
+                .saturating_sub(self.compact_config.output_reserve)
+                .saturating_sub(self.compact_config.autocompact_buffer);
+            if self.compact_state.last_input_tokens as usize >= threshold {
+                self.output.emit_info(&format!(
+                    "Autocompact: disabled (compact.enabled=false, \
+                     last_input_tokens={}, threshold={})",
+                    self.compact_state.last_input_tokens, threshold
+                ));
             }
         }
 

--- a/crates/aion-agent/src/spawn_tool.rs
+++ b/crates/aion-agent/src/spawn_tool.rs
@@ -133,8 +133,7 @@ impl Tool for SpawnTool {
             .get("task")
             .and_then(|v| v.as_str())
             .unwrap_or("sub-agent");
-        let display = if task.len() > 80 { &task[..80] } else { task };
-        format!("Spawn: {}", display)
+        format!("Spawn: {}", aion_tools::truncate_utf8(task, 80))
     }
 }
 

--- a/crates/aion-tools/src/bash.rs
+++ b/crates/aion-tools/src/bash.rs
@@ -112,7 +112,6 @@ impl Tool for BashTool {
 
     fn describe(&self, input: &Value) -> String {
         let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
-        let display = if cmd.len() > 80 { &cmd[..80] } else { cmd };
-        format!("Execute: {}", display)
+        format!("Execute: {}", crate::truncate_utf8(cmd, 80))
     }
 }

--- a/crates/aion-tools/src/lib.rs
+++ b/crates/aion-tools/src/lib.rs
@@ -16,6 +16,18 @@ use aion_protocol::events::ToolCategory;
 use aion_types::skill_types::ContextModifier;
 use aion_types::tool::{JsonSchema, ToolResult};
 
+/// Truncate a string to at most `max_bytes`, snapping to a char boundary.
+pub fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 /// A tool that the agent can invoke
 #[async_trait]
 pub trait Tool: Send + Sync {
@@ -70,5 +82,47 @@ pub trait Tool: Send + Sync {
             self.name(),
             serde_json::to_string(input).unwrap_or_default()
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_utf8_ascii_within_limit() {
+        assert_eq!(truncate_utf8("hello", 80), "hello");
+    }
+
+    #[test]
+    fn truncate_utf8_ascii_at_boundary() {
+        assert_eq!(truncate_utf8("abcde", 3), "abc");
+    }
+
+    #[test]
+    fn truncate_utf8_multibyte_snaps_back() {
+        // '些' is 3 bytes (E4 BA 9B) starting at index 79 would span 79..82
+        let s = "# 用 script 模拟 TTY 交互来添加 DeepSeek 提供商\n# 首先看看有哪些";
+        let result = truncate_utf8(s, 80);
+        assert!(result.len() <= 80);
+        assert!(result.is_char_boundary(result.len()));
+    }
+
+    #[test]
+    fn truncate_utf8_empty() {
+        assert_eq!(truncate_utf8("", 80), "");
+    }
+
+    #[test]
+    fn truncate_utf8_zero_limit() {
+        assert_eq!(truncate_utf8("hello", 0), "");
+    }
+
+    #[test]
+    fn truncate_utf8_emoji() {
+        // 🦀 is 4 bytes
+        let s = "aaa🦀bbb";
+        assert_eq!(truncate_utf8(s, 4), "aaa");
+        assert_eq!(truncate_utf8(s, 7), "aaa🦀");
     }
 }


### PR DESCRIPTION
## Summary

- Fix panic when `BashTool::describe()` and `SpawnTool::describe()` truncate non-ASCII command strings at a non-char-boundary byte index (e.g. Chinese characters). Extract `truncate_utf8()` helper to `aion-tools` and use it in both tools.
- Emit info-level diagnostics via `emit_info` when autocompact is skipped due to circuit breaker trip or `compact.enabled=false`, so the skip reason is visible in AionUi logs for debugging context growth issues.

## Context

Sentry ELECTRON-X9: aionrs panicked at `bash.rs:115` when describing a Bash command containing Chinese text (`# 用 script 模拟 TTY 交互来添加 DeepSeek 提供商`), crashing the process and causing AionUi to report "超过1m卡死上下文". The autocompact skip logging was added to help diagnose why autocompact may not trigger in long sessions.

## Test plan

- [x] `truncate_utf8` unit tests cover ASCII, multi-byte (Chinese), emoji, empty, and zero-limit cases
- [x] `cargo fmt && cargo clippy && cargo test` all pass
- [ ] Verify in AionUi that autocompact skip logs appear as `[AionrsManager] info: Autocompact: skipped (...)` when circuit breaker trips