### PR TITLE
fix: cross-platform shell execution for Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,9 @@
 
 # Git worktrees
 .worktree/
+.worktrees/
 worktree/
+worktrees/
 
 # aionrs session data
 .aionrs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,38 @@
 # AGENTS.md
 
-Project-specific rules and conventions for AI assistants and contributors.
+Rules and conventions for AI assistants and contributors working on aionrs.
+
+## Overview
+
+aionrs is a **multi-provider AI agent CLI** written in Rust. It connects to
+LLM providers (Anthropic, OpenAI, AWS Bedrock, Google Vertex AI), orchestrates
+built-in tools (Read, Write, Edit, Bash, Grep, Glob, Spawn), supports MCP
+servers, skills, hooks, and long-term memory. It also exposes a JSON stream
+protocol for host integration (e.g. Electron-based AionUI).
+
+Tech stack: Rust 2021 edition, stable toolchain, Cargo workspace under `crates/`.
+
+## Crate Map
+
+Dependencies flow **downward** — never introduce circular or upward references.
+
+| Layer | Crate | Responsibility |
+|-------|-------|----------------|
+| Bottom | `aion-types` | Shared provider-neutral data types (LLM, message, tool) — zero internal deps |
+| Bottom | `aion-compact` | Context compression algorithms (folding, sanitization, tokenization) |
+| Mid | `aion-config` | Configuration, ProviderCompat, auth, hooks, **cross-platform shell helpers** |
+| Mid | `aion-protocol` | JSON stream protocol (events, commands, approval manager) for host integration |
+| Mid | `aion-providers` | LLM provider implementations (Anthropic, OpenAI, Bedrock, Vertex) |
+| Mid | `aion-tools` | Built-in agent tools (Read, Write, Edit, Bash, Grep, Glob, Spawn) |
+| Mid | `aion-mcp` | MCP (Model Context Protocol) client |
+| Mid | `aion-skills` | Skills system (prompt snippets, hooks, permissions, shell expansion) |
+| Mid | `aion-memory` | Long-term cross-session memory (user prefs, feedback, project context) |
+| Top | `aion-agent` | Agent engine, session management, orchestration |
+| Top | `aion-cli` | CLI binary entry point |
+
+When adding new functionality, place it in the **lowest crate where it
+semantically belongs**. Don't create a new crate just for one shared function.
+Run `cargo metadata` to verify dependency changes fit the graph.
 
 ## Build & Test
 
@@ -15,86 +47,64 @@ cargo fmt --all        # Format (CI enforces this)
 It runs fmt → clippy → test before pushing, preventing CI failures.
 Supports the same arguments as `git push` (e.g. `just push -u origin branch`).
 
+## Code Style
+
+- `cargo clippy` must pass without warnings
+- `cargo fmt` must pass without diffs
+- Comments in English, commit messages in English
+- Error handling:
+  - `thiserror` for public API error types (structured, matchable)
+  - `anyhow` for internal/application-level error propagation
+  - Never silently swallow errors; never `unwrap()` in production code
+    unless the invariant is proven and commented
+
+## File Organization
+
+- Each module (`.rs` file) follows the **single responsibility principle** —
+  one clear purpose per file
+- Keep files under 1000 lines; extract sub-modules when approaching the limit
+- Organize by domain responsibility, not by type
+
 ## Architecture Principles
 
 ### No Hardcoded Provider Quirks
 
 **This is the single most important rule for this codebase.**
 
-Different LLM providers have different API quirks (field names, message format
-requirements, schema restrictions, etc.). We handle these differences through
-the **`ProviderCompat` configuration layer**, not through hardcoded conditionals.
-
-**Never do this:**
+Handle provider differences through the **`ProviderCompat` configuration
+layer**, not through hardcoded conditionals.
 
 ```rust
 // WRONG: hardcoded provider detection
 if self.base_url.contains("api.openai.com") {
     body["max_completion_tokens"] = json!(max_tokens);
-} else {
-    body["max_tokens"] = json!(max_tokens);
 }
 
-// WRONG: hardcoded model name check
-if request.model.starts_with("deepseek") {
-    msg["reasoning_content"] = json!("");
-}
-
-// WRONG: hardcoded vendor workaround
-if is_kimi_model {
-    body["temperature"] = json!(1.0);
-}
-```
-
-**Always do this:**
-
-```rust
 // CORRECT: read from compat config
 let field = self.compat.max_tokens_field.as_deref().unwrap_or("max_tokens");
 body[field] = json!(request.max_tokens);
-
-// CORRECT: configurable content filtering
-if let Some(patterns) = &self.compat.strip_patterns {
-    for p in patterns { text = text.replace(p, ""); }
-}
 ```
 
