### PR TITLE
refactor: extract ProtocolEmitter trait for backend integration

### DIFF
--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -42,7 +42,7 @@ pub struct AgentEngine {
     output: Arc<dyn OutputSink>,
     current_msg_id: String,
     approval_manager: Option<Arc<aion_protocol::ToolApprovalManager>>,
-    protocol_writer: Option<Arc<aion_protocol::writer::ProtocolWriter>>,
+    protocol_writer: Option<Arc<dyn aion_protocol::writer::ProtocolEmitter>>,
     allow_list: Vec<String>,
     /// Persisted reasoning effort, updated by skill context modifiers.
     /// Carried into each turn's LlmRequest.reasoning_effort.
@@ -240,7 +240,7 @@ impl AgentEngine {
         self.approval_manager = Some(mgr);
     }
 
-    pub fn set_protocol_writer(&mut self, writer: Arc<aion_protocol::writer::ProtocolWriter>) {
+    pub fn set_protocol_writer(&mut self, writer: Arc<dyn aion_protocol::writer::ProtocolEmitter>) {
         self.protocol_writer = Some(writer);
     }
 

--- a/crates/aion-agent/src/orchestration.rs
+++ b/crates/aion-agent/src/orchestration.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use crate::confirm::{ConfirmResult, ToolConfirmer};
 use aion_config::hooks::HookEngine;
 use aion_protocol::events::{OutputType, ProtocolEvent, ToolCategory, ToolInfo, ToolStatus};
-use aion_protocol::writer::ProtocolWriter;
+use aion_protocol::writer::ProtocolEmitter;
 use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
 use aion_types::message::ContentBlock;
 use aion_types::skill_types::ContextModifier;
@@ -229,7 +229,7 @@ pub async fn execute_tool_calls_with_approval(
     registry: &ToolRegistry,
     tool_calls: &[ContentBlock],
     approval_manager: &Arc<ToolApprovalManager>,
-    writer: &Arc<ProtocolWriter>,
+    writer: &Arc<dyn ProtocolEmitter>,
     msg_id: &str,
     auto_approve: bool,
     allow_list: &[String],

--- a/crates/aion-agent/src/output/protocol_sink.rs
+++ b/crates/aion-agent/src/output/protocol_sink.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use aion_config::compat::ProviderCompat;
 use aion_protocol::events::{Capabilities, ErrorInfo, ProtocolEvent, Usage};
-use aion_protocol::writer::ProtocolWriter;
+use aion_protocol::writer::{ProtocolEmitter, ProtocolWriter};
 
 use super::OutputSink;
 

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -16,7 +16,7 @@ use aion_mcp::tool_proxy::register_single_server_tools;
 use aion_protocol::commands::{ApprovalScope, ProtocolCommand};
 use aion_protocol::events::ProtocolEvent;
 use aion_protocol::reader::spawn_stdin_reader;
-use aion_protocol::writer::ProtocolWriter;
+use aion_protocol::writer::{ProtocolEmitter, ProtocolWriter};
 use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
 
 #[derive(Parser)]

--- a/crates/aion-protocol/src/writer.rs
+++ b/crates/aion-protocol/src/writer.rs
@@ -3,6 +3,15 @@ use std::sync::Mutex;
 
 use crate::events::ProtocolEvent;
 
+/// Trait for emitting protocol events to a host.
+///
+/// The default implementation (`ProtocolWriter`) writes JSON Lines to stdout.
+/// Backend integrations provide alternative implementations that bridge events
+/// to their own event systems.
+pub trait ProtocolEmitter: Send + Sync {
+    fn emit(&self, event: &ProtocolEvent) -> io::Result<()>;
+}
+
 /// Thread-safe JSON Lines writer to stdout
 pub struct ProtocolWriter {
     writer: Mutex<BufWriter<Stdout>>,
@@ -20,9 +29,10 @@ impl ProtocolWriter {
             writer: Mutex::new(BufWriter::new(io::stdout())),
         }
     }
+}
 
-    /// Serialize and write a protocol event as a single JSON line to stdout
-    pub fn emit(&self, event: &ProtocolEvent) -> io::Result<()> {
+impl ProtocolEmitter for ProtocolWriter {
+    fn emit(&self, event: &ProtocolEvent) -> io::Result<()> {
         let mut w = self
             .writer
             .lock()
@@ -46,7 +56,6 @@ mod tests {
 
     #[test]
     fn test_writer_emit_does_not_panic() {
-        // Just verify emit doesn't panic (output goes to stdout)
         let writer = ProtocolWriter::new();
         let event = ProtocolEvent::Ready {
             version: "0.1.0".to_string(),


### PR DESCRIPTION
## Summary
- Extract `ProtocolEmitter` trait from `ProtocolWriter` in `aion-protocol`, enabling backend integrations to provide custom protocol event sinks
- Change `AgentEngine::set_protocol_writer()` and `execute_tool_calls_with_approval()` to accept `Arc<dyn ProtocolEmitter>` instead of `Arc<ProtocolWriter>`
- `ProtocolWriter` (JSON Lines to stdout) implements the trait as before — CLI behavior unchanged

## Motivation
In the separated frontend/backend architecture (aionui-backend), the agent engine runs as a library, not a CLI process. Tool approval confirmations need to be bridged to the backend's event system instead of written to stdout. This trait extraction makes that possible without modifying aionrs internals.

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 153 tests)
- [ ] Integration test with aionui-backend `BackendProtocolSink` implementing `ProtocolEmitter`