### PR TITLE
Retry initial OpenAI connect failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "regex",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aion-config",
  "chrono",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aion-types",
  "rstest",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -501,35 +501,40 @@ impl LlmProvider for OpenAIProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = format!("{}{}", self.base_url, self.compat.api_path());
         let body = self.build_request_body(request);
+        let headers = self.build_headers()?;
 
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
 
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.build_headers()?)
-            .json(&body)
-            .send()
-            .await?;
+        let response = crate::retry::with_initial_connect_retry(|| async {
+            let response = self
+                .client
+                .post(&url)
+                .headers(headers.clone())
+                .json(&body)
+                .send()
+                .await?;
 
-        let status = response.status();
-        if !status.is_success() {
-            let body_text = response.text().await.unwrap_or_default();
-            if status.as_u16() == 429 {
-                return Err(ProviderError::RateLimited {
-                    retry_after_ms: 5000,
+            let status = response.status();
+            if !status.is_success() {
+                let body_text = response.text().await.unwrap_or_default();
+                if status.as_u16() == 429 {
+                    return Err(ProviderError::RateLimited {
+                        retry_after_ms: 5000,
+                    });
+                }
+                return Err(ProviderError::Api {
+                    status: status.as_u16(),
+                    message: body_text,
                 });
             }
-            return Err(ProviderError::Api {
-                status: status.as_u16(),
-                message: body_text,
-            });
-        }
+
+            Ok(response)
+        })
+        .await?;
 
         let (tx, rx) = mpsc::channel(64);
         let auto_tool_id = self.compat.auto_tool_id();
         let client = self.client.clone();
-        let headers = self.build_headers()?;
         let url_clone = url.clone();
 
         tokio::spawn(async move {

--- a/crates/aion-providers/src/retry.rs
+++ b/crates/aion-providers/src/retry.rs
@@ -29,7 +29,45 @@ where
 }
 
 pub const MAX_STREAM_RETRIES: u32 = 2;
+pub const MAX_INITIAL_CONNECT_RETRIES: u32 = 2;
 const MAX_BACKOFF: Duration = Duration::from_secs(15);
+const INITIAL_CONNECT_BACKOFF: Duration = Duration::from_millis(300);
+const MAX_INITIAL_CONNECT_BACKOFF: Duration = Duration::from_secs(2);
+
+/// Retry initial request failures that occur before an HTTP response exists.
+/// HTTP status errors and rate limits are intentionally not retried here.
+pub async fn with_initial_connect_retry<F, Fut, T>(f: F) -> Result<T, ProviderError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, ProviderError>>,
+{
+    let mut backoff = INITIAL_CONNECT_BACKOFF;
+    for attempt in 0..=MAX_INITIAL_CONNECT_RETRIES {
+        match f().await {
+            Ok(val) => return Ok(val),
+            Err(e) if is_initial_connect_error(&e) && attempt < MAX_INITIAL_CONNECT_RETRIES => {
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    max_retries = MAX_INITIAL_CONNECT_RETRIES,
+                    error = %e,
+                    "retrying initial provider request after connect failure"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_INITIAL_CONNECT_BACKOFF);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!()
+}
+
+fn is_initial_connect_error(error: &ProviderError) -> bool {
+    match error {
+        ProviderError::Http(err) => err.is_connect(),
+        ProviderError::Connection(_) => true,
+        _ => false,
+    }
+}
 
 /// Send an HTTP request and check status, returning the response on success.
 /// Used by provider-specific retry loops to avoid duplicating request logic.
@@ -159,6 +197,51 @@ mod tests {
 
         // Non-retryable errors should fail immediately without retrying
         assert!(result.is_err());
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_initial_connect_retry_succeeds_after_connection_failures() {
+        tokio::time::pause();
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let result = with_initial_connect_retry(|| {
+            let counter = Arc::clone(&counter);
+            async move {
+                let attempt = counter.fetch_add(1, Ordering::SeqCst);
+                if attempt < 2 {
+                    Err(ProviderError::Connection("connection refused".into()))
+                } else {
+                    Ok(attempt)
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), 2);
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_initial_connect_retry_does_not_retry_rate_limit() {
+        let counter = Arc::new(AtomicU32::new(0));
+        let result = with_initial_connect_retry(|| {
+            let counter = Arc::clone(&counter);
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>(ProviderError::RateLimited {
+                    retry_after_ms: 5000,
+                })
+            }
+        })
+        .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            ProviderError::RateLimited {
+                retry_after_ms: 5000
+            }
+        ));
         assert_eq!(counter.load(Ordering::SeqCst), 1);
     }
 

--- a/crates/aion-providers/tests/provider_openai_test.rs
+++ b/crates/aion-providers/tests/provider_openai_test.rs
@@ -1,9 +1,13 @@
+use std::time::Duration;
+
 use aion_config::compat::ProviderCompat;
 use aion_providers::LlmProvider;
 use aion_providers::openai::OpenAIProvider;
 use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason};
 use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -49,6 +53,30 @@ fn build_sse_body(data_lines: &[&str]) -> String {
     }
     body.push_str("data: [DONE]\n\n");
     body
+}
+
+async fn start_server_after_initial_connect_refusal(sse_body: String) -> String {
+    let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = probe.local_addr().unwrap();
+    drop(probe);
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let (mut second, _) = listener.accept().await.unwrap();
+        let mut buf = [0_u8; 4096];
+        let _ = second.read(&mut buf).await.unwrap();
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            sse_body.len(),
+            sse_body
+        );
+        second.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    format!("http://{addr}")
 }
 
 // ---------------------------------------------------------------------------
@@ -135,6 +163,58 @@ async fn test_openai_stream_text_response() {
             assert_eq!(usage.input_tokens, 25);
             assert_eq!(usage.output_tokens, 10);
         }
+        e => panic!("expected Done, got: {:?}", e),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// test_openai_initial_connect_error_is_retried
+// ---------------------------------------------------------------------------
+
+/// Verify that the provider retries when the initial HTTP request fails before
+/// receiving any response. This covers transient connect/TLS failures where no
+/// model output has been emitted yet.
+#[tokio::test]
+async fn test_openai_initial_connect_error_is_retried() {
+    let chunk = json!({
+        "id": "chatcmpl-retry",
+        "object": "chat.completion.chunk",
+        "choices": [{
+            "index": 0,
+            "delta": { "role": "assistant", "content": "Recovered" },
+            "finish_reason": null
+        }]
+    })
+    .to_string();
+    let finish = json!({
+        "id": "chatcmpl-retry",
+        "object": "chat.completion.chunk",
+        "choices": [{
+            "index": 0,
+            "delta": {},
+            "finish_reason": "stop"
+        }]
+    })
+    .to_string();
+    let sse_body = build_sse_body(&[&chunk, &finish]);
+    let base_url = start_server_after_initial_connect_refusal(sse_body).await;
+
+    let provider = OpenAIProvider::new("test-key", &base_url, ProviderCompat::openai_defaults());
+    let rx = provider.stream(&make_request()).await.unwrap();
+    let events = collect_events(rx).await;
+
+    assert_eq!(
+        events.len(),
+        2,
+        "expected retry success events, got: {:?}",
+        events
+    );
+    match &events[0] {
+        LlmEvent::TextDelta(text) => assert_eq!(text, "Recovered"),
+        e => panic!("expected TextDelta, got: {:?}", e),
+    }
+    match &events[1] {
+        LlmEvent::Done { stop_reason, .. } => assert_eq!(*stop_reason, StopReason::EndTurn),
         e => panic!("expected Done, got: {:?}", e),
     }
 }


### PR DESCRIPTION
## Summary
- Add a narrow retry helper for transient initial provider connection failures.
- Apply it to the initial OpenAI-compatible streaming request without retrying API or rate-limit responses.
- Add regression coverage for connection-refused startup recovery.

## Test Plan
- `vx just push -u origin fix/openai-initial-connect-retry`
  - `cargo fix --allow-dirty --allow-staged`
  - `cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged -- -D warnings`
  - `cargo fmt --all`
  - `cargo nextest run --workspace --profile default` (1852 passed, 2 skipped)
  - `git push -u origin fix/openai-initial-connect-retry`