### PR TITLE
feat: slash command system with engine-layer interception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "regex",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aion-config",
  "chrono",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aion-types",
  "rstest",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-agent/src/commands/clear.rs
+++ b/crates/aion-agent/src/commands/clear.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandResult, SlashCommand};
+use crate::compact::state::CompactState;
+
+pub struct ClearCommand;
+
+#[async_trait]
+impl SlashCommand for ClearCommand {
+    fn name(&self) -> &str {
+        "clear"
+    }
+
+    fn description(&self) -> &str {
+        "Clear conversation history"
+    }
+
+    async fn execute(
+        &self,
+        ctx: &mut CommandContext<'_>,
+        _args: &str,
+    ) -> anyhow::Result<CommandResult> {
+        ctx.messages.clear();
+        *ctx.compact_state = CompactState::new();
+        ctx.output.emit_info("Conversation cleared");
+        Ok(CommandResult::Continue)
+    }
+}

--- a/crates/aion-agent/src/commands/clear.rs
+++ b/crates/aion-agent/src/commands/clear.rs
@@ -57,8 +57,16 @@ mod tests {
         let registry = CommandRegistry::new();
         let output = NullSink;
         let mut messages = vec![
-            Message::new(Role::User, vec![ContentBlock::Text { text: "hello".into() }]),
-            Message::new(Role::Assistant, vec![ContentBlock::Text { text: "hi".into() }]),
+            Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "hello".into(),
+                }],
+            ),
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::Text { text: "hi".into() }],
+            ),
         ];
         let mut state = CompactState::new();
         state.last_input_tokens = 5000;

--- a/crates/aion-agent/src/commands/clear.rs
+++ b/crates/aion-agent/src/commands/clear.rs
@@ -26,3 +26,86 @@ impl SlashCommand for ClearCommand {
         Ok(CommandResult::Continue)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use aion_providers::{LlmProvider, ProviderError};
+    use aion_types::llm::{LlmEvent, LlmRequest};
+    use aion_types::message::{ContentBlock, Message, Role};
+
+    use super::*;
+    use crate::commands::{CommandContext, CommandRegistry};
+    use crate::output::null_sink::NullSink;
+
+    struct NullProvider;
+    #[async_trait::async_trait]
+    impl LlmProvider for NullProvider {
+        async fn stream(
+            &self,
+            _: &LlmRequest,
+        ) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(rx)
+        }
+    }
+
+    #[tokio::test]
+    async fn clear_empties_messages() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(NullProvider);
+        let registry = CommandRegistry::new();
+        let output = NullSink;
+        let mut messages = vec![
+            Message::new(Role::User, vec![ContentBlock::Text { text: "hello".into() }]),
+            Message::new(Role::Assistant, vec![ContentBlock::Text { text: "hi".into() }]),
+        ];
+        let mut state = CompactState::new();
+        state.last_input_tokens = 5000;
+        state.consecutive_failures = 2;
+        let config = aion_config::compact::CompactConfig::default();
+
+        let mut ctx = CommandContext {
+            messages: &mut messages,
+            compact_state: &mut state,
+            compact_config: &config,
+            provider,
+            model: "test",
+            output: &output,
+            registry: &registry,
+        };
+
+        let cmd = ClearCommand;
+        let result = cmd.execute(&mut ctx, "").await.unwrap();
+
+        assert_eq!(result, CommandResult::Continue);
+        assert!(ctx.messages.is_empty());
+        assert_eq!(ctx.compact_state.last_input_tokens, 0);
+        assert_eq!(ctx.compact_state.consecutive_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn clear_on_empty_messages() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(NullProvider);
+        let registry = CommandRegistry::new();
+        let output = NullSink;
+        let mut messages: Vec<Message> = vec![];
+        let mut state = CompactState::new();
+        let config = aion_config::compact::CompactConfig::default();
+
+        let mut ctx = CommandContext {
+            messages: &mut messages,
+            compact_state: &mut state,
+            compact_config: &config,
+            provider,
+            model: "test",
+            output: &output,
+            registry: &registry,
+        };
+
+        let cmd = ClearCommand;
+        let result = cmd.execute(&mut ctx, "").await.unwrap();
+        assert_eq!(result, CommandResult::Continue);
+        assert!(ctx.messages.is_empty());
+    }
+}