-**Why:** Hardcoded quirks accumulate fast and turn the codebase into an
-unmaintainable "workaround warehouse". Provider behaviors change, new providers
-appear, and model-name checks go stale. Configuration-driven compat keeps the
-code clean and gives users control.
-
-**How it works:**
-
-1. Each provider type has **default compat presets** (see `ProviderCompat::openai_defaults()`, etc.)
-2. Users override any setting via `[providers.xxx.compat]` or `[profiles.xxx.compat]` in config
-3. Provider code reads `self.compat.*` fields — never inspects URLs or model names
-
 If you need a new compat behavior:
-- Add an `Option<T>` field to `ProviderCompat`
-- Set its default in the appropriate preset function
-- Use it in provider code via `self.compat.field_name`
-- Document it in the config reference
+1. Add an `Option<T>` field to `ProviderCompat`
+2. Set its default in the appropriate preset function (e.g. `openai_defaults()`)
+3. Use it in provider code via `self.compat.field_name`
 
-All providers implement the `LlmProvider` trait. The engine never sees
-provider-specific details. Keep it that way:
+All providers implement the `LlmProvider` trait. The engine sees only
+provider-neutral types (`LlmRequest`, `LlmEvent`, `Message`, `ContentBlock`).
+Format conversion happens inside each provider's `build_messages()` /
+`build_request_body()`.
 
-- `LlmRequest` / `LlmEvent` / `Message` / `ContentBlock` are provider-neutral
-- Format conversion happens inside each provider's `build_messages()` / `build_request_body()`
+> **Deep dive:** see [docs/providers.md](docs/providers.md) for provider
+> setup, auth, aliases, and profile inheritance.
 
 ### Centralize Platform Differences
 
 Any platform-specific behavior (paths, permissions, shell commands, line
 endings, etc.) must be wrapped in a single centralized function. All call
 sites use that function — never scatter raw platform detection across
-multiple crates or modules.
-
-When adding new platform-aware logic:
-1. Create one function in the appropriate low-level crate
-2. Replace all direct platform API calls with calls to that function
-3. Tests and docs must use platform-neutral notation (e.g.
-   `<config_dir>/aionrs`), never hardcoded platform-specific literals
-   (e.g. `~/.config/aionrs`)
+multiple crates or modules. See [Cross-Platform](#cross-platform) for
+concrete rules.
 
 ### No Duplicate Code Across Crates
 
@@ -102,42 +112,6 @@ If multiple crates need the same functionality, extract it to the
 appropriate existing crate in the dependency graph — don't copy-paste
 or reimplement. Choose the extraction target based on where it
 semantically belongs and where it minimizes dependency changes.
-
-Don't create a new crate just for one shared function.
-
-### Crate Dependency Direction
-
-This is a Cargo workspace under `crates/`. Dependencies flow downward:
-
-- `aion-types` is the bottom layer — zero internal dependencies
-- `aion-config`, `aion-protocol` depend only on `aion-types`
-- Higher-level crates (`aion-agent`, `aion-cli`) may depend on lower ones
-- Never introduce circular dependencies or upward references
-
-When adding a new crate, check `cargo metadata` to verify it fits the
-existing dependency graph before adding cross-crate imports.
-
-### File Organization
-
-- Each module (`.rs` file) follows the **single responsibility principle** —
-  one clear purpose per file
-- Keep files under 1000 lines; extract sub-modules when approaching the limit
-- Organize by domain responsibility, not by type
-
-## Test Organization
-
-| Location | What goes there |
-|----------|----------------|
-| Inline `#[cfg(test)]` in each `.rs` file | Unit tests for that module's internals |
-| `crates/<crate>/tests/` | Integration tests for that crate |
-
-Unit tests target internal logic and code paths.
-Integration tests target functional requirements and public API —
-write them from the spec, not from reading the implementation.
-
-Every test must verify a meaningful behavior or edge case.
-No trivial tests that just assert the happy path without checking boundaries,
-error conditions, or non-obvious logic.
 
 ## Cross-Platform
 
@@ -167,8 +141,32 @@ verified by CI alone.
   `findstr`) must use `cfg!(windows)` branches or equivalent
   platform-aware selection.
 
-## Code Style
+## Test Organization
 
