### PR TITLE
fix(providers): retry SSE stream on mid-stream connection disconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "regex",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aion-config",
  "chrono",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aion-types",
  "rstest",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-providers/src/anthropic.rs
+++ b/crates/aion-providers/src/anthropic.rs
@@ -123,10 +123,45 @@ impl LlmProvider for AnthropicProvider {
         }
 
         let (tx, rx) = mpsc::channel(64);
+        let client = self.client.clone();
+        let headers = self.build_headers()?;
+        let url_clone = url.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = anthropic_shared::process_sse_stream(response, &tx).await {
-                let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+            match anthropic_shared::process_sse_stream(response, &tx).await {
+                anthropic_shared::StreamOutcome::Ok => {}
+                anthropic_shared::StreamOutcome::FailedPartial(e) => {
+                    let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+                }
+                anthropic_shared::StreamOutcome::FailedEmpty(e) => {
+                    if e.is_retryable() {
+                        let mut backoff = std::time::Duration::from_secs(1);
+                        let mut final_err = Some(e);
+                        for attempt in 1..=crate::retry::MAX_STREAM_RETRIES {
+                            backoff = crate::retry::backoff_sleep(attempt, backoff).await;
+                            match crate::retry::send_and_check(&client, &url_clone, &headers, &body).await {
+                                Ok(resp) => {
+                                    let outcome = anthropic_shared::process_sse_stream(resp, &tx).await;
+                                    match crate::retry::evaluate_outcome(outcome, attempt) {
+                                        Ok(None) => { final_err = None; break; }
+                                        Ok(Some(e)) => { final_err = Some(e); break; }
+                                        Err(_) => continue,
+                                    }
+                                }
+                                Err(e) if attempt == crate::retry::MAX_STREAM_RETRIES => {
+                                    final_err = Some(e);
+                                    break;
+                                }
+                                Err(_) => continue,
+                            }
+                        }
+                        if let Some(err) = final_err {
+                            let _ = tx.send(LlmEvent::Error(err.to_string())).await;
+                        }
+                    } else {
+                        let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+                    }
+                }
             }
         });
 