--- a/crates/aion-agent/src/commands/compact.rs
+++ b/crates/aion-agent/src/commands/compact.rs
@@ -46,20 +46,20 @@ impl SlashCommand for CompactCommand {
 
                 if let Some(boundary) = ctx.messages.first_mut() {
                     for block in &mut boundary.content {
-                        if let aion_types::message::ContentBlock::Text { text } = block {
-                            if text.starts_with(auto::BOUNDARY_PREFIX) {
-                                let metadata = aion_types::compact::CompactMetadata {
-                                    trigger: CompactTrigger::Manual,
-                                    pre_compact_tokens: pre_tokens,
-                                    messages_summarized: msgs_summarized,
-                                };
-                                *text = format!(
-                                    "{}\n{}",
-                                    auto::BOUNDARY_PREFIX,
-                                    serde_json::to_string(&metadata)
-                                        .expect("metadata serialization cannot fail")
-                                );
-                            }
+                        if let aion_types::message::ContentBlock::Text { text } = block
+                            && text.starts_with(auto::BOUNDARY_PREFIX)
+                        {
+                            let metadata = aion_types::compact::CompactMetadata {
+                                trigger: CompactTrigger::Manual,
+                                pre_compact_tokens: pre_tokens,
+                                messages_summarized: msgs_summarized,
+                            };
+                            *text = format!(
+                                "{}\n{}",
+                                auto::BOUNDARY_PREFIX,
+                                serde_json::to_string(&metadata)
+                                    .expect("metadata serialization cannot fail")
+                            );
                         }
                     }
                 }
@@ -111,9 +111,7 @@ mod tests {
         let output = NullSink;
         let mut messages = vec![Message::new(
             Role::User,
-            vec![ContentBlock::Text {
-                text: "hi".into(),
-            }],
+            vec![ContentBlock::Text { text: "hi".into() }],
         )];
         let mut state = CompactState::new();
         let config = aion_config::compact::CompactConfig::default();
@@ -141,8 +139,17 @@ mod tests {
         let output = NullSink;
         let mut messages: Vec<Message> = (0..10)
             .map(|i| {
-                let role = if i % 2 == 0 { Role::User } else { Role::Assistant };
-                Message::new(role, vec![ContentBlock::Text { text: format!("msg-{i}") }])
+                let role = if i % 2 == 0 {
+                    Role::User
+                } else {
+                    Role::Assistant
+                };
+                Message::new(
+                    role,
+                    vec![ContentBlock::Text {
+                        text: format!("msg-{i}"),
+                    }],
+                )
             })
             .collect();
         let mut state = CompactState::new();

--- a/crates/aion-agent/src/commands/compact.rs
+++ b/crates/aion-agent/src/commands/compact.rs
@@ -1,0 +1,80 @@
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandResult, SlashCommand};
+use crate::compact::auto;
+use aion_types::compact::CompactTrigger;
+
+pub struct CompactCommand;
+
+#[async_trait]
+impl SlashCommand for CompactCommand {
+    fn name(&self) -> &str {
+        "compact"
+    }
+
+    fn description(&self) -> &str {
+        "Compress conversation context"
+    }
+
+    async fn execute(
+        &self,
+        ctx: &mut CommandContext<'_>,
+        _args: &str,
+    ) -> anyhow::Result<CommandResult> {
+        if ctx.messages.len() <= 2 {
+            ctx.output.emit_info("Context is already compact");
+            return Ok(CommandResult::Continue);
+        }
+
+        // Reset circuit breaker — manual intent overrides protection
+        ctx.compact_state.consecutive_failures = 0;
+
+        let pre_tokens = ctx.compact_state.last_input_tokens;
+
+        match auto::autocompact(
+            ctx.provider.as_ref(),
+            ctx.messages,
+            ctx.model,
+            ctx.compact_config,
+            ctx.compact_state,
+        )
+        .await
+        {
+            Ok(result) => {
+                let msgs_summarized = result.messages_summarized;
+                *ctx.messages = result.messages;
+
+                if let Some(boundary) = ctx.messages.first_mut() {
+                    for block in &mut boundary.content {
+                        if let aion_types::message::ContentBlock::Text { text } = block {
+                            if text.starts_with(auto::BOUNDARY_PREFIX) {
+                                let metadata = aion_types::compact::CompactMetadata {
+                                    trigger: CompactTrigger::Manual,
+                                    pre_compact_tokens: pre_tokens,
+                                    messages_summarized: msgs_summarized,
+                                };
+                                *text = format!(
+                                    "{}\n{}",
+                                    auto::BOUNDARY_PREFIX,
+                                    serde_json::to_string(&metadata)
+                                        .expect("metadata serialization cannot fail")
+                                );
+                            }
+                        }
+                    }
+                }
+
+                ctx.output.emit_info(&format!(
+                    "Context compacted: {}k → compact ({} messages summarized)",
+                    pre_tokens / 1000,
+                    msgs_summarized
+                ));
+            }
+            Err(e) => {
+                ctx.output.emit_error(&format!("Compact failed: {}", e));
+            }
+        }
+
+        Ok(CommandResult::Continue)
+    }
+}

--- a/crates/aion-agent/src/commands/compact.rs
+++ b/crates/aion-agent/src/commands/compact.rs
@@ -78,3 +78,90 @@ impl SlashCommand for CompactCommand {
         Ok(CommandResult::Continue)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use aion_providers::{LlmProvider, ProviderError};
+    use aion_types::llm::{LlmEvent, LlmRequest};
+    use aion_types::message::{ContentBlock, Message, Role};
+
+    use super::*;
+    use crate::commands::{CommandContext, CommandRegistry};
+    use crate::compact::state::CompactState;
+    use crate::output::null_sink::NullSink;
+
+    struct NullProvider;
+    #[async_trait::async_trait]
+    impl LlmProvider for NullProvider {
+        async fn stream(
+            &self,
+            _: &LlmRequest,
+        ) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(rx)
+        }
+    }
+
+    #[tokio::test]
+    async fn compact_already_compact_guard() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(NullProvider);
+        let registry = CommandRegistry::new();
+        let output = NullSink;
+        let mut messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "hi".into(),
+            }],
+        )];
+        let mut state = CompactState::new();
+        let config = aion_config::compact::CompactConfig::default();
+
+        let mut ctx = CommandContext {
+            messages: &mut messages,
+            compact_state: &mut state,
+            compact_config: &config,
+            provider,
+            model: "test-model",
+            output: &output,
+            registry: &registry,
+        };
+
+        let cmd = CompactCommand;
+        let result = cmd.execute(&mut ctx, "").await.unwrap();
+        assert_eq!(result, CommandResult::Continue);
+        assert_eq!(ctx.messages.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn compact_resets_circuit_breaker() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(NullProvider);
+        let registry = CommandRegistry::new();
+        let output = NullSink;
+        let mut messages: Vec<Message> = (0..10)
+            .map(|i| {
+                let role = if i % 2 == 0 { Role::User } else { Role::Assistant };
+                Message::new(role, vec![ContentBlock::Text { text: format!("msg-{i}") }])
+            })
+            .collect();
+        let mut state = CompactState::new();
+        state.consecutive_failures = 5;
+        let config = aion_config::compact::CompactConfig::default();
+
+        let mut ctx = CommandContext {
+            messages: &mut messages,
+            compact_state: &mut state,
+            compact_config: &config,
+            provider,
+            model: "test-model",
+            output: &output,
+            registry: &registry,
+        };
+
+        let cmd = CompactCommand;
+        let _ = cmd.execute(&mut ctx, "").await;
+        // Circuit breaker was reset to 0 before the call, then failure increments it
+        assert!(ctx.compact_state.consecutive_failures <= 1);
+    }
+}

