### PR TITLE
fix(compact): autocompact token watermark for prefix-caching providers

### DIFF
--- a/crates/aion-agent/src/compact/estimate.rs
+++ b/crates/aion-agent/src/compact/estimate.rs
@@ -1,0 +1,166 @@
+use aion_types::message::{ContentBlock, Message};
+
+const CHARS_PER_TOKEN_TEXT: usize = 4;
+
+const CHARS_PER_TOKEN_JSON: usize = 3;
+
+/// Estimate the total token count for a slice of messages.
+///
+/// Intentionally conservative (slightly over-estimates) to ensure
+/// compaction triggers rather than being skipped.
+pub fn estimate_tokens_from_messages(messages: &[Message]) -> u64 {
+    let mut total_chars: usize = 0;
+    let mut json_chars: usize = 0;
+
+    for msg in messages {
+        for block in &msg.content {
+            match block {
+                ContentBlock::Text { text } => {
+                    total_chars += text.len();
+                }
+                ContentBlock::Thinking { thinking } => {
+                    total_chars += thinking.len();
+                }
+                ContentBlock::ToolUse { name, input, .. } => {
+                    let input_str = input.to_string();
+                    json_chars += name.len() + input_str.len();
+                }
+                ContentBlock::ToolResult { content, .. } => {
+                    total_chars += content.len();
+                }
+            }
+        }
+    }
+
+    let text_tokens = total_chars / CHARS_PER_TOKEN_TEXT;
+    let json_tokens = json_chars / CHARS_PER_TOKEN_JSON;
+
+    (text_tokens + json_tokens) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aion_types::message::{Message, Role};
+    use serde_json::json;
+
+    #[test]
+    fn empty_messages_returns_zero() {
+        assert_eq!(estimate_tokens_from_messages(&[]), 0);
+    }
+
+    #[test]
+    fn text_only_message() {
+        let text = "a".repeat(400);
+        let msg = Message::new(Role::User, vec![ContentBlock::Text { text }]);
+        assert_eq!(estimate_tokens_from_messages(&[msg]), 100);
+    }
+
+    #[test]
+    fn tool_use_message_uses_json_ratio() {
+        let input = json!({"cmd": "ls -la"});
+        let input_len = "Bash".len() + input.to_string().len();
+        let msg = Message::new(
+            Role::Assistant,
+            vec![ContentBlock::ToolUse {
+                id: "call_1".into(),
+                name: "Bash".into(),
+                input,
+            }],
+        );
+        let result = estimate_tokens_from_messages(&[msg]);
+        assert_eq!(result, (input_len / CHARS_PER_TOKEN_JSON) as u64);
+    }
+
+    #[test]
+    fn tool_result_uses_text_ratio() {
+        let content = "x".repeat(800);
+        let msg = Message::new(
+            Role::User,
+            vec![ContentBlock::ToolResult {
+                tool_use_id: "call_1".into(),
+                content,
+                is_error: false,
+            }],
+        );
+        assert_eq!(estimate_tokens_from_messages(&[msg]), 200);
+    }
+
+    #[test]
+    fn mixed_conversation_accumulates() {
+        let messages = vec![
+            Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "a".repeat(400),
+                }],
+            ),
+            Message::new(
+                Role::Assistant,
+                vec![
+                    ContentBlock::Text {
+                        text: "b".repeat(200),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "c1".into(),
+                        name: "Read".into(),
+                        input: json!({"path": "/foo/bar.rs"}),
+                    },
+                ],
+            ),
+            Message::new(
+                Role::User,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "c1".into(),
+                    content: "c".repeat(1200),
+                    is_error: false,
+                }],
+            ),
+        ];
+        let estimate = estimate_tokens_from_messages(&messages);
+        // text_tokens = (400 + 200 + 1200) / 4 = 450
+        // json_tokens = ("Read".len() + json_string.len()) / 3
+        assert!(estimate > 450);
+        assert!(estimate < 600);
+    }
+
+    #[test]
+    fn thinking_block_counted() {
+        let thinking = "t".repeat(4000);
+        let msg = Message::new(Role::Assistant, vec![ContentBlock::Thinking { thinking }]);
+        assert_eq!(estimate_tokens_from_messages(&[msg]), 1000);
+    }
+
+    #[test]
+    fn large_conversation_realistic_estimate() {
+        let big_result = "x".repeat(400_000);
+        let messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::ToolResult {
+                tool_use_id: "c1".into(),
+                content: big_result,
+                is_error: false,
+            }],
+        )];
+        let estimate = estimate_tokens_from_messages(&messages);
+        assert_eq!(estimate, 100_000);
+    }
+
+    #[test]
+    fn effective_watermark_uses_max() {
+        let provider_reported: u64 = 500;
+        let messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::ToolResult {
+                tool_use_id: "c1".into(),
+                content: "x".repeat(400_000),
+                is_error: false,
+            }],
+        )];
+        let local_estimate = estimate_tokens_from_messages(&messages);
+        let effective = provider_reported.max(local_estimate);
+
+        assert_eq!(effective, 100_000);
+        assert!(effective > provider_reported);
+    }
+}

