### PR TITLE
fix(openai): preserve reasoning_content in multi-turn conversations

### DIFF
--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -46,6 +46,16 @@ impl OpenAIProvider {
     fn build_messages(messages: &[Message], system: &str, compat: &ProviderCompat) -> Vec<Value> {
         let mut result: Vec<Value> = Vec::new();
 
+        // Check if any assistant message in the conversation has thinking content.
+        // If so, DeepSeek API requires ALL assistant messages to include
+        // reasoning_content (even if empty string).
+        let has_any_thinking = messages.iter().any(|m| {
+            m.role == Role::Assistant
+                && m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Thinking { .. }))
+        });
+
         // System message first
         if !system.is_empty() {
             result.push(json!({
@@ -104,7 +114,8 @@ impl OpenAIProvider {
 
                     // Preserve reasoning_content for models with thinking mode
                     // (e.g. DeepSeek Reasoner, Kimi K2.5). The API requires
-                    // previous reasoning_content to be sent back in multi-turn.
+                    // ALL assistant messages to include reasoning_content once
+                    // any message in the conversation has it.
                     let thinking: String = msg
                         .content
                         .iter()
@@ -118,7 +129,7 @@ impl OpenAIProvider {
                         .collect::<Vec<_>>()
                         .join("");
 
-                    if !thinking.is_empty() {
+                    if has_any_thinking {
                         msg_json["reasoning_content"] = json!(thinking);
                     }
 
@@ -366,6 +377,23 @@ fn merge_consecutive_assistant(messages: &mut Vec<Value>) {
 
             if !merged_text.is_empty() {
                 messages[i]["content"] = json!(merged_text);
+            }
+
+            // Merge reasoning_content
+            let curr_rc = messages[i]["reasoning_content"]
+                .as_str()
+                .unwrap_or("")
+                .to_string();
+            let next_rc = next["reasoning_content"].as_str().unwrap_or("").to_string();
+            let merged_rc = match (curr_rc.is_empty(), next_rc.is_empty()) {
+                (true, true) => String::new(),
+                (true, false) => next_rc,
+                (false, true) => curr_rc,
+                (false, false) => format!("{}{}", curr_rc, next_rc),
+            };
+
+            if !merged_rc.is_empty() {
+                messages[i]["reasoning_content"] = json!(merged_rc);
             }
 
             // Merge tool_calls


### PR DESCRIPTION
## Summary

- DeepSeek API requires that once any assistant message includes `reasoning_content`, **all** assistant messages must include the field (even as empty string)
- Previously, turns where the model did not produce thinking output would omit `reasoning_content` entirely, causing `API error 400: The reasoning_content in the thinking mode must be passed back to the API`
- Also fixes `merge_consecutive_assistant` which was dropping `reasoning_content` when merging adjacent assistant messages

## Changes

1. **`build_messages`**: Scan conversation history for any Thinking blocks; if found, all assistant messages unconditionally include `reasoning_content` (empty string when no thinking was produced)
2. **`merge_consecutive_assistant`**: Preserve and concatenate `reasoning_content` when merging adjacent assistant messages (same pattern as existing `content` merge)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test -p aion-providers` — all 8 tests pass
- [ ] Manual test: multi-turn conversation with `deepseek-v4-flash` including tool calls — no 400 error on turns without thinking output