--- a/crates/aion-agent/src/commands/help.rs
+++ b/crates/aion-agent/src/commands/help.rs
@@ -1,0 +1,37 @@
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandResult, SlashCommand};
+
+pub struct HelpCommand;
+
+#[async_trait]
+impl SlashCommand for HelpCommand {
+    fn name(&self) -> &str {
+        "help"
+    }
+
+    fn description(&self) -> &str {
+        "List available commands"
+    }
+
+    async fn execute(
+        &self,
+        ctx: &mut CommandContext<'_>,
+        _args: &str,
+    ) -> anyhow::Result<CommandResult> {
+        let mut entries: Vec<(&str, &str)> = ctx
+            .registry
+            .all()
+            .iter()
+            .map(|cmd| (cmd.name(), cmd.description()))
+            .collect();
+        entries.sort_by_key(|(name, _)| *name);
+
+        let mut output = String::from("Available commands:\n");
+        for (name, desc) in entries {
+            output.push_str(&format!("  /{} — {}\n", name, desc));
+        }
+        ctx.output.emit_info(output.trim_end());
+        Ok(CommandResult::Continue)
+    }
+}

--- a/crates/aion-agent/src/commands/help.rs
+++ b/crates/aion-agent/src/commands/help.rs
@@ -35,3 +35,123 @@ impl SlashCommand for HelpCommand {
         Ok(CommandResult::Continue)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use aion_providers::{LlmProvider, ProviderError};
+    use aion_types::llm::{LlmEvent, LlmRequest};
+    use aion_types::message::Message;
+
+    use super::*;
+    use crate::commands::{CommandContext, default_registry};
+    use crate::compact::state::CompactState;
+    use crate::output::OutputSink;
+
+    struct CaptureSink {
+        messages: Mutex<Vec<String>>,
+    }
+
+    impl CaptureSink {
+        fn new() -> Self {
+            Self {
+                messages: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn captured(&self) -> Vec<String> {
+            self.messages.lock().unwrap().clone()
+        }
+    }
+
+    impl OutputSink for CaptureSink {
+        fn emit_text_delta(&self, _: &str, _: &str) {}
+        fn emit_thinking(&self, _: &str, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_stream_start(&self, _: &str) {}
+        fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
+        fn emit_error(&self, _: &str) {}
+        fn emit_info(&self, msg: &str) {
+            self.messages.lock().unwrap().push(msg.to_string());
+        }
+    }
+
+    struct NullProvider;
+    #[async_trait::async_trait]
+    impl LlmProvider for NullProvider {
+        async fn stream(
+            &self,
+            _: &LlmRequest,
+        ) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(rx)
+        }
+    }
+
+    #[tokio::test]
+    async fn help_lists_all_commands() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(NullProvider);
+        let registry = default_registry();
+        let output = CaptureSink::new();
+        let mut messages: Vec<Message> = Vec::new();
+        let mut state = CompactState::new();
+        let config = aion_config::compact::CompactConfig::default();
+
+        let mut ctx = CommandContext {
+            messages: &mut messages,
+            compact_state: &mut state,
+            compact_config: &config,
+            provider,
+            model: "test",
+            output: &output,
+            registry: &registry,
+        };
+
+        let cmd = HelpCommand;
+        let result = cmd.execute(&mut ctx, "").await.unwrap();
+        assert_eq!(result, CommandResult::Continue);
+
+        let captured = output.captured();
+        assert_eq!(captured.len(), 1);
+        let help_text = &captured[0];
+        assert!(help_text.contains("/clear"));
+        assert!(help_text.contains("/compact"));
+        assert!(help_text.contains("/help"));
+        assert!(help_text.contains("/quit"));
+    }
+
+    #[tokio::test]
+    async fn help_output_is_sorted() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(NullProvider);
+        let registry = default_registry();
+        let output = CaptureSink::new();
+        let mut messages: Vec<Message> = Vec::new();
+        let mut state = CompactState::new();
+        let config = aion_config::compact::CompactConfig::default();
+
+        let mut ctx = CommandContext {
+            messages: &mut messages,
+            compact_state: &mut state,
+            compact_config: &config,
+            provider,
+            model: "test",
+            output: &output,
+            registry: &registry,
+        };
+
+        let cmd = HelpCommand;
+        cmd.execute(&mut ctx, "").await.unwrap();
+
+        let help_text = &output.captured()[0];
+        let clear_pos = help_text.find("/clear").unwrap();
+        let compact_pos = help_text.find("/compact").unwrap();
+        let help_pos = help_text.find("/help").unwrap();
+        let quit_pos = help_text.find("/quit").unwrap();
+
+        assert!(clear_pos < compact_pos);
+        assert!(compact_pos < help_pos);
+        assert!(help_pos < quit_pos);
+    }
+}