--- a/crates/aion-agent/src/compact/mod.rs
+++ b/crates/aion-agent/src/compact/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod auto;
 pub mod emergency;
+pub mod estimate;
 pub mod micro;
 pub mod prompt;
 pub mod state;

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -458,8 +458,7 @@ impl AgentEngine {
             // Use max(provider_reported, local_estimate) as a safety net:
             // some providers (e.g. DeepSeek with prefix caching) underreport
             // prompt_tokens, causing compaction to never trigger.
-            let local_estimate =
-                estimate::estimate_tokens_from_messages(&self.messages);
+            let local_estimate = estimate::estimate_tokens_from_messages(&self.messages);
             let effective_watermark = turn_usage.input_tokens.max(local_estimate);
 
             if local_estimate > turn_usage.input_tokens

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -460,8 +460,18 @@ impl AgentEngine {
             // prompt_tokens, causing compaction to never trigger.
             let local_estimate =
                 estimate::estimate_tokens_from_messages(&self.messages);
-            self.compact_state.last_input_tokens =
-                turn_usage.input_tokens.max(local_estimate);
+            let effective_watermark = turn_usage.input_tokens.max(local_estimate);
+
+            if local_estimate > turn_usage.input_tokens
+                && local_estimate.saturating_sub(turn_usage.input_tokens) > 10_000
+            {
+                self.output.emit_info(&format!(
+                    "Token watermark override: provider={}, local_estimate={}, using={}",
+                    turn_usage.input_tokens, local_estimate, effective_watermark
+                ));
+            }
+
+            self.compact_state.last_input_tokens = effective_watermark;
 
             // Cache break detection
             let cache_stats = CacheStats {

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -13,7 +13,7 @@ use aion_types::skill_types::{ContextModifier, PlanModeTransition, effort_to_str
 
 use crate::cache_diagnostics::{CacheBreakDetector, CacheDiagnostic, CacheStats};
 use crate::compact::state::CompactState;
-use crate::compact::{auto, emergency, micro};
+use crate::compact::{auto, emergency, estimate, micro};
 use crate::confirm::ToolConfirmer;
 use crate::orchestration::{
     ExecutionControl, execute_tool_calls, execute_tool_calls_with_approval,
@@ -454,8 +454,14 @@ impl AgentEngine {
             self.total_usage.cache_creation_tokens += turn_usage.cache_creation_tokens;
             self.total_usage.cache_read_tokens += turn_usage.cache_read_tokens;
 
-            // Track per-turn input tokens for compaction watermark
-            self.compact_state.last_input_tokens = turn_usage.input_tokens;
+            // Track per-turn input tokens for compaction watermark.
+            // Use max(provider_reported, local_estimate) as a safety net:
+            // some providers (e.g. DeepSeek with prefix caching) underreport
+            // prompt_tokens, causing compaction to never trigger.
+            let local_estimate =
+                estimate::estimate_tokens_from_messages(&self.messages);
+            self.compact_state.last_input_tokens =
+                turn_usage.input_tokens.max(local_estimate);
 
             // Cache break detection
             let cache_stats = CacheStats {

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -580,9 +580,16 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
 
     // Extract usage if present
     if let Some(usage) = json.get("usage") {
-        state.input_tokens = usage["prompt_tokens"]
+        let base_prompt = usage["prompt_tokens"]
             .as_u64()
             .unwrap_or(state.input_tokens);
+
+        // DeepSeek-style: prompt_cache_hit_tokens is reported separately and
+        // prompt_tokens only contains the cache-miss portion.
+        // Add it to get the true total prompt size.
+        let cache_hit = usage["prompt_cache_hit_tokens"].as_u64().unwrap_or(0);
+
+        state.input_tokens = base_prompt + cache_hit;
         state.output_tokens = usage["completion_tokens"]
             .as_u64()
             .unwrap_or(state.output_tokens);
@@ -965,5 +972,44 @@ mod tests {
         assert!(spawn_params["properties"].as_object().unwrap().is_empty());
         let spawn_desc = result[1]["function"]["description"].as_str().unwrap();
         assert!(spawn_desc.contains("ToolSearch"));
+    }
+
+    #[test]
+    fn usage_includes_prompt_cache_hit_tokens() {
+        // DeepSeek reports prompt_cache_hit_tokens separately;
+        // input_tokens should be the sum of prompt_tokens + prompt_cache_hit_tokens
+        let mut state = StreamState::new();
+
+        let chunk = r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":500,"completion_tokens":100,"prompt_cache_hit_tokens":999500}}"#;
+        let _ = parse_sse_chunk(chunk, &mut state);
+
+        assert_eq!(state.input_tokens, 1_000_000);
+        assert_eq!(state.output_tokens, 100);
+    }
+
+    #[test]
+    fn usage_with_prompt_tokens_details_cached() {
+        // OpenAI standard: prompt_tokens already includes cached_tokens (it's the total)
+        // prompt_tokens_details.cached_tokens is informational only
+        let mut state = StreamState::new();
+
+        let chunk = r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1000000,"completion_tokens":100,"prompt_tokens_details":{"cached_tokens":999000}}}"#;
+        let _ = parse_sse_chunk(chunk, &mut state);
+
+        // prompt_tokens is already the full total for OpenAI
+        assert_eq!(state.input_tokens, 1_000_000);
+        assert_eq!(state.output_tokens, 100);
+    }
+
+    #[test]
+    fn usage_without_cache_fields_unchanged() {
+        // Provider that only sends prompt_tokens (no cache fields)
+        let mut state = StreamState::new();
+
+        let chunk = r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":50000,"completion_tokens":200}}"#;
+        let _ = parse_sse_chunk(chunk, &mut state);
+
+        assert_eq!(state.input_tokens, 50_000);
+        assert_eq!(state.output_tokens, 200);
     }
 }


### PR DESCRIPTION
## Summary

- Parse `prompt_cache_hit_tokens` in OpenAI-compatible provider usage to get true prompt size (DeepSeek reports cache-miss only in `prompt_tokens`)
- Add local token estimation module (`estimate_tokens_from_messages`) as provider-independent safety net
- Use `max(provider_reported, local_estimate)` as the compaction watermark so autocompact triggers even when provider underreports
- Emit diagnostic info log when local estimate overrides provider value by >10k tokens

## Context

DeepSeek-v4-pro (and potentially other prefix-caching providers) reports only the cache-miss portion in `prompt_tokens`, while the cached portion goes to `prompt_cache_hit_tokens`. This caused the compaction watermark to stay far below reality, so `should_autocompact()` never triggered — leading to context overflow (ELECTRON-16Y).

Two-layer fix: (A) parse the cache field to get accurate totals, (B) local estimation fallback for providers that don't report any cache field at all.

## Test Plan

- [x] `usage_includes_prompt_cache_hit_tokens` — verifies DeepSeek-style cache tokens are summed
- [x] `usage_with_prompt_tokens_details_cached` — verifies OpenAI standard format unchanged
- [x] `usage_without_cache_fields_unchanged` — verifies no regression for simple providers
- [x] 8 unit tests for `estimate_tokens_from_messages` covering all content block types
- [x] Full workspace: `cargo test` (all pass), `cargo clippy` (no warnings), `cargo fmt` (clean)