--- a/crates/aion-providers/src/anthropic.rs
+++ b/crates/aion-providers/src/anthropic.rs
@@ -139,12 +139,21 @@ impl LlmProvider for AnthropicProvider {
                         let mut final_err = Some(e);
                         for attempt in 1..=crate::retry::MAX_STREAM_RETRIES {
                             backoff = crate::retry::backoff_sleep(attempt, backoff).await;
-                            match crate::retry::send_and_check(&client, &url_clone, &headers, &body).await {
+                            match crate::retry::send_and_check(&client, &url_clone, &headers, &body)
+                                .await
+                            {
                                 Ok(resp) => {
-                                    let outcome = anthropic_shared::process_sse_stream(resp, &tx).await;
+                                    let outcome =
+                                        anthropic_shared::process_sse_stream(resp, &tx).await;
                                     match crate::retry::evaluate_outcome(outcome, attempt) {
-                                        Ok(None) => { final_err = None; break; }
-                                        Ok(Some(e)) => { final_err = Some(e); break; }
+                                        Ok(None) => {
+                                            final_err = None;
+                                            break;
+                                        }
+                                        Ok(Some(e)) => {
+                                            final_err = Some(e);
+                                            break;
+                                        }
                                         Err(_) => continue,
                                     }
                                 }

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -275,7 +275,9 @@ pub async fn process_sse_stream(
                     for event in events {
                         if matches!(
                             event,
-                            LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
+                            LlmEvent::TextDelta(_)
+                                | LlmEvent::ThinkingDelta(_)
+                                | LlmEvent::ToolUse { .. }
                         ) {
                             emitted_content = true;
                         }

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -225,20 +225,39 @@ impl StreamState {
     }
 }
 
+/// Outcome of SSE stream processing — distinguishes "failed before any content
+/// was emitted" (safe to retry) from "failed after partial content" (not safe).
+pub enum StreamOutcome {
+    Ok,
+    FailedEmpty(ProviderError),
+    FailedPartial(ProviderError),
+}
+
 /// Process the SSE stream from an Anthropic-compatible API
 pub async fn process_sse_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
-) -> Result<(), ProviderError> {
+) -> StreamOutcome {
     use futures::StreamExt;
 
     let mut state = StreamState::new();
     let mut buffer = String::new();
     let mut current_event_type = String::new();
     let mut stream = response.bytes_stream();
+    let mut emitted_content = false;
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| ProviderError::Connection(e.to_string()))?;
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                let err = ProviderError::Connection(e.to_string());
+                return if emitted_content {
+                    StreamOutcome::FailedPartial(err)
+                } else {
+                    StreamOutcome::FailedEmpty(err)
+                };
+            }
+        };
         let text = String::from_utf8_lossy(&chunk);
         buffer.push_str(&text);
 
@@ -254,8 +273,14 @@ pub async fn process_sse_stream(
                     tracing::debug!(target: "aion_providers", chunk = %data, "sse chunk received");
                     let events = parse_sse_data(&current_event_type, data, &mut state);
                     for event in events {
+                        if matches!(
+                            event,
+                            LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
+                        ) {
+                            emitted_content = true;
+                        }
                         if tx.send(event).await.is_err() {
-                            return Ok(()); // receiver dropped
+                            return StreamOutcome::Ok; // receiver dropped
                         }
                     }
                 }
@@ -263,7 +288,7 @@ pub async fn process_sse_stream(
         }
     }
 
-    Ok(())
+    StreamOutcome::Ok
 }
 
 /// Parse a single SSE data payload into zero or more LlmEvents

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -288,8 +288,13 @@ impl LlmProvider for BedrockProvider {
 
         // AWS event stream uses binary framing
         tokio::spawn(async move {
-            if let Err(e) = process_aws_event_stream(response, &tx).await {
-                let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+            match process_aws_event_stream(response, &tx).await {
+                anthropic_shared::StreamOutcome::Ok => {}
+                anthropic_shared::StreamOutcome::FailedPartial(e)
+                | anthropic_shared::StreamOutcome::FailedEmpty(e) => {
+                    // Bedrock retry requires re-signing; not implemented yet.
+                    let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+                }
             }
         });
 
@@ -301,15 +306,26 @@ impl LlmProvider for BedrockProvider {
 async fn process_aws_event_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
-) -> Result<(), ProviderError> {
+) -> anthropic_shared::StreamOutcome {
     use futures::StreamExt;
 
     let mut state = anthropic_shared::StreamState::new();
     let mut buffer = Vec::new();
     let mut stream = response.bytes_stream();
+    let mut emitted_content = false;
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| ProviderError::Connection(e.to_string()))?;
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                let err = ProviderError::Connection(e.to_string());
+                return if emitted_content {
+                    anthropic_shared::StreamOutcome::FailedPartial(err)
+                } else {
+                    anthropic_shared::StreamOutcome::FailedEmpty(err)
+                };
+            }
+        };
         buffer.extend_from_slice(&chunk);
 
         // Parse complete AWS event stream messages from buffer
@@ -331,8 +347,14 @@ async fn process_aws_event_stream(
                             let events =
                                 anthropic_shared::parse_sse_data(event_type, &inner, &mut state);
                             for event in events {
+                                if matches!(
+                                    event,
+                                    LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
+                                ) {
+                                    emitted_content = true;
+                                }
                                 if tx.send(event).await.is_err() {
-                                    return Ok(());
+                                    return anthropic_shared::StreamOutcome::Ok;
                                 }
                             }
                         }
@@ -357,7 +379,7 @@ async fn process_aws_event_stream(
             .await;
     }
 
