### PR TITLE
feat: add ping/pong heartbeat protocol support

### DIFF
--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -689,6 +689,9 @@ async fn run_json_stream_mode(
                                             message: format!("mode updated: {}", approval_manager.current_mode()),
                                         });
                                     }
+                                    ProtocolCommand::Ping => {
+                                        let _ = writer.emit(&aion_protocol::events::ProtocolEvent::Pong);
+                                    }
                                     _ => {
                                         eprintln!("[protocol] Ignoring command during active message processing");
                                     }
@@ -794,6 +797,9 @@ async fn run_json_stream_mode(
                 output.emit_error(&format!(
                     "AddMcpServer '{name}': rejected — only allowed before first Message"
                 ));
+            }
+            ProtocolCommand::Ping => {
+                let _ = writer.emit(&aion_protocol::events::ProtocolEvent::Pong);
             }
         }
     }

--- a/crates/aion-protocol/src/commands.rs
+++ b/crates/aion-protocol/src/commands.rs
@@ -56,6 +56,7 @@ pub enum ProtocolCommand {
         #[serde(default)]
         headers: Option<HashMap<String, String>>,
     },
+    Ping,
 }
 
 #[derive(Debug, Deserialize, Default, PartialEq, Eq)]
@@ -207,6 +208,13 @@ mod tests {
             }
             _ => panic!("expected AddMcpServer"),
         }
+    }
+
+    #[test]
+    fn ping_deserialize() {
+        let json = r#"{"type":"ping"}"#;
+        let cmd: ProtocolCommand = serde_json::from_str(json).unwrap();
+        assert_eq!(cmd, ProtocolCommand::Ping);
     }
 
     #[test]

--- a/crates/aion-protocol/src/events.rs
+++ b/crates/aion-protocol/src/events.rs
@@ -69,6 +69,7 @@ pub enum ProtocolEvent {
         name: String,
         tools: Vec<String>,
     },
+    Pong,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -307,6 +308,14 @@ mod tests {
         assert_eq!(json["tools"][0], "team_send_message");
         assert_eq!(json["tools"][1], "team_task_create");
         assert_eq!(json["tools"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_pong_event_serialization() {
+        let event = ProtocolEvent::Pong;
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "pong");
+        assert_eq!(json.as_object().unwrap().len(), 1);
     }
 
     #[test]

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -291,6 +291,18 @@ Emitted after a dynamically injected MCP server has connected and its tools are 
 | `name` | string | Server name (as provided in `add_mcp_server`) |
 | `tools` | string[] | List of tool names registered from this server |
 
+### 1.14 `pong`
+
+Response to a `ping` command from the client. Used for heartbeat/liveness detection.
+
+```json
+{
+  "type": "pong"
+}
+```
+
+No additional fields. The agent emits `pong` immediately upon receiving a `ping` command, regardless of whether a message turn is active.
+
 ## 2. Client → Agent Commands (stdin)
 
 Every line is a JSON object with a `type` field.
@@ -456,6 +468,18 @@ Agent  → stdout: {"type":"mcp_ready","name":"tools","tools":["tool_a","tool_b"
 Client → stdin:  {"type":"message","msg_id":"m1","content":"Hello"}
                   ↑ first message ends the injection window
 ```
+
+### 2.9 `ping`
+
+Heartbeat probe. The agent responds immediately with a `pong` event.
+
+```json
+{
+  "type": "ping"
+}
+```
+
+Can be sent at any time — during idle, during message processing, or during tool execution. The agent always responds with `{"type":"pong"}`.
 
 After the first `message`, any further `add_mcp_server` commands are rejected:
 


### PR DESCRIPTION
## Summary

- Add `ping` command and `pong` event to the JSON stream protocol, enabling client-side heartbeat/liveness detection
- Handle `ping` in both idle state and during active message processing in `run_json_stream_mode()`
- Update protocol documentation (§1.14 `pong` event, §2.9 `ping` command)

## Context

AionUi is replacing its broken 15-second idle fake finish mechanism with a proper ping/pong heartbeat. This PR adds the aionrs-side support: when the client sends `{"type":"ping"}`, aionrs immediately responds with `{"type":"pong"}`.

Fully backward compatible — old clients that don't send `ping` are unaffected; old aionrs binaries that don't understand `ping` will log an invalid command warning and continue normally.

## Test plan

- [x] `ping_deserialize` — verifies `{"type":"ping"}` parses to `ProtocolCommand::Ping`
- [x] `test_pong_event_serialization` — verifies `Pong` serializes to `{"type":"pong"}`
- [x] Full test suite passes (`cargo test`)
- [x] `cargo clippy` — zero warnings
- [x] `cargo fmt --all -- --check` — clean