### PR TITLE
fix(providers): Gemini tool call compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "regex",
  "serde",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aion-config",
  "chrono",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aion-types",
  "rstest",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-agent/src/compact/estimate.rs
+++ b/crates/aion-agent/src/compact/estimate.rs
@@ -66,6 +66,7 @@ mod tests {
                 id: "call_1".into(),
                 name: "Bash".into(),
                 input,
+                extra: None,
             }],
         );
         let result = estimate_tokens_from_messages(&[msg]);
@@ -105,6 +106,7 @@ mod tests {
                         id: "c1".into(),
                         name: "Read".into(),
                         input: json!({"path": "/foo/bar.rs"}),
+                        extra: None,
                     },
                 ],
             ),

--- a/crates/aion-agent/src/compact/micro.rs
+++ b/crates/aion-agent/src/compact/micro.rs
@@ -200,6 +200,7 @@ mod tests {
             id: id.to_string(),
             name: name.to_string(),
             input: json!({}),
+            extra: None,
         }
     }
 

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -427,10 +427,20 @@ impl AgentEngine {
                         self.output.emit_text_delta(&text, &self.current_msg_id);
                         assistant_text.push_str(&text);
                     }
-                    LlmEvent::ToolUse { id, name, input } => {
+                    LlmEvent::ToolUse {
+                        id,
+                        name,
+                        input,
+                        extra,
+                    } => {
                         let input_str = serde_json::to_string(&input).unwrap_or_default();
                         self.output.emit_tool_call(&name, &input_str);
-                        tool_calls.push(ContentBlock::ToolUse { id, name, input });
+                        tool_calls.push(ContentBlock::ToolUse {
+                            id,
+                            name,
+                            input,
+                            extra,
+                        });
                     }
                     LlmEvent::ThinkingDelta(text) => {
                         self.output.emit_thinking(&text, &self.current_msg_id);
@@ -1368,6 +1378,7 @@ mod compact_tests {
                 id: id.to_string(),
                 name: name.to_string(),
                 input: json!({}),
+                extra: None,
             }],
         )
     }

