### PR TITLE
chore(deps): upgrade rust toolchain to 1.95.0

### DIFF
--- a/crates/aion-agent/src/session.rs
+++ b/crates/aion-agent/src/session.rs
@@ -198,9 +198,7 @@ impl SessionManager {
         }
 
         // Sort by created_at, remove oldest
-        index
-            .sessions
-            .sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        index.sessions.sort_by_key(|s| s.created_at);
         let to_remove = index.sessions.len() - self.max_sessions;
         let removed: Vec<_> = index.sessions.drain(..to_remove).collect();
 

--- a/crates/aion-memory/src/store.rs
+++ b/crates/aion-memory/src/store.rs
@@ -98,7 +98,7 @@ pub fn scan_memory_files(dir: &Path) -> Result<Vec<MemoryHeader>> {
     }
 
     // Sort by mtime descending (newest first).
-    headers.sort_by(|a, b| b.mtime.cmp(&a.mtime));
+    headers.sort_by_key(|h| std::cmp::Reverse(h.mtime));
 
     // Cap at limit.
     headers.truncate(MAX_MEMORY_FILES);

--- a/crates/aion-skills/src/discovery.rs
+++ b/crates/aion-skills/src/discovery.rs
@@ -115,11 +115,7 @@ impl RuntimeDiscovery {
         }
 
         // Sort deepest-first: more path components = deeper
-        new_dirs.sort_by(|a, b| {
-            let depth_b = b.components().count();
-            let depth_a = a.components().count();
-            depth_b.cmp(&depth_a)
-        });
+        new_dirs.sort_by_key(|d| std::cmp::Reverse(d.components().count()));
 
         new_dirs
     }

--- a/crates/aion-skills/src/shell.rs
+++ b/crates/aion-skills/src/shell.rs
@@ -48,7 +48,7 @@ pub async fn execute_shell_commands(
     }
 
     // Replace from back to front to preserve byte offsets
-    pairs.sort_by(|a, b| b.0.cmp(&a.0));
+    pairs.sort_by_key(|p| std::cmp::Reverse(p.0));
 
     let mut result = content.to_owned();
     for (start, end, output) in pairs {

--- a/crates/aion-tools/src/glob.rs
+++ b/crates/aion-tools/src/glob.rs
@@ -106,7 +106,7 @@ impl Tool for GlobTool {
         }
 
         // Sort by modification time, newest first
-        files.sort_by(|a, b| b.0.cmp(&a.0));
+        files.sort_by_key(|f| std::cmp::Reverse(f.0));
 
         if files.is_empty() {
             return ToolResult {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.1"
-components = ["cargo", "clippy", "rustfmt"]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]
 

--- a/vx.lock
+++ b/vx.lock
@@ -4,7 +4,7 @@
 version = 2
 
 [metadata]
-generated_at = "2026-04-04T02:13:43Z"
+generated_at = "2026-05-07T13:38:40Z"
 vx_version = "0.8.15"
 platform = "x86_64-pc-windows-msvc"
 
@@ -16,8 +16,16 @@ ecosystem = "generic"
 download_url = "https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-x86_64-pc-windows-msvc.zip"
 
 [tools.rust]
-version = "1.93.1"
-source = "rust"
-resolved_from = "1.93.1"
-ecosystem = "rust"
-download_url = "https://github.com/rust-lang/rustup/releases/download/1.29.0/rustup-init-1.29.0-x86_64-pc-windows-msvc.exe"
+version = "1.95.0"
+source = "provider"
+resolved_from = "1.95.0"
+ecosystem = "generic"
+download_url = "https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init"
+
+[tools.rust.platform_urls]
+darwin-arm64 = "https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init"
+darwin-x64 = "https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init"
+linux-arm64 = "https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init"
+linux-x64 = "https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init"
+windows-arm64 = "https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init"
+windows-x64 = "https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init"

--- a/vx.toml
+++ b/vx.toml
@@ -1,6 +1,6 @@
 [tools]
 just = "1.48.1"
-rust = "1.93.1"
+rust = "1.95.0"
 
 [settings]
 # Automatically install missing tools when entering dev environment


### PR DESCRIPTION
## Summary
- Upgrade Rust toolchain from 1.93.1 to 1.95.0
- Remove redundant `cargo` from `rust-toolchain.toml` components (it's always included by default)
- Fix new `clippy::unnecessary_sort_by` warnings introduced in 1.95.0 (use `sort_by_key` instead)

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all` passes