### PR TITLE
feat: add AgentBootstrap builder for consistent engine initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "regex",
  "serde",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aion-config",
  "chrono",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aion-types",
  "rstest",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use aion_config::config::Config;
 use aion_mcp::manager::McpManager;
@@ -37,11 +37,7 @@ pub struct AgentBootstrap {
 }
 
 impl AgentBootstrap {
-    pub fn new(
-        config: Config,
-        workspace: impl Into<String>,
-        output: Arc<dyn OutputSink>,
-    ) -> Self {
+    pub fn new(config: Config, workspace: impl Into<String>, output: Arc<dyn OutputSink>) -> Self {
         Self {
             config,
             workspace: workspace.into(),
@@ -197,12 +193,7 @@ impl AgentBootstrap {
                 session,
             )
         } else {
-            AgentEngine::new_with_provider(
-                provider.clone(),
-                self.config,
-                registry,
-                self.output,
-            )
+            AgentEngine::new_with_provider(provider.clone(), self.config, registry, self.output)
         };
         engine.set_plan_active_flag(plan_active_flag);
 

--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use aion_config::config::Config;
+use aion_mcp::manager::McpManager;
+use aion_providers::LlmProvider;
+
+use crate::engine::AgentEngine;
+use crate::output::OutputSink;
+use crate::session::Session;
+
+/// Result of bootstrapping an agent engine with all features initialized.
+pub struct BootstrapResult {
+    pub engine: AgentEngine,
+    pub provider: Arc<dyn LlmProvider>,
+    pub mcp_managers: Vec<Arc<McpManager>>,
+    pub has_mcp: bool,
+}
+
+/// Builder for creating a fully-initialized `AgentEngine`.
+///
+/// Encapsulates the complete initialization pipeline so all consumers
+/// (CLI, backend, sub-agents) get consistent behavior:
+///
+/// - System prompt always includes model identity, working directory, date
+/// - Tool usage guidance is always injected
+/// - AGENTS.md is loaded from the workspace hierarchy
+/// - Skills, MCP, plan mode, spawn are enabled based on `Config` fields
+pub struct AgentBootstrap {
+    config: Config,
+    workspace: String,
+    output: Arc<dyn OutputSink>,
+    provider: Option<Arc<dyn LlmProvider>>,
+    resume_session: Option<Session>,
+    extra_skill_dirs: Vec<PathBuf>,
+}
+
+impl AgentBootstrap {
+    pub fn new(
+        config: Config,
+        workspace: impl Into<String>,
+        output: Arc<dyn OutputSink>,
+    ) -> Self {
+        Self {
+            config,
+            workspace: workspace.into(),
+            output,
+            provider: None,
+            resume_session: None,
+            extra_skill_dirs: Vec::new(),
+        }
+    }
+
+    /// Use a pre-created provider instead of creating one from config.
+    pub fn provider(mut self, provider: Arc<dyn LlmProvider>) -> Self {
+        self.provider = Some(provider);
+        self
+    }
+
+    /// Resume from a previously saved session.
+    pub fn resume(mut self, session: Session) -> Self {
+        self.resume_session = Some(session);
+        self
+    }
+
+    /// Add extra directories to scan for skills.
+    pub fn extra_skill_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
+        self.extra_skill_dirs = dirs;
+        self
+    }
+
+    /// Read-only access to the config (for session management before build).
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Build the fully-initialized engine.
+    pub async fn build(self) -> anyhow::Result<BootstrapResult> {
+        todo!("Implemented in Task 2")
+    }
+}

--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use aion_config::config::Config;
@@ -75,7 +76,141 @@ impl AgentBootstrap {
     }
 
     /// Build the fully-initialized engine.
-    pub async fn build(self) -> anyhow::Result<BootstrapResult> {
-        todo!("Implemented in Task 2")
+    pub async fn build(mut self) -> anyhow::Result<BootstrapResult> {
+        let cwd = &self.workspace;
+        let cwd_path = std::path::Path::new(cwd);
+
+        let provider = self
+            .provider
+            .unwrap_or_else(|| aion_providers::create_provider(&self.config));
+
+        let memory_dir = aion_memory::paths::auto_memory_dir(cwd_path);
+
+        let file_cache = if self.config.file_cache.enabled {
+            Some(Arc::new(std::sync::RwLock::new(
+                aion_tools::file_cache::FileStateCache::new(&self.config.file_cache),
+            )))
+        } else {
+            None
+        };
+
+        let mut registry = aion_tools::registry::ToolRegistry::new();
+        registry.register(Box::new(aion_tools::read::ReadTool::new(
+            file_cache.clone(),
+        )));
+        registry.register(Box::new(aion_tools::write::WriteTool::new(
+            file_cache.clone(),
+        )));
+        registry.register(Box::new(aion_tools::edit::EditTool::new(file_cache)));
+        registry.register(Box::new(aion_tools::bash::BashTool));
+        registry.register(Box::new(aion_tools::grep::GrepTool));
+        registry.register(Box::new(aion_tools::glob::GlobTool));
+
+        let builtin_names: Vec<String> = registry.tool_names();
+
+        let mut mcp_managers: Vec<Arc<McpManager>> = Vec::new();
+        let mcp_manager = if !self.config.mcp.servers.is_empty() {
+            match McpManager::connect_all(&self.config.mcp.servers).await {
+                Ok(mgr) => {
+                    let mgr = Arc::new(mgr);
+                    aion_mcp::tool_proxy::register_mcp_tools(
+                        &mut registry,
+                        &mgr,
+                        &builtin_names,
+                        &self.config.mcp.servers,
+                    );
+                    mcp_managers.push(mgr.clone());
+                    Some(mgr)
+                }
+                Err(e) => {
+                    self.output
+                        .emit_error(&format!("MCP initialization error: {e}"));
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let has_mcp = mcp_manager.is_some();
+
+        let skills = aion_skills::loader::load_all_skills(
+            cwd_path,
+            &self.extra_skill_dirs,
+            false,
+            mcp_manager.as_deref(),
+        )
+        .await;
+
+        let mut prompt_cache = crate::context::SystemPromptCache::new();
+        let system_prompt = crate::context::build_system_prompt(
+            &mut prompt_cache,
+            self.config.system_prompt.as_deref(),
+            cwd,
+            &self.config.model,
+            &skills,
+            None,
+            memory_dir.as_deref(),
+            false,
+            self.config.compact.toon,
+        );
+        self.config.system_prompt = Some(system_prompt);
+
+        let skills_arc = Arc::new(skills);
+        let skill_checker = aion_skills::permissions::SkillPermissionChecker::new(
+            self.config.tools.skills.deny.clone(),
+            self.config.tools.skills.allow.clone(),
+            self.config.tools.auto_approve,
+        );
+        registry.register(Box::new(crate::skill_tool::SkillTool::new(
+            skills_arc,
+            cwd.to_string(),
+            skill_checker,
+        )));
+
+        let spawner = Arc::new(crate::spawner::AgentSpawner::new(
+            provider.clone(),
+            self.config.clone(),
+        ));
+        registry.register(Box::new(crate::spawn_tool::SpawnTool::new(spawner)));
+
+        let plan_active_flag = Arc::new(AtomicBool::new(false));
+        if self.config.plan.enabled {
+            registry.register(Box::new(crate::plan::tools::EnterPlanModeTool::new(
+                Arc::clone(&plan_active_flag),
+            )));
+            registry.register(Box::new(crate::plan::tools::ExitPlanModeTool::new(
+                Arc::clone(&plan_active_flag),
+            )));
+        }
+
+        let tool_defs_snapshot = registry.to_tool_defs();
+        registry.register(Box::new(aion_tools::tool_search::ToolSearchTool::new(
+            tool_defs_snapshot,
+        )));
+
+        let mut engine = if let Some(session) = self.resume_session {
+            AgentEngine::resume_with_provider(
+                provider.clone(),
+                self.config,
+                registry,
+                self.output,
+                session,
+            )
+        } else {
+            AgentEngine::new_with_provider(
+                provider.clone(),
+                self.config,
+                registry,
+                self.output,
+            )
+        };
+        engine.set_plan_active_flag(plan_active_flag);
+
+        Ok(BootstrapResult {
+            engine,
+            provider,
+            mcp_managers,
+            has_mcp,
+        })
     }
 }

--- a/crates/aion-agent/src/lib.rs
+++ b/crates/aion-agent/src/lib.rs
@@ -1,6 +1,7 @@
 // Core agent infrastructure: engine, session, orchestration, output sinks.
 
 pub mod agents_md;
+pub mod bootstrap;
 pub mod cache_diagnostics;
 pub mod compact;
 pub mod confirm;

--- a/crates/aion-agent/tests/bootstrap_test.rs
+++ b/crates/aion-agent/tests/bootstrap_test.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use aion_agent::bootstrap::AgentBootstrap;
+use aion_agent::output::null_sink::NullSink;
+use aion_config::compat::ProviderCompat;
+use aion_config::config::{Config, ProviderType};
+
+fn minimal_config() -> Config {
+    Config {
+        provider_label: "openai".into(),
+        provider: ProviderType::OpenAI,
+        api_key: "sk-test".into(),
+        base_url: "http://localhost:0".into(),
+        model: "gpt-test-model".into(),
+        max_tokens: 1024,
+        max_turns: Some(5),
+        system_prompt: None,
+        thinking: None,
+        prompt_caching: false,
+        compat: ProviderCompat::openai_defaults(),
+        tools: Default::default(),
+        session: Default::default(),
+        compact: Default::default(),
+        plan: Default::default(),
+        file_cache: Default::default(),
+        hooks: Default::default(),
+        bedrock: None,
+        vertex: None,
+        mcp: Default::default(),
+        debug: Default::default(),
+    }
+}
+
+#[tokio::test]
+async fn bootstrap_builds_engine_with_model_in_prompt() {
+    let config = minimal_config();
+    let output: Arc<dyn aion_agent::output::OutputSink> = Arc::new(NullSink);
+
+    let result = AgentBootstrap::new(config, "/tmp/test-workspace", output)
+        .build()
+        .await
+        .expect("bootstrap should succeed");
+
+    assert!(!result.engine.tool_names().is_empty());
+    assert!(!result.has_mcp);
+    assert!(result.mcp_managers.is_empty());
+}

--- a/crates/aion-agent/tests/bootstrap_test.rs
+++ b/crates/aion-agent/tests/bootstrap_test.rs
@@ -31,12 +31,14 @@ fn minimal_config() -> Config {
     }
 }
 
+fn null_output() -> Arc<dyn aion_agent::output::OutputSink> {
+    Arc::new(NullSink)
+}
+
 #[tokio::test]
 async fn bootstrap_builds_engine_with_model_in_prompt() {
     let config = minimal_config();
-    let output: Arc<dyn aion_agent::output::OutputSink> = Arc::new(NullSink);
-
-    let result = AgentBootstrap::new(config, "/tmp/test-workspace", output)
+    let result = AgentBootstrap::new(config, "/tmp/test-workspace", null_output())
         .build()
         .await
         .expect("bootstrap should succeed");
@@ -44,4 +46,132 @@ async fn bootstrap_builds_engine_with_model_in_prompt() {
     assert!(!result.engine.tool_names().is_empty());
     assert!(!result.has_mcp);
     assert!(result.mcp_managers.is_empty());
+}
+
+#[tokio::test]
+async fn bootstrap_registers_all_expected_tools() {
+    let config = minimal_config();
+    let result = AgentBootstrap::new(config, "/tmp/test-workspace", null_output())
+        .build()
+        .await
+        .unwrap();
+
+    let names = result.engine.tool_names();
+
+    for expected in &["Read", "Write", "Edit", "Bash", "Grep", "Glob"] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "missing built-in tool: {expected}"
+        );
+    }
+
+    assert!(
+        names.iter().any(|n| n == "Skill"),
+        "SkillTool should be registered"
+    );
+    assert!(
+        names.iter().any(|n| n == "Spawn"),
+        "SpawnTool should be registered"
+    );
+    assert!(
+        names.iter().any(|n| n == "ToolSearch"),
+        "ToolSearchTool should be registered"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_plan_tools_when_enabled() {
+    let mut config = minimal_config();
+    config.plan.enabled = true;
+
+    let result = AgentBootstrap::new(config, "/tmp/test-workspace", null_output())
+        .build()
+        .await
+        .unwrap();
+
+    let names = result.engine.tool_names();
+    assert!(
+        names.iter().any(|n| n == "EnterPlanMode"),
+        "EnterPlanMode should be registered when plan.enabled"
+    );
+    assert!(
+        names.iter().any(|n| n == "ExitPlanMode"),
+        "ExitPlanMode should be registered when plan.enabled"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_no_plan_tools_when_disabled() {
+    let mut config = minimal_config();
+    config.plan.enabled = false;
+
+    let result = AgentBootstrap::new(config, "/tmp/test-workspace", null_output())
+        .build()
+        .await
+        .unwrap();
+
+    let names = result.engine.tool_names();
+    assert!(
+        !names.iter().any(|n| n == "EnterPlanMode"),
+        "EnterPlanMode should NOT be registered when plan.disabled"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_no_mcp_when_no_servers() {
+    let config = minimal_config();
+    let result = AgentBootstrap::new(config, "/tmp/test-workspace", null_output())
+        .build()
+        .await
+        .unwrap();
+
+    assert!(!result.has_mcp);
+    assert!(result.mcp_managers.is_empty());
+}
+
+#[tokio::test]
+async fn bootstrap_with_custom_system_prompt() {
+    let mut config = minimal_config();
+    config.system_prompt = Some("You are a pirate assistant.".into());
+
+    let _result = AgentBootstrap::new(config, "/tmp/test-workspace", null_output())
+        .build()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn bootstrap_with_agents_md_in_workspace() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let workspace = tmp.path();
+    std::fs::write(workspace.join("AGENTS.md"), "PROJECT_RULES_MARKER").unwrap();
+
+    let config = minimal_config();
+    let _result =
+        AgentBootstrap::new(config, workspace.to_string_lossy().as_ref(), null_output())
+            .build()
+            .await
+            .unwrap();
+}
+
+#[tokio::test]
+async fn bootstrap_config_accessor_returns_config() {
+    let config = minimal_config();
+    let bootstrap = AgentBootstrap::new(config, "/tmp/ws", null_output());
+    assert_eq!(bootstrap.config().model, "gpt-test-model");
+    assert_eq!(bootstrap.config().max_tokens, 1024);
+}
+
+#[tokio::test]
+async fn bootstrap_with_external_provider() {
+    let config = minimal_config();
+    let provider = aion_providers::create_provider(&config);
+
+    let result = AgentBootstrap::new(config, "/tmp/test-workspace", null_output())
+        .provider(provider)
+        .build()
+        .await
+        .unwrap();
+
+    assert!(!result.engine.tool_names().is_empty());
 }

--- a/crates/aion-agent/tests/bootstrap_test.rs
+++ b/crates/aion-agent/tests/bootstrap_test.rs
@@ -147,11 +147,10 @@ async fn bootstrap_with_agents_md_in_workspace() {
     std::fs::write(workspace.join("AGENTS.md"), "PROJECT_RULES_MARKER").unwrap();
 
     let config = minimal_config();
-    let _result =
-        AgentBootstrap::new(config, workspace.to_string_lossy().as_ref(), null_output())
-            .build()
-            .await
-            .unwrap();
+    let _result = AgentBootstrap::new(config, workspace.to_string_lossy().as_ref(), null_output())
+        .build()
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -1,40 +1,23 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 
 use clap::Parser;
 
-use aion_agent::context;
-use aion_agent::engine::AgentEngine;
+use aion_agent::bootstrap::AgentBootstrap;
 use aion_agent::output::OutputSink;
 use aion_agent::output::protocol_sink::ProtocolSink;
 use aion_agent::output::terminal::TerminalSink;
-use aion_agent::plan::tools::{EnterPlanModeTool, ExitPlanModeTool};
 use aion_agent::session;
-use aion_agent::skill_tool::SkillTool;
-use aion_agent::spawn_tool::SpawnTool;
-use aion_agent::spawner::AgentSpawner;
 use aion_config::auth;
 use aion_config::config::{self, CliArgs, Config, McpServerConfig, TransportType};
 use aion_mcp::manager::McpManager;
-use aion_mcp::tool_proxy::{register_mcp_tools, register_single_server_tools};
+use aion_mcp::tool_proxy::register_single_server_tools;
 use aion_protocol::commands::{ApprovalScope, ProtocolCommand};
 use aion_protocol::events::ProtocolEvent;
 use aion_protocol::reader::spawn_stdin_reader;
 use aion_protocol::writer::ProtocolWriter;
 use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
-use aion_skills::loader::load_all_skills;
-use aion_skills::permissions::SkillPermissionChecker;
-use aion_tools::bash::BashTool;
-use aion_tools::edit::EditTool;
-use aion_tools::file_cache::FileStateCache;
-use aion_tools::glob::GlobTool;
-use aion_tools::grep::GrepTool;
-use aion_tools::read::ReadTool;
-use aion_tools::registry::ToolRegistry;
-use aion_tools::tool_search::ToolSearchTool;
-use aion_tools::write::WriteTool;
 
 #[derive(Parser)]
 #[command(
@@ -227,156 +210,57 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Resolve memory directory for the current project
-    let cwd_path = std::path::Path::new(&cwd);
-    let memory_dir = aion_memory::paths::auto_memory_dir(cwd_path);
-
-    // Create file state cache (shared across Read/Edit/Write tools)
-    let file_cache = if config.file_cache.enabled {
-        Some(Arc::new(std::sync::RwLock::new(FileStateCache::new(
-            &config.file_cache,
-        ))))
-    } else {
-        None
-    };
-
-    // Register built-in tools
-    let mut registry = ToolRegistry::new();
-    registry.register(Box::new(ReadTool::new(file_cache.clone())));
-    registry.register(Box::new(WriteTool::new(file_cache.clone())));
-    registry.register(Box::new(EditTool::new(file_cache)));
-    registry.register(Box::new(BashTool));
-    registry.register(Box::new(GrepTool));
-    registry.register(Box::new(GlobTool));
-
-    let builtin_names: Vec<String> = registry.tool_names();
-
-    // Connect to MCP servers (if configured)
-    let mcp_manager = if !config.mcp.servers.is_empty() {
-        match McpManager::connect_all(&config.mcp.servers).await {
-            Ok(mgr) => {
-                let mgr = Arc::new(mgr);
-                register_mcp_tools(&mut registry, &mgr, &builtin_names, &config.mcp.servers);
-                Some(mgr)
-            }
-            Err(e) => {
-                output.emit_error(&format!("MCP initialization error: {}", e));
-                None
-            }
-        }
-    } else {
-        None
-    };
-
-    // Load skills from all sources (bundled, MCP, user, project)
-    let skills = load_all_skills(cwd_path, &[], false, mcp_manager.as_deref()).await;
-
-    // Build system prompt with loaded skills
-    let mut prompt_cache = aion_agent::context::SystemPromptCache::new();
-    let system_prompt = context::build_system_prompt(
-        &mut prompt_cache,
-        config.system_prompt.as_deref(),
-        &cwd,
-        &config.model,
-        &skills,
-        None,
-        memory_dir.as_deref(),
-        false,
-        config.compact.toon,
-    );
-    config.system_prompt = Some(system_prompt);
-
-    // Register SkillTool so the LLM can invoke skills
-    let skills_arc = Arc::new(skills);
-    let skill_checker = SkillPermissionChecker::new(
-        config.tools.skills.deny.clone(),
-        config.tools.skills.allow.clone(),
-        config.tools.auto_approve,
-    );
-    registry.register(Box::new(SkillTool::new(
-        skills_arc,
-        cwd.clone(),
-        skill_checker,
-    )));
-
-    // Create provider (shared via Arc for sub-agent reuse)
-    let provider = aion_providers::create_provider(&config);
-
-    // Register SpawnTool (sub-agent spawning)
-    let spawner = Arc::new(AgentSpawner::new(provider.clone(), config.clone()));
-    registry.register(Box::new(SpawnTool::new(spawner.clone())));
-
-    // Register Plan Mode tools (if enabled)
-    let plan_active_flag = Arc::new(AtomicBool::new(false));
-    if config.plan.enabled {
-        registry.register(Box::new(EnterPlanModeTool::new(Arc::clone(
-            &plan_active_flag,
-        ))));
-        registry.register(Box::new(ExitPlanModeTool::new(Arc::clone(
-            &plan_active_flag,
-        ))));
-    }
-
-    // Register ToolSearch (must be after all other tools to capture full snapshot)
-    let tool_defs_snapshot = registry.to_tool_defs();
-    registry.register(Box::new(ToolSearchTool::new(tool_defs_snapshot)));
-
+    // Branch to JSON stream mode
     if cli.json_stream {
-        return run_json_stream_mode(
-            config,
-            registry,
-            provider,
-            mcp_manager,
-            cli.resume,
-            cli.session_id,
-            plan_active_flag.clone(),
-        )
-        .await;
+        return run_json_stream_mode(config, &cwd, cli.resume, cli.session_id).await;
     }
 
     let provider_name = config.provider_label.clone();
 
-    // Handle --resume
-    let mut engine = if let Some(resume_id) = cli.resume {
+    // Bootstrap engine with full feature initialization
+    let mut bootstrap = AgentBootstrap::new(config, &cwd, output.clone());
+
+    if let Some(resume_id) = &cli.resume {
+        let cfg = bootstrap.config();
         let session_mgr = session::SessionManager::new(
-            config.session.directory.clone().into(),
-            config.session.max_sessions,
+            cfg.session.directory.clone().into(),
+            cfg.session.max_sessions,
         );
-        let session = session_mgr.load(&resume_id)?;
+        let session = session_mgr.load(resume_id)?;
         terminal.formatter().session_info(&format!(
             "Resumed session {} ({} messages, {} model)",
             session.id,
             session.messages.len(),
             session.model
         ));
-        AgentEngine::resume_with_provider(provider, config, registry, output.clone(), session)
-    } else {
-        let mut engine = AgentEngine::new_with_provider(provider, config, registry, output.clone());
+        bootstrap = bootstrap.resume(session);
+    }
+
+    let result = bootstrap.build().await?;
+    let mut engine = result.engine;
+
+    if cli.resume.is_none() {
         engine.init_session(&provider_name, &cwd, cli.session_id.as_deref())?;
-        engine
-    };
-    engine.set_plan_active_flag(plan_active_flag.clone());
+    }
 
     let prompt = cli.prompt.join(" ");
     if prompt.is_empty() {
         repl_loop(&mut engine, &terminal, &output).await?;
     } else {
-        let result = engine.run(&prompt, "").await?;
+        let run_result = engine.run(&prompt, "").await?;
         output.emit_stream_end(
             "",
-            result.turns,
-            result.usage.input_tokens,
-            result.usage.output_tokens,
-            result.usage.cache_creation_tokens,
-            result.usage.cache_read_tokens,
+            run_result.turns,
+            run_result.usage.input_tokens,
+            run_result.usage.output_tokens,
+            run_result.usage.cache_creation_tokens,
+            run_result.usage.cache_read_tokens,
         );
     }
 
-    // Run stop hooks before cleanup
     engine.run_stop_hooks().await;
 
-    // Cleanup MCP servers on exit
-    if let Some(mgr) = &mcp_manager {
+    for mgr in &result.mcp_managers {
         mgr.shutdown().await;
     }
 
@@ -384,7 +268,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn repl_loop(
-    engine: &mut AgentEngine,
+    engine: &mut aion_agent::engine::AgentEngine,
     terminal: &Arc<TerminalSink>,
     output: &Arc<dyn OutputSink>,
 ) -> anyhow::Result<()> {
@@ -500,35 +384,37 @@ type PendingConfig = (
 
 async fn run_json_stream_mode(
     config: Config,
-    registry: ToolRegistry,
-    provider: Arc<dyn aion_providers::LlmProvider>,
-    mcp_manager: Option<Arc<McpManager>>,
+    cwd: &str,
     resume: Option<String>,
     session_id: Option<String>,
-    plan_active_flag: Arc<AtomicBool>,
 ) -> anyhow::Result<()> {
     let writer = Arc::new(ProtocolWriter::new());
     let protocol_sink = Arc::new(ProtocolSink::new(writer.clone()));
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let output: Arc<dyn OutputSink> = protocol_sink.clone();
-    let initial_has_mcp = mcp_manager.is_some();
 
     let provider_name = config.provider_label.clone();
-    let cwd = std::env::current_dir()?.to_string_lossy().to_string();
 
-    let mut engine = if let Some(resume_id) = resume {
+    // Bootstrap engine with full feature initialization
+    let mut bootstrap = AgentBootstrap::new(config, cwd, output.clone());
+
+    if let Some(resume_id) = &resume {
+        let cfg = bootstrap.config();
         let session_mgr = session::SessionManager::new(
-            config.session.directory.clone().into(),
-            config.session.max_sessions,
+            cfg.session.directory.clone().into(),
+            cfg.session.max_sessions,
         );
-        let session = session_mgr.load(&resume_id)?;
-        AgentEngine::resume_with_provider(provider, config, registry, output.clone(), session)
-    } else {
-        let mut engine = AgentEngine::new_with_provider(provider, config, registry, output.clone());
-        engine.init_session(&provider_name, &cwd, session_id.as_deref())?;
-        engine
-    };
-    engine.set_plan_active_flag(plan_active_flag);
+        let session = session_mgr.load(resume_id)?;
+        bootstrap = bootstrap.resume(session);
+    }
+
+    let result = bootstrap.build().await?;
+    let mut engine = result.engine;
+    let initial_has_mcp = result.has_mcp;
+
+    if resume.is_none() {
+        engine.init_session(&provider_name, cwd, session_id.as_deref())?;
+    }
 
     let sid = engine.current_session_id();
     protocol_sink.emit_ready(
@@ -544,8 +430,6 @@ async fn run_json_stream_mode(
     let mut cmd_rx = spawn_stdin_reader();
 
     // --- Pre-message phase: accept AddMcpServer commands ---
-    // Dynamic servers get their own McpManager instances because the initial
-    // mcp_manager Arc may already be shared by tool proxies (Arc::get_mut fails).
     let mut dynamic_managers: Vec<Arc<McpManager>> = Vec::new();
     let mut first_cmd: Option<ProtocolCommand> = None;
 
@@ -612,7 +496,7 @@ async fn run_json_stream_mode(
         }
     }
 
-    let has_mcp = mcp_manager.is_some() || !dynamic_managers.is_empty();
+    let has_mcp = initial_has_mcp || !dynamic_managers.is_empty();
     let mut pending_cmd = first_cmd;
 
     loop {
@@ -655,8 +539,6 @@ async fn run_json_stream_mode(
                                     }
                                     Err(e) => {
                                         output.emit_error(&e.to_string());
-                                        // Always emit stream_end so the client
-                                        // can leave the "running" state.
                                         output.emit_stream_end(&msg_id, 0, 0, 0, 0, 0);
                                     }
                                 }
@@ -699,9 +581,8 @@ async fn run_json_stream_mode(
                             }
                         }
                     }
-                } // engine_fut dropped here, releasing mutable borrow
+                }
 
-                // Apply any config changes that arrived during processing
                 if let Some((model, thinking, thinking_budget, effort, compaction)) =
                     pending_config.take()
                 {
@@ -718,7 +599,6 @@ async fn run_json_stream_mode(
                             message: format!("config applied: {}", changes.join(", ")),
                         });
                     }
-                    // config_changed covers both config and mode updates
                     protocol_sink.emit_config_changed(
                         engine.compat(),
                         has_mcp,
@@ -805,7 +685,7 @@ async fn run_json_stream_mode(
     }
 
     engine.run_stop_hooks().await;
-    if let Some(mgr) = &mcp_manager {
+    for mgr in &result.mcp_managers {
         mgr.shutdown().await;
     }
     for mgr in &dynamic_managers {


### PR DESCRIPTION
## Summary

- Add `AgentBootstrap` builder in `aion-agent` that encapsulates the full engine initialization pipeline (tool registration, system prompt assembly with model identity, MCP, skills, plan mode, spawn, ToolSearch)
- Refactor CLI `main.rs` to use `AgentBootstrap`, removing ~120 lines of duplicated manual setup code
- Ensure all consumers (CLI, backend, sub-agents) get identical agent behavior through a single initialization path

## Motivation

External integrations (e.g. aionui-backend) that construct `AgentEngine` directly bypass `build_system_prompt()`, causing missing model identity, tool guidance, AGENTS.md, memory, skills, and other features that only the CLI path previously assembled. This PR extracts that logic into a reusable builder at the library layer.

## Changes

| File | Change |
|------|--------|
| `crates/aion-agent/src/bootstrap.rs` | New — `AgentBootstrap` builder + `BootstrapResult` (207 lines) |
| `crates/aion-agent/src/lib.rs` | Add `pub mod bootstrap` |
| `crates/aion-agent/tests/bootstrap_test.rs` | New — 9 integration tests |
| `crates/aion-cli/src/main.rs` | Refactored — net -120 lines (181 deleted, 61 added) |

## Usage

```rust
let result = AgentBootstrap::new(config, workspace, output)
    .provider(provider)       // optional: use pre-created provider
    .resume(session)          // optional: resume saved session
    .extra_skill_dirs(dirs)   // optional: additional skill directories
    .build()
    .await?;

// result.engine — fully initialized AgentEngine
// result.provider — Arc<dyn LlmProvider>
// result.mcp_managers — for shutdown cleanup
// result.has_mcp — whether MCP servers are connected
```

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 327+ tests including 9 new bootstrap tests)
- [x] CLI interactive mode and JSON stream mode both use bootstrap
- [ ] Verify CLI behavior unchanged via manual smoke test