--- a/crates/aion-agent/src/orchestration.rs
+++ b/crates/aion-agent/src/orchestration.rs
@@ -119,7 +119,7 @@ fn confirm_call(
     confirmer: &Arc<Mutex<ToolConfirmer>>,
     call: &ContentBlock,
 ) -> Result<Option<ContentBlock>, ExecutionControl> {
-    let ContentBlock::ToolUse { id, name, input } = call else {
+    let ContentBlock::ToolUse { id, name, input, .. } = call else {
         return Ok(None);
     };
 
@@ -147,7 +147,7 @@ async fn execute_single(
     compaction_level: aion_compact::CompactionLevel,
     toon_enabled: bool,
 ) -> (ContentBlock, Option<ContextModifier>) {
-    let ContentBlock::ToolUse { id, name, input } = call else {
+    let ContentBlock::ToolUse { id, name, input, .. } = call else {
         unreachable!("execute_single called with non-ToolUse block")
     };
 
@@ -241,7 +241,7 @@ pub async fn execute_tool_calls_with_approval(
     let mut modifiers = Vec::new();
 
     for call in tool_calls {
-        let ContentBlock::ToolUse { id, name, input } = call else {
+        let ContentBlock::ToolUse { id, name, input, .. } = call else {
             continue;
         };
 
@@ -696,6 +696,7 @@ mod tests {
             id: "call_1".into(),
             name: "MockDeferred".into(),
             input: json!({}),
+            extra: None,
         };
         let (result, _) = execute_single(
             &registry,
@@ -725,6 +726,7 @@ mod tests {
             id: "call_2".into(),
             name: "MockDeferred".into(),
             input: json!({"tasks": "not_an_array"}),
+            extra: None,
         };
         let (result, _) = execute_single(
             &registry,
@@ -753,6 +755,7 @@ mod tests {
             id: "call_3".into(),
             name: "MockDeferred".into(),
             input: json!({"tasks": [{"name": "t1", "prompt": "do x"}]}),
+            extra: None,
         };
         let (result, _) = execute_single(
             &registry,
@@ -780,6 +783,7 @@ mod tests {
             id: "call_4".into(),
             name: "MockNonDeferred".into(),
             input: json!({}),
+            extra: None,
         };
         let (result, _) = execute_single(
             &registry,

--- a/crates/aion-agent/src/orchestration.rs
+++ b/crates/aion-agent/src/orchestration.rs
@@ -119,7 +119,10 @@ fn confirm_call(
     confirmer: &Arc<Mutex<ToolConfirmer>>,
     call: &ContentBlock,
 ) -> Result<Option<ContentBlock>, ExecutionControl> {
-    let ContentBlock::ToolUse { id, name, input, .. } = call else {
+    let ContentBlock::ToolUse {
+        id, name, input, ..
+    } = call
+    else {
         return Ok(None);
     };
 
@@ -147,7 +150,10 @@ async fn execute_single(
     compaction_level: aion_compact::CompactionLevel,
     toon_enabled: bool,
 ) -> (ContentBlock, Option<ContextModifier>) {
-    let ContentBlock::ToolUse { id, name, input, .. } = call else {
+    let ContentBlock::ToolUse {
+        id, name, input, ..
+    } = call
+    else {
         unreachable!("execute_single called with non-ToolUse block")
     };
 
@@ -241,7 +247,10 @@ pub async fn execute_tool_calls_with_approval(
     let mut modifiers = Vec::new();
 
     for call in tool_calls {
-        let ContentBlock::ToolUse { id, name, input, .. } = call else {
+        let ContentBlock::ToolUse {
+            id, name, input, ..
+        } = call
+        else {
             continue;
         };
 

--- a/crates/aion-agent/tests/acceptance/compact_test.rs
+++ b/crates/aion-agent/tests/acceptance/compact_test.rs
@@ -20,6 +20,7 @@ fn tool_use_block(id: &str, name: &str) -> ContentBlock {
         id: id.to_string(),
         name: name.to_string(),
         input: json!({}),
+        extra: None,
     }
 }
 

--- a/crates/aion-agent/tests/acceptance/cross_feature_test.rs
+++ b/crates/aion-agent/tests/acceptance/cross_feature_test.rs
@@ -100,6 +100,7 @@ async fn tc_ax_01_multi_feature_collaboration() {
                 id: id.clone(),
                 name: "Read".to_string(),
                 input: json!({}),
+                extra: None,
             }],
         ));
         messages.push(Message::new(

--- a/crates/aion-agent/tests/common/mod.rs
+++ b/crates/aion-agent/tests/common/mod.rs
@@ -56,6 +56,7 @@ impl MockLlmProvider {
                 id: id.to_string(),
                 name: name.to_string(),
                 input,
+                extra: None,
             },
             LlmEvent::Done {
                 stop_reason: StopReason::ToolUse,

--- a/crates/aion-agent/tests/e2e/compaction.rs
+++ b/crates/aion-agent/tests/e2e/compaction.rs
@@ -136,6 +136,7 @@ async fn case_9_off_vs_safe_content() {
         id: "t1".to_string(),
         name: "check_tool".to_string(),
         input: json!({}),
+        extra: None,
     }];
 
     // Off
@@ -326,6 +327,7 @@ async fn case_11_toon_comprehension_and_system_prompt() {
         id: "t1".to_string(),
         name: "data_tool".to_string(),
         input: json!({}),
+        extra: None,
     }];
 
     let outcome = execute_tool_calls(

--- a/crates/aion-agent/tests/engine_compact_test.rs
+++ b/crates/aion-agent/tests/engine_compact_test.rs
@@ -141,6 +141,7 @@ async fn tc_2_6_03_emergency_returns_error() {
             id: "t1".to_string(),
             name: "mock_tool".to_string(),
             input: serde_json::json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -198,6 +199,7 @@ async fn tc_2_6_04_autocompact_then_continue() {
             id: "t1".to_string(),
             name: "mock_tool".to_string(),
             input: serde_json::json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -251,6 +253,7 @@ async fn tc_2_6_05_session_save_after_compact() {
             id: "t1".to_string(),
             name: "mock_tool".to_string(),
             input: serde_json::json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -348,6 +351,7 @@ async fn tc_2_6_06b_disabled_still_fires_emergency() {
             id: "t1".to_string(),
             name: "mock_tool".to_string(),
             input: serde_json::json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -397,6 +401,7 @@ async fn tc_2_6_07_input_tokens_tracked() {
             id: "t1".to_string(),
             name: "mock_tool".to_string(),
             input: serde_json::json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -501,6 +506,7 @@ async fn tc_2_6_02_micro_before_auto_execution_order() {
                         id: format!("t{count}"),
                         name: "mock_tool".to_string(),
                         input: serde_json::json!({}),
+                        extra: None,
                     },
                     LlmEvent::Done {
                         stop_reason: StopReason::ToolUse,
@@ -655,6 +661,7 @@ async fn tc_2_6_e2e_02_micro_and_auto_cooperative() {
                         id: format!("t{count}"),
                         name: "mock_tool".to_string(),
                         input: serde_json::json!({}),
+                        extra: None,
                     },
                     LlmEvent::Done {
                         stop_reason: StopReason::ToolUse,
@@ -776,6 +783,7 @@ async fn tc_2_6_e2e_03_circuit_breaker_stops_retries() {
                         id: format!("t{idx}"),
                         name: "mock_tool".to_string(),
                         input: serde_json::json!({}),
+                        extra: None,
                     },
                     LlmEvent::Done {
                         stop_reason: StopReason::ToolUse,

--- a/crates/aion-agent/tests/engine_test.rs
+++ b/crates/aion-agent/tests/engine_test.rs
@@ -60,6 +60,7 @@ async fn test_engine_tool_use_executes_and_continues() {
             id: "tool-1".to_string(),
             name: "mock_tool".to_string(),
             input: json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -231,6 +232,7 @@ async fn test_engine_token_usage_tracking() {
             id: "tool-1".to_string(),
             name: "mock_tool".to_string(),
             input: json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -294,6 +296,7 @@ async fn test_engine_max_turns_returns_ok() {
                 id: "tool-1".to_string(),
                 name: "mock_tool".to_string(),
                 input: json!({}),
+                extra: None,
             },
             LlmEvent::Done {
                 stop_reason: StopReason::ToolUse,

--- a/crates/aion-agent/tests/json_stream_approval_test.rs
+++ b/crates/aion-agent/tests/json_stream_approval_test.rs
@@ -41,6 +41,7 @@ async fn test_tool_approval_approve_flow() {
             id: "call-1".to_string(),
             name: "exec_tool".to_string(),
             input: json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -109,6 +110,7 @@ async fn test_tool_approval_deny_flow() {
             id: "call-2".to_string(),
             name: "exec_tool".to_string(),
             input: json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -170,6 +172,7 @@ async fn test_auto_approve_bypasses_approval() {
             id: "call-3".to_string(),
             name: "exec_tool".to_string(),
             input: json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -220,6 +223,7 @@ async fn test_session_auto_approve_category() {
             id: "call-4".to_string(),
             name: "exec_tool".to_string(),
             input: json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,
@@ -273,6 +277,7 @@ async fn test_client_disconnect_aborts() {
             id: "call-5".to_string(),
             name: "exec_tool".to_string(),
             input: json!({}),
+            extra: None,
         },
         LlmEvent::Done {
             stop_reason: StopReason::ToolUse,

--- a/crates/aion-agent/tests/microcompact_test.rs
+++ b/crates/aion-agent/tests/microcompact_test.rs
@@ -19,6 +19,7 @@ fn tool_use(id: &str, name: &str) -> ContentBlock {
         id: id.into(),
         name: name.into(),
         input: json!({}),
+        extra: None,
     }
 }
 

--- a/crates/aion-agent/tests/orchestration_test.rs
+++ b/crates/aion-agent/tests/orchestration_test.rs
@@ -17,6 +17,7 @@ fn make_tool_use(id: &str, name: &str) -> ContentBlock {
         id: id.to_string(),
         name: name.to_string(),
         input: json!({}),
+        extra: None,
     }
 }
 

--- a/crates/aion-agent/tests/output_compaction_test.rs
+++ b/crates/aion-agent/tests/output_compaction_test.rs
@@ -28,6 +28,7 @@ fn make_tool_use(id: &str, name: &str) -> ContentBlock {
         id: id.to_string(),
         name: name.to_string(),
         input: json!({}),
+        extra: None,
     }
 }
 
@@ -280,6 +281,7 @@ async fn case_6_compressed_content_reaches_llm() {
                     id: "t1".to_string(),
                     name: "test_tool".to_string(),
                     input: json!({}),
+                    extra: None,
                 },
                 LlmEvent::Done {
                     stop_reason: StopReason::ToolUse,

--- a/crates/aion-agent/tests/plan_e2e_test.rs
+++ b/crates/aion-agent/tests/plan_e2e_test.rs
@@ -196,6 +196,7 @@ fn tc_3_6_e2e_02_plan_mode_and_compaction_independent() {
                 id: id.clone(),
                 name: "Read".to_string(),
                 input: json!({}),
+                extra: None,
             }],
         ));
         messages.push(Message::new(

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -33,7 +33,7 @@ pub fn build_messages(messages: &[Message], compat: &ProviderCompat) -> Vec<Valu
                     "type": "text",
                     "text": text
                 }),
-                ContentBlock::ToolUse { id, name, input } => {
+                ContentBlock::ToolUse { id, name, input, .. } => {
                     let tool_id = if id.is_empty() && compat.auto_tool_id() {
                         generate_tool_id()
                     } else {
@@ -330,6 +330,7 @@ pub fn parse_sse_data(event_type: &str, data: &str, state: &mut StreamState) -> 
                     id: state.tool_id.clone(),
                     name: state.tool_name.clone(),
                     input,
+                    extra: None,
                 });
                 state.tool_input_json.clear();
             }
@@ -419,6 +420,7 @@ mod tests {
                 id: "call_1".to_string(),
                 name: "bash".to_string(),
                 input: json!({"cmd": "ls"}),
+                extra: None,
             }],
         )];
         let result = build_messages(&messages, &default_compat());
@@ -539,6 +541,7 @@ mod tests {
                 id: String::new(),
                 name: "bash".into(),
                 input: json!({}),
+                extra: None,
             }],
         )];
         let compat = ProviderCompat {
@@ -559,6 +562,7 @@ mod tests {
                 id: "existing_id".into(),
                 name: "bash".into(),
                 input: json!({}),
+                extra: None,
             }],
         )];
         let compat = ProviderCompat {
@@ -683,7 +687,7 @@ mod tests {
         // assert
         assert_eq!(events.len(), 1);
         match &events[0] {
-            LlmEvent::ToolUse { id, name, input } => {
+            LlmEvent::ToolUse { id, name, input, .. } => {
                 assert_eq!(id, "id1");
                 assert_eq!(name, "bash");
                 assert_eq!(input["cmd"], "ls");

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -33,7 +33,9 @@ pub fn build_messages(messages: &[Message], compat: &ProviderCompat) -> Vec<Valu
                     "type": "text",
                     "text": text
                 }),
-                ContentBlock::ToolUse { id, name, input, .. } => {
+                ContentBlock::ToolUse {
+                    id, name, input, ..
+                } => {
                     let tool_id = if id.is_empty() && compat.auto_tool_id() {
                         generate_tool_id()
                     } else {
@@ -687,7 +689,9 @@ mod tests {
         // assert
         assert_eq!(events.len(), 1);
         match &events[0] {
-            LlmEvent::ToolUse { id, name, input, .. } => {
+            LlmEvent::ToolUse {
+                id, name, input, ..
+            } => {
                 assert_eq!(id, "id1");
                 assert_eq!(name, "bash");
                 assert_eq!(input["cmd"], "ls");

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -151,15 +151,25 @@ impl OpenAIProvider {
                         .content
                         .iter()
                         .filter_map(|b| {
-                            if let ContentBlock::ToolUse { id, name, input } = b {
-                                Some(json!({
+                            if let ContentBlock::ToolUse {
+                                id,
+                                name,
+                                input,
+                                extra,
+                            } = b
+                            {
+                                let mut tc_json = json!({
                                     "id": id,
                                     "type": "function",
                                     "function": {
                                         "name": name,
                                         "arguments": serde_json::to_string(input).unwrap_or_default()
                                     }
-                                }))
+                                });
+                                if let Some(extra_val) = extra {
+                                    tc_json["extra_content"] = extra_val.clone();
+                                }
+                                Some(tc_json)
                             } else {
                                 None
                             }
@@ -420,6 +430,7 @@ struct ToolCallAccumulator {
     id: String,
     name: String,
     arguments: String,
+    extra: Option<Value>,
 }
 
 struct StreamState {
@@ -468,6 +479,7 @@ impl StreamState {
                 id: String::new(),
                 name: String::new(),
                 arguments: String::new(),
+                extra: None,
             });
         }
         &mut self.tool_calls[index]
@@ -632,6 +644,9 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
             if let Some(args) = tc["function"]["arguments"].as_str() {
                 acc.arguments.push_str(args);
             }
+            if let Some(extra) = tc.get("extra_content").filter(|v| !v.is_null()) {
+                acc.extra = Some(extra.clone());
+            }
         }
     }
 
@@ -639,27 +654,10 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
     // chunk (choices:[]) can update token counts first.
     if let Some(finish_reason) = choice["finish_reason"].as_str() {
         match finish_reason {
-            "tool_calls" => {
-                // Emit accumulated tool calls immediately.
-                for tc in state.tool_calls.drain(..) {
-                    let input: Value = serde_json::from_str(&tc.arguments)
-                        .unwrap_or(Value::Object(serde_json::Map::new()));
-                    events.push(LlmEvent::ToolUse {
-                        id: tc.id,
-                        name: tc.name,
-                        input,
-                    });
-                }
-                state.pending_done = Some(LlmEvent::Done {
-                    stop_reason: StopReason::ToolUse,
-                    usage: TokenUsage::default(),
-                });
-            }
-            "stop" => {
+            "tool_calls" | "stop" => {
                 if !state.tool_calls.is_empty() {
-                    // Some providers (e.g. Gemini) use "stop" instead of
-                    // "tool_calls" as finish_reason even when tool calls
-                    // are present.
+                    // Emit accumulated tool calls. Gemini uses "stop" instead of
+                    // "tool_calls" as finish_reason, so we handle both here.
                     for tc in state.tool_calls.drain(..) {
                         let input: Value = serde_json::from_str(&tc.arguments)
                             .unwrap_or(Value::Object(serde_json::Map::new()));
@@ -667,15 +665,23 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
                             id: tc.id,
                             name: tc.name,
                             input,
+                            extra: tc.extra,
                         });
                     }
                     state.pending_done = Some(LlmEvent::Done {
                         stop_reason: StopReason::ToolUse,
                         usage: TokenUsage::default(),
                     });
-                } else {
+                } else if finish_reason == "stop" {
                     state.pending_done = Some(LlmEvent::Done {
                         stop_reason: StopReason::EndTurn,
+                        usage: TokenUsage::default(),
+                    });
+                } else {
+                    // "tool_calls" with empty accumulator — shouldn't happen,
+                    // but treat as ToolUse for safety.
+                    state.pending_done = Some(LlmEvent::Done {
+                        stop_reason: StopReason::ToolUse,
                         usage: TokenUsage::default(),
                     });
                 }
@@ -809,11 +815,13 @@ mod tests {
                         id: "tc1".into(),
                         name: "bash".into(),
                         input: json!({}),
+                        extra: None,
                     },
                     ContentBlock::ToolUse {
                         id: "tc2".into(),
                         name: "read".into(),
                         input: json!({}),
+                        extra: None,
                     },
                 ],
             ),
@@ -844,11 +852,13 @@ mod tests {
                         id: "tc1".into(),
                         name: "bash".into(),
                         input: json!({}),
+                        extra: None,
                     },
                     ContentBlock::ToolUse {
                         id: "tc2".into(),
                         name: "read".into(),
                         input: json!({}),
+                        extra: None,
                     },
                 ],
             ),
@@ -878,6 +888,7 @@ mod tests {
                     id: "tc1".into(),
                     name: "bash".into(),
                     input: json!({}),
+                    extra: None,
                 }],
             ),
             Message::new(
@@ -1055,7 +1066,7 @@ mod tests {
             .filter(|e| matches!(e, LlmEvent::ToolUse { .. }))
             .collect();
         assert_eq!(tool_events.len(), 1, "tool call should be emitted on stop");
-        if let LlmEvent::ToolUse { id, name, input } = &tool_events[0] {
+        if let LlmEvent::ToolUse { id, name, input, .. } = &tool_events[0] {
             assert_eq!(id, "call_abc123");
             assert_eq!(name, "Skill");
             assert_eq!(input["skill"], "test");

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -1066,7 +1066,10 @@ mod tests {
             .filter(|e| matches!(e, LlmEvent::ToolUse { .. }))
             .collect();
         assert_eq!(tool_events.len(), 1, "tool call should be emitted on stop");
-        if let LlmEvent::ToolUse { id, name, input, .. } = &tool_events[0] {
+        if let LlmEvent::ToolUse {
+            id, name, input, ..
+        } = &tool_events[0]
+        {
             assert_eq!(id, "call_abc123");
             assert_eq!(name, "Skill");
             assert_eq!(input["skill"], "test");
@@ -1089,7 +1092,8 @@ mod tests {
         // Standard stop without tool calls should still produce EndTurn.
         let mut state = StreamState::new();
 
-        let chunk = r#"{"choices":[{"delta":{"content":"done"},"finish_reason":"stop","index":0}]}"#;
+        let chunk =
+            r#"{"choices":[{"delta":{"content":"done"},"finish_reason":"stop","index":0}]}"#;
         let events = parse_sse_chunk(chunk, &mut state);
 
         let text_events: Vec<_> = events

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -656,10 +656,29 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
                 });
             }
             "stop" => {
-                state.pending_done = Some(LlmEvent::Done {
-                    stop_reason: StopReason::EndTurn,
-                    usage: TokenUsage::default(),
-                });
+                if !state.tool_calls.is_empty() {
+                    // Some providers (e.g. Gemini) use "stop" instead of
+                    // "tool_calls" as finish_reason even when tool calls
+                    // are present.
+                    for tc in state.tool_calls.drain(..) {
+                        let input: Value = serde_json::from_str(&tc.arguments)
+                            .unwrap_or(Value::Object(serde_json::Map::new()));
+                        events.push(LlmEvent::ToolUse {
+                            id: tc.id,
+                            name: tc.name,
+                            input,
+                        });
+                    }
+                    state.pending_done = Some(LlmEvent::Done {
+                        stop_reason: StopReason::ToolUse,
+                        usage: TokenUsage::default(),
+                    });
+                } else {
+                    state.pending_done = Some(LlmEvent::Done {
+                        stop_reason: StopReason::EndTurn,
+                        usage: TokenUsage::default(),
+                    });
+                }
             }
             "length" => {
                 state.pending_done = Some(LlmEvent::Done {
@@ -1011,5 +1030,69 @@ mod tests {
 
         assert_eq!(state.input_tokens, 50_000);
         assert_eq!(state.output_tokens, 200);
+    }
+
+    #[test]
+    fn tool_calls_with_stop_finish_reason() {
+        // Gemini uses finish_reason:"stop" even when tool_calls are present.
+        // The accumulated tool calls must still be emitted.
+        let mut state = StreamState::new();
+
+        // chunk 1: tool call delta (name + partial args)
+        let chunk1 = r#"{"choices":[{"delta":{"role":"assistant","tool_calls":[{"extra_content":{},"function":{"arguments":"{\"skill\":\"test\",\"args\":\"hello\"}","name":"Skill"},"id":"call_abc123","type":"function"}]},"index":0}]}"#;
+        let events1 = parse_sse_chunk(chunk1, &mut state);
+        assert!(events1.is_empty(), "no events until finish_reason");
+        assert_eq!(state.tool_calls.len(), 1);
+        assert_eq!(state.tool_calls[0].name, "Skill");
+
+        // chunk 2: finish_reason:"stop" (not "tool_calls")
+        let chunk2 = r#"{"choices":[{"delta":{"role":"assistant"},"finish_reason":"stop","index":0}],"usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120}}"#;
+        let events2 = parse_sse_chunk(chunk2, &mut state);
+
+        // Tool call should be emitted
+        let tool_events: Vec<_> = events2
+            .iter()
+            .filter(|e| matches!(e, LlmEvent::ToolUse { .. }))
+            .collect();
+        assert_eq!(tool_events.len(), 1, "tool call should be emitted on stop");
+        if let LlmEvent::ToolUse { id, name, input } = &tool_events[0] {
+            assert_eq!(id, "call_abc123");
+            assert_eq!(name, "Skill");
+            assert_eq!(input["skill"], "test");
+        }
+
+        // Done should be deferred with ToolUse stop reason
+        let done = state.flush_done().unwrap();
+        match done {
+            LlmEvent::Done { stop_reason, .. } => {
+                assert_eq!(stop_reason, StopReason::ToolUse);
+            }
+            other => panic!("expected Done with ToolUse, got {other:?}"),
+        }
+
+        assert!(state.tool_calls.is_empty(), "tool calls should be drained");
+    }
+
+    #[test]
+    fn stop_without_tool_calls_unchanged() {
+        // Standard stop without tool calls should still produce EndTurn.
+        let mut state = StreamState::new();
+
+        let chunk = r#"{"choices":[{"delta":{"content":"done"},"finish_reason":"stop","index":0}]}"#;
+        let events = parse_sse_chunk(chunk, &mut state);
+
+        let text_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, LlmEvent::TextDelta(_)))
+            .collect();
+        assert_eq!(text_events.len(), 1);
+
+        let done = state.flush_done().unwrap();
+        match done {
+            LlmEvent::Done { stop_reason, .. } => {
+                assert_eq!(stop_reason, StopReason::EndTurn);
+            }
+            other => panic!("expected Done with EndTurn, got {other:?}"),
+        }
     }
 }

--- a/crates/aion-providers/tests/provider_anthropic_test.rs
+++ b/crates/aion-providers/tests/provider_anthropic_test.rs
@@ -177,7 +177,9 @@ data: {\"type\":\"message_stop\"}\n\n";
     assert_eq!(tool_events.len(), 1, "expected exactly one ToolUse event");
 
     match tool_events[0] {
-        LlmEvent::ToolUse { id, name, input, .. } => {
+        LlmEvent::ToolUse {
+            id, name, input, ..
+        } => {
             assert_eq!(id, "toolu_abc");
             assert_eq!(name, "Read");
             assert_eq!(input["file_path"], "/tmp/test");

--- a/crates/aion-providers/tests/provider_anthropic_test.rs
+++ b/crates/aion-providers/tests/provider_anthropic_test.rs
@@ -177,7 +177,7 @@ data: {\"type\":\"message_stop\"}\n\n";
     assert_eq!(tool_events.len(), 1, "expected exactly one ToolUse event");
 
     match tool_events[0] {
-        LlmEvent::ToolUse { id, name, input } => {
+        LlmEvent::ToolUse { id, name, input, .. } => {
             assert_eq!(id, "toolu_abc");
             assert_eq!(name, "Read");
             assert_eq!(input["file_path"], "/tmp/test");

--- a/crates/aion-providers/tests/provider_openai_test.rs
+++ b/crates/aion-providers/tests/provider_openai_test.rs
@@ -233,7 +233,7 @@ async fn test_openai_stream_tool_call_aggregation() {
     assert_eq!(events.len(), 2, "expected 2 events, got: {:?}", events);
 
     match &events[0] {
-        LlmEvent::ToolUse { id, name, input } => {
+        LlmEvent::ToolUse { id, name, input, .. } => {
             assert_eq!(id, "call_abc123");
             assert_eq!(name, "read_file");
             assert_eq!(input["path"], "/tmp/test.txt");
@@ -342,7 +342,7 @@ async fn test_openai_multiple_tool_calls() {
     assert_eq!(events.len(), 3, "expected 3 events, got: {:?}", events);
 
     match &events[0] {
-        LlmEvent::ToolUse { id, name, input } => {
+        LlmEvent::ToolUse { id, name, input, .. } => {
             assert_eq!(id, "call_tool0");
             assert_eq!(name, "list_files");
             assert_eq!(input["dir"], "/tmp");
@@ -351,7 +351,7 @@ async fn test_openai_multiple_tool_calls() {
     }
 
     match &events[1] {
-        LlmEvent::ToolUse { id, name, input } => {
+        LlmEvent::ToolUse { id, name, input, .. } => {
             assert_eq!(id, "call_tool1");
             assert_eq!(name, "read_file");
             assert_eq!(input["path"], "/etc/hosts");

--- a/crates/aion-providers/tests/provider_openai_test.rs
+++ b/crates/aion-providers/tests/provider_openai_test.rs
@@ -233,7 +233,9 @@ async fn test_openai_stream_tool_call_aggregation() {
     assert_eq!(events.len(), 2, "expected 2 events, got: {:?}", events);
 
     match &events[0] {
-        LlmEvent::ToolUse { id, name, input, .. } => {
+        LlmEvent::ToolUse {
+            id, name, input, ..
+        } => {
             assert_eq!(id, "call_abc123");
             assert_eq!(name, "read_file");
             assert_eq!(input["path"], "/tmp/test.txt");
@@ -342,7 +344,9 @@ async fn test_openai_multiple_tool_calls() {
     assert_eq!(events.len(), 3, "expected 3 events, got: {:?}", events);
 
     match &events[0] {
-        LlmEvent::ToolUse { id, name, input, .. } => {
+        LlmEvent::ToolUse {
+            id, name, input, ..
+        } => {
             assert_eq!(id, "call_tool0");
             assert_eq!(name, "list_files");
             assert_eq!(input["dir"], "/tmp");
@@ -351,7 +355,9 @@ async fn test_openai_multiple_tool_calls() {
     }
 
     match &events[1] {
-        LlmEvent::ToolUse { id, name, input, .. } => {
+        LlmEvent::ToolUse {
+            id, name, input, ..
+        } => {
             assert_eq!(id, "call_tool1");
             assert_eq!(name, "read_file");
             assert_eq!(input["path"], "/etc/hosts");

--- a/crates/aion-types/src/llm.rs
+++ b/crates/aion-types/src/llm.rs
@@ -103,7 +103,9 @@ mod tests {
             extra: None,
         };
         match &event {
-            LlmEvent::ToolUse { id, name, input, .. } => {
+            LlmEvent::ToolUse {
+                id, name, input, ..
+            } => {
                 assert_eq!(id, "call_1");
                 assert_eq!(name, "bash");
                 assert_eq!(input["cmd"], "ls");

--- a/crates/aion-types/src/llm.rs
+++ b/crates/aion-types/src/llm.rs
@@ -33,6 +33,8 @@ pub enum LlmEvent {
         id: ToolUseId,
         name: String,
         input: Value,
+        /// Opaque provider metadata (e.g. Gemini thought_signature) to round-trip.
+        extra: Option<Value>,
     },
     /// Thinking content (Anthropic only)
     ThinkingDelta(String),
@@ -98,9 +100,10 @@ mod tests {
             id: "call_1".to_string(),
             name: "bash".to_string(),
             input: json!({"cmd": "ls"}),
+            extra: None,
         };
         match &event {
-            LlmEvent::ToolUse { id, name, input } => {
+            LlmEvent::ToolUse { id, name, input, .. } => {
                 assert_eq!(id, "call_1");
                 assert_eq!(name, "bash");
                 assert_eq!(input["cmd"], "ls");

--- a/crates/aion-types/src/message.rs
+++ b/crates/aion-types/src/message.rs
@@ -19,6 +19,10 @@ pub enum ContentBlock {
         id: ToolUseId,
         name: String,
         input: Value,
+        /// Opaque provider-specific metadata (e.g. Gemini thought_signature).
+        /// Round-tripped verbatim so the provider can include it in follow-up requests.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra: Option<Value>,
     },
 
     /// Result of a tool execution, sent back as user message
@@ -190,10 +194,11 @@ mod tests {
             id: "call_1".to_string(),
             name: "bash".to_string(),
             input: json!({"cmd": "ls"}),
+            extra: None,
         };
         // assert
         match &block {
-            ContentBlock::ToolUse { id, name, input } => {
+            ContentBlock::ToolUse { id, name, input, .. } => {
                 assert_eq!(id, "call_1");
                 assert_eq!(name, "bash");
                 assert_eq!(input["cmd"], "ls");
@@ -209,6 +214,7 @@ mod tests {
             id: "call_1".to_string(),
             name: "bash".to_string(),
             input: json!({}),
+            extra: None,
         };
         // act
         let value = serde_json::to_value(&block).unwrap();
@@ -319,6 +325,7 @@ mod tests {
                 id: "call_2".to_string(),
                 name: "search".to_string(),
                 input: json!({"query": "rust"}),
+                extra: None,
             },
         ];
         let msg = Message::new(Role::Assistant, content);

--- a/crates/aion-types/src/message.rs
+++ b/crates/aion-types/src/message.rs
@@ -198,7 +198,9 @@ mod tests {
         };
         // assert
         match &block {
-            ContentBlock::ToolUse { id, name, input, .. } => {
+            ContentBlock::ToolUse {
+                id, name, input, ..
+            } => {
                 assert_eq!(id, "call_1");
                 assert_eq!(name, "bash");
                 assert_eq!(input["cmd"], "ls");

--- a/justfile
+++ b/justfile
@@ -62,6 +62,10 @@ test-acceptance-compact:
 lint:
     vx cargo clippy --workspace --all-targets -- -D warnings
 
+lint-fix:
+    vx cargo fix --allow-dirty --allow-staged
+    vx cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged -- -D warnings
+
 fmt:
     vx cargo fmt --all
 
@@ -93,12 +97,16 @@ version:
 clean:
     vx cargo clean
 
-# ── Pre-push gate (format, lint, test, then push) ────────────────────────
-push *ARGS:
-    vx cargo fmt --all
-    vx cargo clippy --workspace --all-targets -- -D warnings
-    vx cargo test --workspace
+# ── Pre-push gate (lint-fix, format, auto-commit fixes, test, then push) ─
+push *ARGS: lint-fix fmt _auto-commit-fixes test
     git push {{ ARGS }}
+
+_auto-commit-fixes:
+    #!/usr/bin/env bash
+    if [ -n "$(git diff --name-only)" ]; then
+        git add -A
+        git commit -m "chore: auto-commit lint/fmt fixes in just push recipe"
+    fi
 
 # ── All checks (mirrors CI exactly) ───────────────────────────────────────
 check-all: fmt-check lint test-ci hakari-verify audit


### PR DESCRIPTION
## Summary

- Fix Gemini returning `finish_reason: "stop"` instead of `"tool_calls"` when tool calls are present — tool calls were silently dropped, causing conversations to hang
- Round-trip Gemini's `extra_content` (containing `thought_signature`) through the Provider → Engine → Provider cycle via a new `extra: Option<Value>` field on `ContentBlock::ToolUse` and `LlmEvent::ToolUse` — without this, Gemini returns 400 on follow-up requests
- Improve `just push` recipe with auto-fix (`cargo fix` + `clippy --fix`) and auto-commit of formatting/lint changes before testing

## Details

**Bug 1: Tool calls dropped on `finish_reason: "stop"`**

Gemini's OpenAI-compatible endpoint returns `finish_reason: "stop"` even when `tool_calls` are present in the response. The previous code only drained accumulated tool calls in the `"tool_calls"` branch, so Gemini tool calls were silently lost. Fixed by merging the two branches — both `"stop"` and `"tool_calls"` now check for pending tool calls before deciding the stop reason.

**Bug 2: Missing `thought_signature` causes 400**

Gemini returns an `extra_content.google.thought_signature` field on streaming tool call deltas. This signature must be included when sending those tool calls back in subsequent requests. Added `extra: Option<Value>` to `ContentBlock::ToolUse` and `LlmEvent::ToolUse` to carry opaque provider metadata through the round-trip. The field is `Option::None` for providers that don't use it (Anthropic, standard OpenAI) — zero runtime cost.

## Test plan

- [x] All existing tests pass (`cargo nextest run --workspace`)
- [ ] Manual test with `gemini-3.1-pro-preview`: multi-turn tool-use conversation completes without hanging or 400 errors