--- a/crates/aion-agent/src/commands/mod.rs
+++ b/crates/aion-agent/src/commands/mod.rs
@@ -1,0 +1,130 @@
+pub mod clear;
+pub mod compact;
+pub mod help;
+pub mod quit;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::compact::state::CompactState;
+use crate::output::OutputSink;
+use aion_config::compact::CompactConfig;
+use aion_providers::LlmProvider;
+use aion_types::message::Message;
+
+/// Result of executing a slash command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandResult {
+    /// Command handled, continue the REPL loop.
+    Continue,
+    /// Exit the REPL.
+    Exit,
+}
+
+/// Context passed to slash commands during execution.
+pub struct CommandContext<'a> {
+    pub messages: &'a mut Vec<Message>,
+    pub compact_state: &'a mut CompactState,
+    pub compact_config: &'a CompactConfig,
+    pub provider: Arc<dyn LlmProvider>,
+    pub model: &'a str,
+    pub output: &'a dyn OutputSink,
+    pub registry: &'a CommandRegistry,
+}
+
+/// A slash command that can be executed in the REPL.
+#[async_trait]
+pub trait SlashCommand: Send + Sync {
+    fn name(&self) -> &str;
+    fn aliases(&self) -> &[&str] {
+        &[]
+    }
+    fn description(&self) -> &str;
+    async fn execute(
+        &self,
+        ctx: &mut CommandContext<'_>,
+        args: &str,
+    ) -> anyhow::Result<CommandResult>;
+}
+
+/// Registry of all available slash commands.
+pub struct CommandRegistry {
+    commands: Vec<Box<dyn SlashCommand>>,
+}
+
+impl CommandRegistry {
+    pub fn new() -> Self {
+        Self {
+            commands: Vec::new(),
+        }
+    }
+
+    pub fn register(&mut self, cmd: Box<dyn SlashCommand>) {
+        self.commands.push(cmd);
+    }
+
+    pub fn find(&self, name: &str) -> Option<&dyn SlashCommand> {
+        self.commands.iter().find_map(|cmd| {
+            if cmd.name() == name || cmd.aliases().contains(&name) {
+                Some(cmd.as_ref())
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn all(&self) -> &[Box<dyn SlashCommand>] {
+        &self.commands
+    }
+}
+
+impl Default for CommandRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Build the default registry with all built-in commands.
+pub fn default_registry() -> CommandRegistry {
+    let mut registry = CommandRegistry::new();
+    registry.register(Box::new(compact::CompactCommand));
+    registry.register(Box::new(clear::ClearCommand));
+    registry.register(Box::new(help::HelpCommand));
+    registry.register(Box::new(quit::QuitCommand));
+    registry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_find_by_name() {
+        let registry = default_registry();
+        assert!(registry.find("compact").is_some());
+        assert!(registry.find("clear").is_some());
+        assert!(registry.find("help").is_some());
+        assert!(registry.find("quit").is_some());
+    }
+
+    #[test]
+    fn registry_find_by_alias() {
+        let registry = default_registry();
+        assert!(registry.find("exit").is_some());
+        let cmd = registry.find("exit").unwrap();
+        assert_eq!(cmd.name(), "quit");
+    }
+
+    #[test]
+    fn registry_find_unknown_returns_none() {
+        let registry = default_registry();
+        assert!(registry.find("nonexistent").is_none());
+    }
+
+    #[test]
+    fn registry_all_returns_all_commands() {
+        let registry = default_registry();
+        assert_eq!(registry.all().len(), 4);
+    }
+}

--- a/crates/aion-agent/src/commands/quit.rs
+++ b/crates/aion-agent/src/commands/quit.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandResult, SlashCommand};
+
+pub struct QuitCommand;
+
+#[async_trait]
+impl SlashCommand for QuitCommand {
+    fn name(&self) -> &str {
+        "quit"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &["exit"]
+    }
+
+    fn description(&self) -> &str {
+        "Exit the REPL"
+    }
+
+    async fn execute(
+        &self,
+        _ctx: &mut CommandContext<'_>,
+        _args: &str,
+    ) -> anyhow::Result<CommandResult> {
+        Ok(CommandResult::Exit)
+    }
+}

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -61,6 +61,7 @@ pub struct AgentEngine {
     cache_detector: CacheBreakDetector,
     compaction_level: aion_compact::CompactionLevel,
     toon_enabled: bool,
+    commands: crate::commands::CommandRegistry,
 }
 
 impl AgentEngine {
@@ -122,6 +123,7 @@ impl AgentEngine {
             cache_detector: CacheBreakDetector::new(),
             compaction_level: config.compact.compaction,
             toon_enabled: config.compact.toon,
+            commands: crate::commands::default_registry(),
         }
     }
 
@@ -188,6 +190,7 @@ impl AgentEngine {
             cache_detector: CacheBreakDetector::new(),
             compaction_level: config.compact.compaction,
             toon_enabled: config.compact.toon,
+            commands: crate::commands::default_registry(),
         }
     }
 
@@ -349,6 +352,42 @@ impl AgentEngine {
         }
 
         changes
+    }
+
+    /// Handle a slash command. Returns `None` if input is not a recognized command.
+    pub async fn handle_command(
+        &mut self,
+        input: &str,
+    ) -> Option<Result<crate::commands::CommandResult, anyhow::Error>> {
+        let input = input.trim();
+        let without_slash = input.strip_prefix('/')?;
+        let (name, args) = match without_slash.split_once(char::is_whitespace) {
+            Some((n, rest)) => (n, rest.trim()),
+            None => (without_slash, ""),
+        };
+
+        let cmd = self.commands.find(name)?;
+
+        // We need to borrow self mutably for CommandContext while also
+        // borrowing self.commands immutably (already done above via find()).
+        // Use a raw pointer to break the borrow conflict — safe because
+        // the command is not modified during execution.
+        let cmd_ptr = cmd as *const dyn crate::commands::SlashCommand;
+
+        let mut ctx = crate::commands::CommandContext {
+            messages: &mut self.messages,
+            compact_state: &mut self.compact_state,
+            compact_config: &self.compact_config,
+            provider: Arc::clone(&self.provider),
+            model: &self.model,
+            output: self.output.as_ref(),
+            registry: &self.commands,
+        };
+
+        // SAFETY: cmd_ptr points to a command inside self.commands which is only
+        // borrowed immutably and not mutated during execute().
+        let result = unsafe { &*cmd_ptr }.execute(&mut ctx, args).await;
+        Some(result)
     }
 
     /// Run the agent loop with user input
@@ -880,6 +919,7 @@ mod set_config_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: aion_compact::CompactionLevel::default(),
             toon_enabled: false,
+            commands: crate::commands::default_registry(),
         }
     }
 