-    Ok(())
+    anthropic_shared::StreamOutcome::Ok
 }
 
 /// Parse one AWS event stream message from the buffer.

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -349,7 +349,9 @@ async fn process_aws_event_stream(
                             for event in events {
                                 if matches!(
                                     event,
-                                    LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
+                                    LlmEvent::TextDelta(_)
+                                        | LlmEvent::ThinkingDelta(_)
+                                        | LlmEvent::ToolUse { .. }
                                 ) {
                                     emitted_content = true;
                                 }

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -8,6 +8,7 @@ use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 use aion_types::tool::{ToolDef, truncate_deferred_description};
 
 use crate::{LlmProvider, ProviderError};
+use crate::anthropic_shared::StreamOutcome;
 use aion_config::compat::ProviderCompat;
 
 pub struct OpenAIProvider {
@@ -527,10 +528,45 @@ impl LlmProvider for OpenAIProvider {
 
         let (tx, rx) = mpsc::channel(64);
         let auto_tool_id = self.compat.auto_tool_id();
+        let client = self.client.clone();
+        let headers = self.build_headers()?;
+        let url_clone = url.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = process_sse_stream(response, &tx, auto_tool_id).await {
-                let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+            match process_sse_stream(response, &tx, auto_tool_id).await {
+                StreamOutcome::Ok => {}
+                StreamOutcome::FailedPartial(e) => {
+                    let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+                }
+                StreamOutcome::FailedEmpty(e) => {
+                    if e.is_retryable() {
+                        let mut backoff = std::time::Duration::from_secs(1);
+                        let mut final_err = Some(e);
+                        for attempt in 1..=crate::retry::MAX_STREAM_RETRIES {
+                            backoff = crate::retry::backoff_sleep(attempt, backoff).await;
+                            match crate::retry::send_and_check(&client, &url_clone, &headers, &body).await {
+                                Ok(resp) => {
+                                    let outcome = process_sse_stream(resp, &tx, auto_tool_id).await;
+                                    match crate::retry::evaluate_outcome(outcome, attempt) {
+                                        Ok(None) => { final_err = None; break; }
+                                        Ok(Some(e)) => { final_err = Some(e); break; }
+                                        Err(_) => continue,
+                                    }
+                                }
+                                Err(e) if attempt == crate::retry::MAX_STREAM_RETRIES => {
+                                    final_err = Some(e);
+                                    break;
+                                }
+                                Err(_) => continue,
+                            }
+                        }
+                        if let Some(err) = final_err {
+                            let _ = tx.send(LlmEvent::Error(err.to_string())).await;
+                        }
+                    } else {
+                        let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+                    }
+                }
             }
         });
 
@@ -542,15 +578,26 @@ async fn process_sse_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
     auto_tool_id: bool,
-) -> Result<(), ProviderError> {
+) -> StreamOutcome {
     use futures::StreamExt;
 
     let mut state = StreamState::new();
     let mut buffer = String::new();
     let mut stream = response.bytes_stream();
+    let mut emitted_content = false;
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| ProviderError::Connection(e.to_string()))?;
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                let err = ProviderError::Connection(e.to_string());
+                return if emitted_content {
+                    StreamOutcome::FailedPartial(err)
+                } else {
+                    StreamOutcome::FailedEmpty(err)
+                };
+            }
+        };
         let text = String::from_utf8_lossy(&chunk);
         buffer.push_str(&text);
 
@@ -571,21 +618,28 @@ async fn process_sse_stream(
                     if let Some(done) = state.flush_done() {
                         let _ = tx.send(done).await;
                     }
-                    return Ok(());
+                    return StreamOutcome::Ok;
                 }
 
                 let events = parse_sse_chunk(data, &mut state, auto_tool_id);
                 for event in events {
+                    if matches!(
+                        event,
+                        LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
+                    ) {
+                        emitted_content = true;
+                    }
                     if tx.send(event).await.is_err() {
-                        return Ok(());
+                        return StreamOutcome::Ok;
                     }
                 }
             }
         }
     }
 
-    Ok(())
+    StreamOutcome::Ok
 }
