### PR TITLE
feat(compact): add autocompact_threshold_pct config option

### DIFF
--- a/crates/aion-agent/src/compact/auto.rs
+++ b/crates/aion-agent/src/compact/auto.rs
@@ -57,14 +57,18 @@ pub enum CompactError {
 
 /// Check if autocompact should trigger based on the token watermark.
 ///
-/// Returns `true` when `last_input_tokens` >= the autocompact threshold:
-/// `threshold = context_window - output_reserve - autocompact_buffer`
+/// When `autocompact_threshold_pct` is set, threshold = context_window * pct / 100.
+/// Otherwise falls back to: `threshold = context_window - output_reserve - autocompact_buffer`
 pub fn should_autocompact(last_input_tokens: u64, config: &CompactConfig) -> bool {
     if !config.enabled {
         return false;
     }
-    let effective_window = config.context_window.saturating_sub(config.output_reserve);
-    let threshold = effective_window.saturating_sub(config.autocompact_buffer);
+    let threshold = if let Some(pct) = config.autocompact_threshold_pct {
+        config.context_window * pct as usize / 100
+    } else {
+        let effective_window = config.context_window.saturating_sub(config.output_reserve);
+        effective_window.saturating_sub(config.autocompact_buffer)
+    };
     last_input_tokens as usize >= threshold
 }
 
@@ -337,6 +341,53 @@ mod tests {
     fn zero_tokens_does_not_trigger() {
         let config = default_config();
         assert!(!should_autocompact(0, &config));
+    }
+
+    #[test]
+    fn threshold_pct_overrides_default_calculation() {
+        let config = CompactConfig {
+            context_window: 200_000,
+            autocompact_threshold_pct: Some(50),
+            ..default_config()
+        };
+        // threshold = 200k * 50 / 100 = 100k
+        assert!(!should_autocompact(99_999, &config));
+        assert!(should_autocompact(100_000, &config));
+        assert!(should_autocompact(150_000, &config));
+    }
+
+    #[test]
+    fn threshold_pct_zero_triggers_immediately() {
+        let config = CompactConfig {
+            autocompact_threshold_pct: Some(0),
+            ..default_config()
+        };
+        // threshold = 0, any non-negative triggers
+        assert!(should_autocompact(0, &config));
+        assert!(should_autocompact(1, &config));
+    }
+
+    #[test]
+    fn threshold_pct_100_never_triggers() {
+        let config = CompactConfig {
+            context_window: 200_000,
+            autocompact_threshold_pct: Some(100),
+            ..default_config()
+        };
+        // threshold = 200k, provider never reports 200k input_tokens
+        assert!(!should_autocompact(199_999, &config));
+        assert!(should_autocompact(200_000, &config));
+    }
+
+    #[test]
+    fn threshold_pct_none_uses_default_logic() {
+        let config = CompactConfig {
+            autocompact_threshold_pct: None,
+            ..default_config()
+        };
+        // Same as default: threshold = 200k - 20k - 13k = 167k
+        assert!(!should_autocompact(166_999, &config));
+        assert!(should_autocompact(167_000, &config));
     }
 
     // ── truncate_for_retry ──────────────────────────────────────────────

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -639,6 +639,22 @@ impl AgentEngine {
         let mut compacted = false;
         let should_compact =
             auto::should_autocompact(self.compact_state.last_input_tokens, &self.compact_config);
+        if should_compact {
+            let threshold = if let Some(pct) = self.compact_config.autocompact_threshold_pct {
+                let t = self.compact_config.context_window * pct as usize / 100;
+                self.output.emit_info(&format!(
+                    "Autocompact threshold: {} tokens ({}% of {})",
+                    t, pct, self.compact_config.context_window
+                ));
+                t
+            } else {
+                self.compact_config
+                    .context_window
+                    .saturating_sub(self.compact_config.output_reserve)
+                    .saturating_sub(self.compact_config.autocompact_buffer)
+            };
+            let _ = threshold;
+        }
         if should_compact && !self.compact_state.is_circuit_broken(&self.compact_config) {
             let provider = Arc::clone(&self.provider);
             match auto::autocompact(

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -673,11 +673,14 @@ impl AgentEngine {
                 self.compact_state.consecutive_failures, self.compact_state.last_input_tokens
             ));
         } else if !self.compact_config.enabled {
-            let threshold = self
-                .compact_config
-                .context_window
-                .saturating_sub(self.compact_config.output_reserve)
-                .saturating_sub(self.compact_config.autocompact_buffer);
+            let threshold = if let Some(pct) = self.compact_config.autocompact_threshold_pct {
+                self.compact_config.context_window * pct as usize / 100
+            } else {
+                self.compact_config
+                    .context_window
+                    .saturating_sub(self.compact_config.output_reserve)
+                    .saturating_sub(self.compact_config.autocompact_buffer)
+            };
             if self.compact_state.last_input_tokens as usize >= threshold {
                 self.output.emit_info(&format!(
                     "Autocompact: disabled (compact.enabled=false, \

--- a/crates/aion-config/src/compact.rs
+++ b/crates/aion-config/src/compact.rs
@@ -42,6 +42,12 @@ pub struct CompactConfig {
     #[serde(default = "default_compactable_tools")]
     pub compactable_tools: Vec<String>,
 
+    /// Optional percentage override for the autocompact trigger threshold.
+    /// When set, threshold = context_window * pct / 100, ignoring
+    /// output_reserve and autocompact_buffer.
+    #[serde(default)]
+    pub autocompact_threshold_pct: Option<u8>,
+
     /// Whether the compaction system is enabled.
     /// When false, microcompact and autocompact are skipped
     /// (emergency truncation still applies).
@@ -72,6 +78,7 @@ impl Default for CompactConfig {
             micro_keep_recent: default_micro_keep_recent(),
             micro_gap_seconds: default_micro_gap_seconds(),
             compactable_tools: default_compactable_tools(),
+            autocompact_threshold_pct: None,
             enabled: default_true(),
             cache_diagnostics: false,
             compaction: aion_compact::CompactionLevel::default(),
@@ -132,6 +139,7 @@ mod tests {
         assert_eq!(cfg.micro_keep_recent, 5);
         assert_eq!(cfg.micro_gap_seconds, 3600);
         assert!(cfg.enabled);
+        assert_eq!(cfg.autocompact_threshold_pct, None);
         assert_eq!(
             cfg.compactable_tools,
             vec!["Read", "Bash", "Grep", "Glob", "Write", "Edit"]
@@ -254,5 +262,19 @@ cache_diagnostics = true
         assert_eq!(back.context_window, 100_000);
         assert_eq!(back.output_reserve, 15_000);
         assert_eq!(back.autocompact_buffer, cfg.autocompact_buffer);
+    }
+
+    #[test]
+    fn toml_autocompact_threshold_pct() {
+        let toml_str = r#"autocompact_threshold_pct = 50"#;
+        let cfg: CompactConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.autocompact_threshold_pct, Some(50));
+    }
+
+    #[test]
+    fn toml_absent_threshold_pct_is_none() {
+        let toml_str = r#"context_window = 128000"#;
+        let cfg: CompactConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.autocompact_threshold_pct, None);
     }
 }


### PR DESCRIPTION
## Summary
- Add `autocompact_threshold_pct` (`Option<u8>`) to `CompactConfig`, allowing users to set the autocompact trigger as a percentage of `context_window` (e.g., `50` = 50% of 200k = 100k tokens)
- When set, overrides the default `context_window - output_reserve - autocompact_buffer` calculation
- Log the computed threshold when autocompact triggers with pct config for easier debugging

## Configuration

```toml
[compact]
autocompact_threshold_pct = 50  # triggers at 100k tokens for 200k context window
```

When unset (`None`), the existing threshold logic is preserved.

## Test plan
- [x] Unit tests for `should_autocompact()` with pct override (0%, 50%, 100%, None)
- [x] TOML deserialization tests for present and absent field
- [x] Default value test updated to assert `None`
- [x] `cargo clippy` / `cargo test` pass
- [x] Verified in AionUI with `autocompact_threshold_pct = 5` — triggered at ~10k tokens