@@ -1207,6 +1247,7 @@ mod phase6_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: aion_compact::CompactionLevel::default(),
             toon_enabled: false,
+            commands: crate::commands::default_registry(),
         }
     }
 
@@ -1409,6 +1450,7 @@ mod compact_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: aion_compact::CompactionLevel::default(),
             toon_enabled: false,
+            commands: crate::commands::default_registry(),
         }
     }
 
@@ -1675,6 +1717,7 @@ mod plan_mode_tests {
             cache_detector: super::CacheBreakDetector::new(),
             compaction_level: aion_compact::CompactionLevel::default(),
             toon_enabled: false,
+            commands: crate::commands::default_registry(),
         }
     }
 
@@ -1817,6 +1860,141 @@ mod plan_mode_tests {
         })]);
 
         assert!(engine.plan_state.is_active);
+    }
+}
+
+#[cfg(test)]
+mod handle_command_tests {
+    use std::sync::{Arc, Mutex};
+
+    use aion_providers::{LlmProvider, ProviderError};
+    use aion_tools::registry::ToolRegistry;
+    use aion_types::llm::{LlmEvent, LlmRequest};
+    use aion_types::message::{ContentBlock, Message, Role};
+
+    use crate::compact::state::CompactState;
+    use crate::confirm::ToolConfirmer;
+    use crate::output::OutputSink;
+
+    struct NullOutput;
+    impl OutputSink for NullOutput {
+        fn emit_text_delta(&self, _: &str, _: &str) {}
+        fn emit_thinking(&self, _: &str, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_stream_start(&self, _: &str) {}
+        fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
+        fn emit_error(&self, _: &str) {}
+        fn emit_info(&self, _: &str) {}
+    }
+
+    struct NullProvider;
+    #[async_trait::async_trait]
+    impl LlmProvider for NullProvider {
+        async fn stream(
+            &self,
+            _: &LlmRequest,
+        ) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(rx)
+        }
+    }
+
+    fn make_engine() -> super::AgentEngine {
+        super::AgentEngine {
+            provider: Arc::new(NullProvider),
+            tools: ToolRegistry::new(),
+            messages: vec![],
+            system_prompt: String::new(),
+            model: "test-model".to_string(),
+            max_tokens: 4096,
+            max_turns: Some(10),
+            total_usage: Default::default(),
+            thinking: None,
+            compat: aion_config::compat::ProviderCompat::anthropic_defaults(),
+            confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
+            hooks: None,
+            session_manager: None,
+            current_session: None,
+            output: Arc::new(NullOutput),
+            current_msg_id: String::new(),
+            approval_manager: None,
+            protocol_writer: None,
+            allow_list: vec![],
+            current_reasoning_effort: None,
+            compact_config: aion_config::compact::CompactConfig::default(),
+            compact_state: CompactState::new(),
+            plan_state: Default::default(),
+            plan_active_flag: None,
+            cache_detector: super::CacheBreakDetector::new(),
+            compaction_level: aion_compact::CompactionLevel::default(),
+            toon_enabled: false,
+            commands: crate::commands::default_registry(),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_command_quit() {
+        let mut engine = make_engine();
+        let result = engine.handle_command("/quit").await;
+        assert!(matches!(
+            result,
+            Some(Ok(crate::commands::CommandResult::Exit))
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_command_exit_alias() {
+        let mut engine = make_engine();
+        let result = engine.handle_command("/exit").await;
+        assert!(matches!(
+            result,
+            Some(Ok(crate::commands::CommandResult::Exit))
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_command_unknown() {
+        let mut engine = make_engine();
+        let result = engine.handle_command("/nonexistent").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn handle_command_clear() {
+        let mut engine = make_engine();
+        engine.messages.push(Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "hello".to_string(),
+            }],
+        ));
+        assert_eq!(engine.messages.len(), 1);
+
+        let result = engine.handle_command("/clear").await;
+        assert!(matches!(
+            result,
+            Some(Ok(crate::commands::CommandResult::Continue))
+        ));
+        assert!(engine.messages.is_empty());
+        assert_eq!(engine.compact_state.last_input_tokens, 0);
+    }
+
+    #[tokio::test]
+    async fn handle_command_with_args() {
+        let mut engine = make_engine();
+        let result = engine.handle_command("/help compact").await;
+        assert!(matches!(
+            result,
+            Some(Ok(crate::commands::CommandResult::Continue))
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_command_not_a_command() {
+        let mut engine = make_engine();
+        let result = engine.handle_command("hello world").await;
+        assert!(result.is_none());
     }
 }
 

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -422,7 +422,7 @@ impl AgentEngine {
     ) -> Result<AgentResult, AgentError> {
         // Slash command interception — before any LLM call
         if let Some(result) = self.handle_command(user_input).await {
-            let cmd_name = user_input.trim().split_whitespace().next().unwrap_or(user_input);
+            let cmd_name = user_input.split_whitespace().next().unwrap_or(user_input);
             return match result {
                 Ok(crate::commands::CommandResult::Exit) => {
                     tracing::info!(command = cmd_name, "Slash command executed: exit");

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -406,11 +406,34 @@ impl AgentEngine {
         self.run_inner(user_input, msg_id).instrument(span).await
     }
 
+    /// Return metadata for all registered slash commands.
+    pub fn slash_command_list(&self) -> Vec<(String, String)> {
+        self.commands
+            .all()
+            .iter()
+            .map(|cmd| (cmd.name().to_string(), cmd.description().to_string()))
+            .collect()
+    }
+
     async fn run_inner(
         &mut self,
         user_input: &str,
         msg_id: &str,
     ) -> Result<AgentResult, AgentError> {
+        // Slash command interception — before any LLM call
+        if let Some(result) = self.handle_command(user_input).await {
+            return match result {
+                Ok(crate::commands::CommandResult::Exit) => Err(AgentError::UserAborted),
+                Ok(crate::commands::CommandResult::Continue) => Ok(AgentResult {
+                    text: String::new(),
+                    stop_reason: StopReason::EndTurn,
+                    usage: TokenUsage::default(),
+                    turns: 0,
+                }),
+                Err(e) => Err(AgentError::ApiError(e.to_string())),
+            };
+        }
+
         self.current_msg_id = msg_id.to_string();
         self.output.emit_stream_start(msg_id);
         self.messages.push(Message::now(
@@ -1995,6 +2018,33 @@ mod handle_command_tests {
         let mut engine = make_engine();
         let result = engine.handle_command("hello world").await;
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn run_intercepts_help_returns_zero_turns() {
+        let mut engine = make_engine();
+        let result = engine.run("/help", "msg-1").await.unwrap();
+        assert_eq!(result.turns, 0);
+        assert_eq!(result.usage.input_tokens, 0);
+    }
+
+    #[tokio::test]
+    async fn run_intercepts_quit_returns_user_aborted() {
+        let mut engine = make_engine();
+        let err = engine.run("/quit", "msg-1").await.unwrap_err();
+        assert!(matches!(err, super::AgentError::UserAborted));
+    }
+
+    #[test]
+    fn slash_command_list_returns_all() {
+        let engine = make_engine();
+        let list = engine.slash_command_list();
+        assert!(list.len() >= 4);
+        let names: Vec<&str> = list.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"help"));
+        assert!(names.contains(&"compact"));
+        assert!(names.contains(&"clear"));
+        assert!(names.contains(&"quit"));
     }
 }
 

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -422,15 +422,25 @@ impl AgentEngine {
     ) -> Result<AgentResult, AgentError> {
         // Slash command interception — before any LLM call
         if let Some(result) = self.handle_command(user_input).await {
+            let cmd_name = user_input.trim().split_whitespace().next().unwrap_or(user_input);
             return match result {
-                Ok(crate::commands::CommandResult::Exit) => Err(AgentError::UserAborted),
-                Ok(crate::commands::CommandResult::Continue) => Ok(AgentResult {
-                    text: String::new(),
-                    stop_reason: StopReason::EndTurn,
-                    usage: TokenUsage::default(),
-                    turns: 0,
-                }),
-                Err(e) => Err(AgentError::ApiError(e.to_string())),
+                Ok(crate::commands::CommandResult::Exit) => {
+                    tracing::info!(command = cmd_name, "Slash command executed: exit");
+                    Err(AgentError::UserAborted)
+                }
+                Ok(crate::commands::CommandResult::Continue) => {
+                    tracing::info!(command = cmd_name, "Slash command executed");
+                    Ok(AgentResult {
+                        text: String::new(),
+                        stop_reason: StopReason::EndTurn,
+                        usage: TokenUsage::default(),
+                        turns: 0,
+                    })
+                }
+                Err(e) => {
+                    tracing::error!(command = cmd_name, error = %e, "Slash command failed");
+                    Err(AgentError::ApiError(e.to_string()))
+                }
             };
         }
 

--- a/crates/aion-agent/src/lib.rs
+++ b/crates/aion-agent/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod agents_md;
 pub mod bootstrap;
 pub mod cache_diagnostics;
+pub mod commands;
 pub mod compact;
 pub mod confirm;
 pub mod context;

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -321,27 +321,20 @@ async fn repl_loop(
             break;
         }
 
-        if input.starts_with('/') {
-            match engine.handle_command(input).await {
-                Some(Ok(aion_agent::commands::CommandResult::Exit)) => break,
-                Some(Ok(aion_agent::commands::CommandResult::Continue)) => {}
-                Some(Err(e)) => output.emit_error(&e.to_string()),
-                None => output.emit_error(&format!("Unknown command: {}", input)),
-            }
-            continue;
-        }
-
         match engine.run(input, "").await {
             Ok(result) => {
-                output.emit_stream_end(
-                    "",
-                    result.turns,
-                    result.usage.input_tokens,
-                    result.usage.output_tokens,
-                    result.usage.cache_creation_tokens,
-                    result.usage.cache_read_tokens,
-                );
+                if result.turns > 0 {
+                    output.emit_stream_end(
+                        "",
+                        result.turns,
+                        result.usage.input_tokens,
+                        result.usage.output_tokens,
+                        result.usage.cache_creation_tokens,
+                        result.usage.cache_read_tokens,
+                    );
+                }
             }
+            Err(aion_agent::engine::AgentError::UserAborted) => break,
             Err(e) => {
                 output.emit_error(&e.to_string());
             }

--- a/crates/aion-cli/src/main.rs
+++ b/crates/aion-cli/src/main.rs
@@ -317,8 +317,18 @@ async fn repl_loop(
         io::stdin().lock().read_line(&mut input)?;
         let input = input.trim();
 
-        if input.is_empty() || input == "/quit" || input == "/exit" {
+        if input.is_empty() {
             break;
+        }
+
+        if input.starts_with('/') {
+            match engine.handle_command(input).await {
+                Some(Ok(aion_agent::commands::CommandResult::Exit)) => break,
+                Some(Ok(aion_agent::commands::CommandResult::Continue)) => {}
+                Some(Err(e)) => output.emit_error(&e.to_string()),
+                None => output.emit_error(&format!("Unknown command: {}", input)),
+            }
+            continue;
         }
 
         match engine.run(input, "").await {


### PR DESCRIPTION
## Summary

- Add extensible slash command system (`/compact`, `/clear`, `/help`, `/quit`) with trait-based registry
- Intercept commands in `engine.run()` so all hosts (CLI, AionUI backend) automatically get command support
- Expose `slash_command_list()` for the backend `/slash-commands` API endpoint
- Simplify CLI `repl_loop()` — unified path through `engine.run()`

## Design

Commands are intercepted at the top of `engine.run_inner()` before any LLM call:
- Known commands return `AgentResult { turns: 0 }` (distinguish from LLM responses)
- `/quit` maps to `AgentError::UserAborted`
- Unknown `/foo` is not intercepted — flows to LLM as normal text
- Command output goes through `OutputSink::emit_info()` (not `AgentResult.text`)

## Test plan

- [x] Unit tests for CommandRegistry (find by name, alias, unknown)
- [x] Unit tests for each command (/compact, /clear, /help, /quit)
- [x] Engine-level tests: `run()` intercepts /help (turns=0), /quit (UserAborted)
- [x] `slash_command_list()` returns all registered commands
- [x] Full test suite passes (cargo test, clippy, fmt)
- [x] Verified in AionUI: commands intercepted, no LLM calls in log