+
 
 fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id: bool) -> Vec<LlmEvent> {
     let mut events = Vec::new();

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -7,8 +7,8 @@ use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 use aion_types::tool::{ToolDef, truncate_deferred_description};
 
-use crate::{LlmProvider, ProviderError};
 use crate::anthropic_shared::StreamOutcome;
+use crate::{LlmProvider, ProviderError};
 use aion_config::compat::ProviderCompat;
 
 pub struct OpenAIProvider {
@@ -544,12 +544,20 @@ impl LlmProvider for OpenAIProvider {
                         let mut final_err = Some(e);
                         for attempt in 1..=crate::retry::MAX_STREAM_RETRIES {
                             backoff = crate::retry::backoff_sleep(attempt, backoff).await;
-                            match crate::retry::send_and_check(&client, &url_clone, &headers, &body).await {
+                            match crate::retry::send_and_check(&client, &url_clone, &headers, &body)
+                                .await
+                            {
                                 Ok(resp) => {
                                     let outcome = process_sse_stream(resp, &tx, auto_tool_id).await;
                                     match crate::retry::evaluate_outcome(outcome, attempt) {
-                                        Ok(None) => { final_err = None; break; }
-                                        Ok(Some(e)) => { final_err = Some(e); break; }
+                                        Ok(None) => {
+                                            final_err = None;
+                                            break;
+                                        }
+                                        Ok(Some(e)) => {
+                                            final_err = Some(e);
+                                            break;
+                                        }
                                         Err(_) => continue,
                                     }
                                 }
@@ -625,7 +633,9 @@ async fn process_sse_stream(
                 for event in events {
                     if matches!(
                         event,
-                        LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
+                        LlmEvent::TextDelta(_)
+                            | LlmEvent::ThinkingDelta(_)
+                            | LlmEvent::ToolUse { .. }
                     ) {
                         emitted_content = true;
                     }
@@ -639,7 +649,6 @@ async fn process_sse_stream(
 
     StreamOutcome::Ok
 }
-
 
 fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id: bool) -> Vec<LlmEvent> {
     let mut events = Vec::new();

--- a/crates/aion-providers/src/retry.rs
+++ b/crates/aion-providers/src/retry.rs
@@ -175,7 +175,9 @@ mod tests {
         let err = ProviderError::Connection("disconnect".into());
         let result = evaluate_outcome(StreamOutcome::FailedPartial(err), 1);
         // FailedPartial means content was already emitted — cannot retry regardless of attempt
-        let Ok(Some(e)) = result else { panic!("expected Ok(Some(err))") };
+        let Ok(Some(e)) = result else {
+            panic!("expected Ok(Some(err))")
+        };
         assert!(matches!(e, ProviderError::Connection(_)));
     }
 
@@ -183,7 +185,9 @@ mod tests {
     fn test_evaluate_outcome_failed_partial_on_last_attempt() {
         let err = ProviderError::Connection("disconnect".into());
         let result = evaluate_outcome(StreamOutcome::FailedPartial(err), MAX_STREAM_RETRIES);
-        let Ok(Some(_)) = result else { panic!("expected Ok(Some(err))") };
+        let Ok(Some(_)) = result else {
+            panic!("expected Ok(Some(err))")
+        };
     }
 
     #[test]
@@ -199,7 +203,9 @@ mod tests {
         let err = ProviderError::Connection("disconnect".into());
         // attempt == MAX_STREAM_RETRIES, should stop and return error
         let result = evaluate_outcome(StreamOutcome::FailedEmpty(err), MAX_STREAM_RETRIES);
-        let Ok(Some(e)) = result else { panic!("expected Ok(Some(err))") };
+        let Ok(Some(e)) = result else {
+            panic!("expected Ok(Some(err))")
+        };
         assert!(matches!(e, ProviderError::Connection(_)));
     }
 

--- a/crates/aion-providers/src/retry.rs
+++ b/crates/aion-providers/src/retry.rs
@@ -1,7 +1,11 @@
 use std::future::Future;
 use std::time::Duration;
 
+use reqwest::header::HeaderMap;
+use serde_json::Value;
+
 use super::ProviderError;
+use super::anthropic_shared::StreamOutcome;
 
 /// Retry a fallible async operation with exponential backoff
 pub async fn with_retry<F, Fut, T>(max_retries: u32, f: F) -> Result<T, ProviderError>
@@ -22,6 +26,70 @@ where
         }
     }
     unreachable!()
+}
+
+pub const MAX_STREAM_RETRIES: u32 = 2;
+const MAX_BACKOFF: Duration = Duration::from_secs(15);
+
+/// Send an HTTP request and check status, returning the response on success.
+/// Used by provider-specific retry loops to avoid duplicating request logic.
+pub async fn send_and_check(
+    client: &reqwest::Client,
+    url: &str,
+    headers: &HeaderMap,
+    body: &Value,
+) -> Result<reqwest::Response, ProviderError> {
+    let response = client
+        .post(url)
+        .headers(headers.clone())
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| ProviderError::Connection(e.to_string()))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body_text = response.text().await.unwrap_or_default();
+        return Err(ProviderError::Api {
+            status: status.as_u16(),
+            message: body_text,
+        });
+    }
+
+    Ok(response)
+}
+
+/// Sleep with exponential backoff and log the retry attempt.
+/// Returns the next backoff duration.
+pub async fn backoff_sleep(attempt: u32, current_backoff: Duration) -> Duration {
+    tracing::warn!(
+        attempt,
+        max = MAX_STREAM_RETRIES,
+        "retrying stream after mid-stream disconnect"
+    );
+    tokio::time::sleep(current_backoff).await;
+    (current_backoff * 2).min(MAX_BACKOFF)
+}
+
+/// Evaluate a `StreamOutcome` within a retry loop. Returns:
+/// - `Ok(None)` — stream succeeded, stop retrying
+/// - `Ok(Some(err))` — non-retryable failure, caller should emit error
+/// - `Err(err)` — retryable failure, caller should continue loop
+pub fn evaluate_outcome(
+    outcome: StreamOutcome,
+    attempt: u32,
+) -> Result<Option<ProviderError>, ProviderError> {
+    match outcome {
+        StreamOutcome::Ok => Ok(None),
+        StreamOutcome::FailedPartial(e) => Ok(Some(e)),
+        StreamOutcome::FailedEmpty(e) => {
+            if attempt == MAX_STREAM_RETRIES {
+                Ok(Some(e))
+            } else {
+                Err(e)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -92,5 +160,72 @@ mod tests {
         // Non-retryable errors should fail immediately without retrying
         assert!(result.is_err());
         assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    // --- evaluate_outcome tests ---
+
+    #[test]
+    fn test_evaluate_outcome_ok_stops_retry() {
+        let result = evaluate_outcome(StreamOutcome::Ok, 1);
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn test_evaluate_outcome_failed_partial_always_stops() {
+        let err = ProviderError::Connection("disconnect".into());
+        let result = evaluate_outcome(StreamOutcome::FailedPartial(err), 1);
+        // FailedPartial means content was already emitted — cannot retry regardless of attempt
+        let Ok(Some(e)) = result else { panic!("expected Ok(Some(err))") };
+        assert!(matches!(e, ProviderError::Connection(_)));
+    }
+
+    #[test]
+    fn test_evaluate_outcome_failed_partial_on_last_attempt() {
+        let err = ProviderError::Connection("disconnect".into());
+        let result = evaluate_outcome(StreamOutcome::FailedPartial(err), MAX_STREAM_RETRIES);
+        let Ok(Some(_)) = result else { panic!("expected Ok(Some(err))") };
+    }
+
+    #[test]
+    fn test_evaluate_outcome_failed_empty_retries_when_not_exhausted() {
+        let err = ProviderError::Connection("disconnect".into());
+        // attempt 1 < MAX_STREAM_RETRIES(2), should signal "continue retrying"
+        let result = evaluate_outcome(StreamOutcome::FailedEmpty(err), 1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_evaluate_outcome_failed_empty_stops_on_last_attempt() {
+        let err = ProviderError::Connection("disconnect".into());
+        // attempt == MAX_STREAM_RETRIES, should stop and return error
+        let result = evaluate_outcome(StreamOutcome::FailedEmpty(err), MAX_STREAM_RETRIES);
+        let Ok(Some(e)) = result else { panic!("expected Ok(Some(err))") };
+        assert!(matches!(e, ProviderError::Connection(_)));
+    }
+
+    // --- backoff_sleep tests ---
+
+    #[tokio::test]
+    async fn test_backoff_sleep_doubles_duration() {
+        tokio::time::pause();
+
+        let next = backoff_sleep(1, Duration::from_secs(1)).await;
+        assert_eq!(next, Duration::from_secs(2));
+
+        let next = backoff_sleep(2, Duration::from_secs(4)).await;
+        assert_eq!(next, Duration::from_secs(8));
+    }
+
+    #[tokio::test]
+    async fn test_backoff_sleep_caps_at_max() {
+        tokio::time::pause();
+
+        // 10s * 2 = 20s, but MAX_BACKOFF is 15s
+        let next = backoff_sleep(1, Duration::from_secs(10)).await;
+        assert_eq!(next, Duration::from_secs(15));
+
+        // Already at max
+        let next = backoff_sleep(2, Duration::from_secs(15)).await;
+        assert_eq!(next, Duration::from_secs(15));
     }
 }

--- a/crates/aion-providers/src/vertex.rs
+++ b/crates/aion-providers/src/vertex.rs
@@ -320,12 +320,26 @@ impl LlmProvider for VertexProvider {
                         let mut final_err = Some(e);
                         for attempt in 1..=crate::retry::MAX_STREAM_RETRIES {
                             backoff = crate::retry::backoff_sleep(attempt, backoff).await;
-                            match crate::retry::send_and_check(&client, &url_clone, &headers_clone, &body).await {
+                            match crate::retry::send_and_check(
+                                &client,
+                                &url_clone,
+                                &headers_clone,
+                                &body,
+                            )
+                            .await
+                            {
                                 Ok(resp) => {
-                                    let outcome = anthropic_shared::process_sse_stream(resp, &tx).await;
+                                    let outcome =
+                                        anthropic_shared::process_sse_stream(resp, &tx).await;
                                     match crate::retry::evaluate_outcome(outcome, attempt) {
-                                        Ok(None) => { final_err = None; break; }
-                                        Ok(Some(e)) => { final_err = Some(e); break; }
+                                        Ok(None) => {
+                                            final_err = None;
+                                            break;
+                                        }
+                                        Ok(Some(e)) => {
+                                            final_err = Some(e);
+                                            break;
+                                        }
                                         Err(_) => continue,
                                     }
                                 }

--- a/crates/aion-providers/src/vertex.rs
+++ b/crates/aion-providers/src/vertex.rs
@@ -294,11 +294,55 @@ impl LlmProvider for VertexProvider {
         }
 
         let (tx, rx) = mpsc::channel(64);
+        let client = self.client.clone();
+        let url_clone = url.clone();
+        let headers_clone = {
+            let mut h = HeaderMap::new();
+            h.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+            h.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", access_token))
+                    .map_err(|e| ProviderError::Connection(format!("Header error: {}", e)))?,
+            );
+            h
+        };
 
         // Vertex uses standard SSE (same as Anthropic)
         tokio::spawn(async move {
-            if let Err(e) = anthropic_shared::process_sse_stream(response, &tx).await {
-                let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+            match anthropic_shared::process_sse_stream(response, &tx).await {
+                anthropic_shared::StreamOutcome::Ok => {}
+                anthropic_shared::StreamOutcome::FailedPartial(e) => {
+                    let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+                }
+                anthropic_shared::StreamOutcome::FailedEmpty(e) => {
+                    if e.is_retryable() {
+                        let mut backoff = std::time::Duration::from_secs(1);
+                        let mut final_err = Some(e);
+                        for attempt in 1..=crate::retry::MAX_STREAM_RETRIES {
+                            backoff = crate::retry::backoff_sleep(attempt, backoff).await;
+                            match crate::retry::send_and_check(&client, &url_clone, &headers_clone, &body).await {
+                                Ok(resp) => {
+                                    let outcome = anthropic_shared::process_sse_stream(resp, &tx).await;
+                                    match crate::retry::evaluate_outcome(outcome, attempt) {
+                                        Ok(None) => { final_err = None; break; }
+                                        Ok(Some(e)) => { final_err = Some(e); break; }
+                                        Err(_) => continue,
+                                    }
+                                }
+                                Err(e) if attempt == crate::retry::MAX_STREAM_RETRIES => {
+                                    final_err = Some(e);
+                                    break;
+                                }
+                                Err(_) => continue,
+                            }
+                        }
+                        if let Some(err) = final_err {
+                            let _ = tx.send(LlmEvent::Error(err.to_string())).await;
+                        }
+                    } else {
+                        let _ = tx.send(LlmEvent::Error(e.to_string())).await;
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
## Summary

- Add `StreamOutcome` enum to distinguish retryable (`FailedEmpty`) from non-retryable (`FailedPartial`) stream failures based on whether content has already been emitted
- Add composable retry helpers (`send_and_check`, `backoff_sleep`, `evaluate_outcome`) to avoid Rust HRTB lifetime issues with generic closures
- Apply retry logic (up to 2 attempts with exponential backoff) to OpenAI, Anthropic, and Vertex providers
- Bedrock skips retry since each request requires SigV4 re-signing
- Add unit tests for `evaluate_outcome` and `backoff_sleep`

## Context

Fixes intermittent "error decoding response body" failures (Sentry ELECTRON-1E6) caused by TCP connection resets during SSE streaming. Longer conversations have higher probability of hitting this due to extended streaming time. Users reported "restarting conversation fixes it" because shorter context = shorter stream = less exposure to disconnects.

## Test plan

- [x] `cargo clippy -p aion-providers -- -D warnings` passes
- [x] `cargo test -p aion-providers` — all 27 tests pass (including 7 new retry tests)
- [x] `cargo clippy -p aion-agent -- -D warnings` — downstream compiles cleanly
- [x] `just push` passes full workspace checks