-- Rust 2021 edition, stable toolchain
-- `cargo clippy` must pass without warnings
-- Comments in English, commit messages in English
+| Location | What goes there |
+|----------|----------------|
+| Inline `#[cfg(test)]` in each `.rs` file | Unit tests for that module's internals |
+| `crates/<crate>/tests/` | Integration tests for that crate |
+
+Unit tests target internal logic and code paths.
+Integration tests target functional requirements and public API —
+write them from the spec, not from reading the implementation.
+
+Every test must verify a meaningful behavior or edge case.
+No trivial tests that just assert the happy path without checking boundaries,
+error conditions, or non-obvious logic.
+
+## Documentation
+
+Key references in `docs/` (don't duplicate their content here):
+
+| Document | Covers |
+|----------|--------|
+| [getting-started.md](docs/getting-started.md) | Installation, CLI usage, config format and cascading precedence |
+| [providers.md](docs/providers.md) | Provider setup, auth, ProviderCompat, custom aliases, profiles |
+| [tools.md](docs/tools.md) | Built-in tool reference and execution flow |
+| [skills.md](docs/skills.md) | Writing skills, front matter, shell expansion, conditional activation |
+| [mcp.md](docs/mcp.md) | MCP server integration, transport types, deferred loading |
+| [advanced.md](docs/advanced.md) | Sub-agents, hooks, memory, plan mode, context compression |
+| [json-stream-protocol.md](docs/json-stream-protocol.md) | JSON Lines protocol spec for host integration (e.g. AionUI) |
+| [troubleshooting.md](docs/troubleshooting.md) | Common errors and solutions |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,13 +139,14 @@ Every test must verify a meaningful behavior or edge case.
 No trivial tests that just assert the happy path without checking boundaries,
 error conditions, or non-obvious logic.
 
-## Cross-Platform Path Handling
+## Cross-Platform
 
 CI runs on macOS, Linux, **and Windows**. Local dev can only test the
 current platform's `#[cfg(...)]` code — other platform branches are
 verified by CI alone.
 
-Rules:
+### Paths
+
 - Never hardcode platform paths (`/tmp/...`, `C:\...`) in production code.
   Use `Path::join()`, `dirs::config_dir()`, `tempfile::tempdir()`, etc.
 - In tests, hardcoded Unix paths (`Path::new("/foo/...")`) are fine for
@@ -155,6 +156,16 @@ Rules:
   platform-sensitive checks.
 - Use `std::path::Component::Normal` (not byte length) when checking
   path depth — prefix/root components differ across platforms.
+
+### Shell Execution
+
+- All shell invocations must go through `aion_config::shell` module
+  (`shell_command()` or `shell_command_builder()`).
+- Never call `Command::new("sh")`, `Command::new("bash")`, or
+  `Command::new("cmd")` directly — these are platform-specific.
+- External CLI tools that differ across platforms (e.g. `grep` vs
+  `findstr`) must use `cfg!(windows)` branches or equivalent
+  platform-aware selection.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,8 +119,9 @@ existing dependency graph before adding cross-crate imports.
 
 ### File Organization
 
-- One file per logical unit within each crate
-- Keep files under 800 lines; extract modules when approaching the limit
+- Each module (`.rs` file) follows the **single responsibility principle** —
+  one clear purpose per file
+- Keep files under 1000 lines; extract sub-modules when approaching the limit
 - Organize by domain responsibility, not by type
 
 ## Test Organization

--- a/crates/aion-config/src/hooks.rs
+++ b/crates/aion-config/src/hooks.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tokio::process::Command;
+
+use crate::shell::shell_command_builder;
 
 /// Hook system configuration
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -227,9 +228,7 @@ async fn run_hook_command(
     let timeout = Duration::from_millis(timeout_ms);
 
     let result = tokio::time::timeout(timeout, async {
-        Command::new("sh")
-            .arg("-c")
-            .arg(&interpolated)
+        shell_command_builder(&interpolated)
             .envs(env_vars)
             .output()
             .await

--- a/crates/aion-config/src/lib.rs
+++ b/crates/aion-config/src/lib.rs
@@ -8,3 +8,4 @@ pub mod debug;
 pub mod file_cache;
 pub mod hooks;
 pub mod plan;
+pub mod shell;

--- a/crates/aion-config/src/shell.rs
+++ b/crates/aion-config/src/shell.rs
@@ -1,0 +1,75 @@
+use std::process::Output;
+
+use tokio::process::Command;
+
+pub struct ShellInfo {
+    pub program: &'static str,
+    pub flag: &'static str,
+}
+
+pub fn shell_info() -> ShellInfo {
+    if cfg!(windows) {
+        ShellInfo {
+            program: "cmd",
+            flag: "/C",
+        }
+    } else {
+        ShellInfo {
+            program: "sh",
+            flag: "-c",
+        }
+    }
+}
+
+pub fn shell_command_builder(command_str: &str) -> Command {
+    let info = shell_info();
+    let mut cmd = Command::new(info.program);
+    cmd.arg(info.flag).arg(command_str);
+    cmd
+}
+
+pub async fn shell_command(command_str: &str) -> std::io::Result<Output> {
+    shell_command_builder(command_str).output().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_info_returns_platform_appropriate_values() {
+        let info = shell_info();
+        if cfg!(windows) {
+            assert_eq!(info.program, "cmd");
+            assert_eq!(info.flag, "/C");
+        } else {
+            assert_eq!(info.program, "sh");
+            assert_eq!(info.flag, "-c");
+        }
+    }
+
+    #[tokio::test]
+    async fn shell_command_runs_echo() {
+        let output = shell_command("echo hello").await.expect("shell_command failed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn shell_command_builder_allows_env_and_cwd() {
+        let tmp = std::env::temp_dir();
+        let cmd_str = if cfg!(windows) {
+            "echo %MY_VAR%"
+        } else {
+            "echo $MY_VAR"
+        };
+        let output = shell_command_builder(cmd_str)
+            .env("MY_VAR", "test_value")
+            .current_dir(&tmp)
+            .output()
+            .await
+            .expect("builder failed");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("test_value"));
+    }
+}

--- a/crates/aion-config/src/shell.rs
+++ b/crates/aion-config/src/shell.rs
@@ -50,7 +50,9 @@ mod tests {
 
     #[tokio::test]
     async fn shell_command_runs_echo() {
-        let output = shell_command("echo hello").await.expect("shell_command failed");
+        let output = shell_command("echo hello")
+            .await
+            .expect("shell_command failed");
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(stdout.contains("hello"));
     }

--- a/crates/aion-skills/src/shell.rs
+++ b/crates/aion-skills/src/shell.rs
@@ -189,25 +189,14 @@ fn extract_shell_matches(content: &str) -> Vec<ShellMatch> {
 
 /// Execute a single shell command and return its combined stdout/stderr output.
 async fn execute_command(command: &str, cwd: &str) -> Result<String, ShellExecutionError> {
-    let output = if cfg!(windows) {
-        tokio::process::Command::new("cmd")
-            .arg("/C")
-            .arg(command)
-            .current_dir(cwd)
-            .output()
-            .await
-    } else {
-        tokio::process::Command::new("bash")
-            .arg("-c")
-            .arg(command)
-            .current_dir(cwd)
-            .output()
-            .await
-    }
-    .map_err(|e| ShellExecutionError::CommandFailed {
-        pattern: command.to_owned(),
-        output: e.to_string(),
-    })?;
+    let output = aion_config::shell::shell_command_builder(command)
+        .current_dir(cwd)
+        .output()
+        .await
+        .map_err(|e| ShellExecutionError::CommandFailed {
+            pattern: command.to_owned(),
+            output: e.to_string(),
+        })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/aion-tools/src/bash.rs
+++ b/crates/aion-tools/src/bash.rs
@@ -74,10 +74,7 @@ impl Tool for BashTool {
 
         let timeout = Duration::from_millis(timeout_ms);
 
-        let result = tokio::time::timeout(timeout, async {
-            shell_command(command).await
-        })
-        .await;
+        let result = tokio::time::timeout(timeout, async { shell_command(command).await }).await;
 
         match result {
             Ok(Ok(output)) => {

--- a/crates/aion-tools/src/bash.rs
+++ b/crates/aion-tools/src/bash.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
-use tokio::process::Command;
 
+use aion_config::shell::shell_command;
 use aion_protocol::events::ToolCategory;
 use aion_types::tool::{JsonSchema, ToolResult};
 
@@ -75,7 +75,7 @@ impl Tool for BashTool {
         let timeout = Duration::from_millis(timeout_ms);
 
         let result = tokio::time::timeout(timeout, async {
-            Command::new("sh").arg("-c").arg(command).output().await
+            shell_command(command).await
         })
         .await;
 
@@ -113,5 +113,28 @@ impl Tool for BashTool {
     fn describe(&self, input: &Value) -> String {
         let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
         format!("Execute: {}", crate::truncate_utf8(cmd, 80))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn execute_echo_returns_stdout() {
+        let tool = BashTool;
+        let input = json!({"command": "echo hello_bash"});
+        let result = tool.execute(input).await;
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert!(result.content.contains("hello_bash"));
+    }
+
+    #[tokio::test]
+    async fn execute_invalid_command_returns_error() {
+        let tool = BashTool;
+        let input = json!({"command": "nonexistent_command_xyz_123"});
+        let result = tool.execute(input).await;
+        assert!(result.is_error);
     }
 }

--- a/crates/aion-tools/src/grep.rs
+++ b/crates/aion-tools/src/grep.rs
@@ -143,10 +143,7 @@ async fn try_grep(pattern: &str, path: &str, case_insensitive: bool) -> ToolResu
             .arg("/N")
             .arg("/R")
             .arg(pattern)
-            .arg(format!(
-                "{}\\*",
-                path.trim_end_matches(['\\', '/'])
-            ));
+            .arg(format!("{}\\*", path.trim_end_matches(['\\', '/'])));
         if case_insensitive {
             c.arg("/I");
         }

--- a/crates/aion-tools/src/grep.rs
+++ b/crates/aion-tools/src/grep.rs
@@ -137,12 +137,28 @@ async fn try_ripgrep(
 }
 
 async fn try_grep(pattern: &str, path: &str, case_insensitive: bool) -> ToolResult {
-    let mut cmd = Command::new("grep");
-    cmd.arg("-rn").arg(pattern).arg(path);
-
-    if case_insensitive {
-        cmd.arg("-i");
-    }
+    let mut cmd = if cfg!(windows) {
+        let mut c = Command::new("findstr");
+        c.arg("/S")
+            .arg("/N")
+            .arg("/R")
+            .arg(pattern)
+            .arg(format!(
+                "{}\\*",
+                path.trim_end_matches(['\\', '/'])
+            ));
+        if case_insensitive {
+            c.arg("/I");
+        }
+        c
+    } else {
+        let mut c = Command::new("grep");
+        c.arg("-rn").arg(pattern).arg(path);
+        if case_insensitive {
+            c.arg("-i");
+        }
+        c
+    };
 
     match cmd.output().await {
         Ok(output) => {
@@ -153,7 +169,6 @@ async fn try_grep(pattern: &str, path: &str, case_insensitive: bool) -> ToolResu
                     is_error: false,
                 }
             } else {
-                // Limit to 250 lines
                 let lines: Vec<&str> = stdout.lines().take(250).collect();
                 ToolResult {
                     content: lines.join("\n"),
@@ -165,5 +180,23 @@ async fn try_grep(pattern: &str, path: &str, case_insensitive: bool) -> ToolResu
             content: format!("grep failed: {}", e),
             is_error: true,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn grep_tool_finds_pattern_in_own_source() {
+        let tool = GrepTool;
+        let input = json!({
+            "pattern": "GrepTool",
+            "path": env!("CARGO_MANIFEST_DIR")
+        });
+        let result = tool.execute(input).await;
+        assert!(!result.is_error, "grep failed: {}", result.content);
+        assert!(result.content.contains("GrepTool"));
     }
 }


### PR DESCRIPTION
## Summary

- **新建 `aion-config::shell` 模块**，提供 `shell_info()` / `shell_command()` / `shell_command_builder()` 三个跨平台 API（Unix 用 `sh -c`，Windows 用 `cmd /C`）
- **修复 BashTool**（`aion-tools/bash.rs`）：硬编码 `Command::new("sh")` 导致 Windows 上所有 Bash 工具调用报 "Failed to execute command: program not found"
- **修复 HookEngine**（`aion-config/hooks.rs`）：同样的 `sh` 硬编码导致 Windows hooks 全部失效
- **修复 GrepTool fallback**（`aion-tools/grep.rs`）：`grep` fallback 在 Windows 上改用 `findstr`
- **消除 `aion-skills/shell.rs` 的重复平台检测代码**：19 行 inline `cfg!(windows)` 分支替换为共享 helper（8 行）

### Root Cause

`BashTool::execute()` 和 `HookEngine::run_hook_command()` 硬编码 `Command::new("sh")`，Windows 上没有 `sh`，导致所有命令执行失败。`aion-skills` 虽然已有正确的平台适配，但没有被复用。

### Design

遵循 AGENTS.md "Centralize Platform Differences" 原则，将平台 shell 选择集中到 `aion-config::shell`（所有受影响 crate 的公共依赖），所有调用点改用共享 API，防止后续新增功能重复犯同样的错误。

## Test plan

- [x] `aion-config::shell` 新增 3 个单元测试（shell_info / shell_command / shell_command_builder）
- [x] `BashTool` 新增 2 个测试（echo 正常输出 / 无效命令报错）
- [x] `GrepTool` 新增 1 个测试（在自身源码中搜索 pattern）
- [x] 全量 `cargo test --workspace` 通过（0 failed）
- [x] `cargo clippy --workspace` 零警告
- [x] `cargo fmt --all` 通过
- [ ] CI Windows runner 验证（本地只能验证 macOS/Linux 分支，Windows `cfg!` 分支依赖 CI）