### PR TITLE
fix: inject workspace cwd into tools and hooks

### DIFF
--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -98,9 +98,15 @@ impl AgentBootstrap {
             file_cache.clone(),
         )));
         registry.register(Box::new(aion_tools::edit::EditTool::new(file_cache)));
-        registry.register(Box::new(aion_tools::bash::BashTool));
-        registry.register(Box::new(aion_tools::grep::GrepTool));
-        registry.register(Box::new(aion_tools::glob::GlobTool));
+        registry.register(Box::new(aion_tools::bash::BashTool::new(
+            cwd_path.to_path_buf(),
+        )));
+        registry.register(Box::new(aion_tools::grep::GrepTool::new(
+            cwd_path.to_path_buf(),
+        )));
+        registry.register(Box::new(aion_tools::glob::GlobTool::new(
+            cwd_path.to_path_buf(),
+        )));
 
         let builtin_names: Vec<String> = registry.tool_names();
 
@@ -166,6 +172,7 @@ impl AgentBootstrap {
         let spawner = Arc::new(crate::spawner::AgentSpawner::new(
             provider.clone(),
             self.config.clone(),
+            cwd_path.to_path_buf(),
         ));
         registry.register(Box::new(crate::spawn_tool::SpawnTool::new(spawner)));
 
@@ -191,9 +198,16 @@ impl AgentBootstrap {
                 registry,
                 self.output,
                 session,
+                cwd_path.to_path_buf(),
             )
         } else {
-            AgentEngine::new_with_provider(provider.clone(), self.config, registry, self.output)
+            AgentEngine::new_with_provider(
+                provider.clone(),
+                self.config,
+                registry,
+                self.output,
+                cwd_path.to_path_buf(),
+            )
         };
         engine.set_plan_active_flag(plan_active_flag);
 

--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -76,6 +76,8 @@ impl AgentBootstrap {
         let cwd = &self.workspace;
         let cwd_path = std::path::Path::new(cwd);
 
+        tracing::info!(target: "aion_agent", workspace = %cwd, "agent bootstrap: workspace cwd resolved");
+
         let provider = self
             .provider
             .unwrap_or_else(|| aion_providers::create_provider(&self.config));

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -65,9 +66,14 @@ pub struct AgentEngine {
 }
 
 impl AgentEngine {
-    pub fn new(config: Config, tools: ToolRegistry, output: Arc<dyn OutputSink>) -> Self {
+    pub fn new(
+        config: Config,
+        tools: ToolRegistry,
+        output: Arc<dyn OutputSink>,
+        cwd: PathBuf,
+    ) -> Self {
         let provider = create_provider(&config);
-        Self::new_with_provider(provider, config, tools, output)
+        Self::new_with_provider(provider, config, tools, output, cwd)
     }
 
     /// Create an engine with an externally-provided provider (for sub-agent sharing)
@@ -76,6 +82,7 @@ impl AgentEngine {
         config: Config,
         tools: ToolRegistry,
         output: Arc<dyn OutputSink>,
+        cwd: PathBuf,
     ) -> Self {
         let system_prompt = config.system_prompt.clone().unwrap_or_default();
         let confirmer =
@@ -105,9 +112,7 @@ impl AgentEngine {
             thinking: config.thinking,
             compat: config.compat.clone(),
             confirmer: Arc::new(Mutex::new(confirmer)),
-            // Always initialise Some so that skill-declared hooks can be merged in
-            // even when the global config has no static hooks configured.
-            hooks: Some(HookEngine::new(config.hooks.clone())),
+            hooks: Some(HookEngine::new(config.hooks.clone(), cwd.clone())),
             session_manager,
             current_session: None,
             output,
@@ -133,9 +138,10 @@ impl AgentEngine {
         tools: ToolRegistry,
         output: Arc<dyn OutputSink>,
         session: Session,
+        cwd: PathBuf,
     ) -> Self {
         let provider = create_provider(&config);
-        Self::resume_with_provider(provider, config, tools, output, session)
+        Self::resume_with_provider(provider, config, tools, output, session, cwd)
     }
 
     /// Create from a resumed session with an externally-provided provider
@@ -145,6 +151,7 @@ impl AgentEngine {
         tools: ToolRegistry,
         output: Arc<dyn OutputSink>,
         session: Session,
+        cwd: PathBuf,
     ) -> Self {
         let system_prompt = config.system_prompt.clone().unwrap_or_default();
         let confirmer =
@@ -174,7 +181,7 @@ impl AgentEngine {
             thinking: config.thinking,
             compat: config.compat.clone(),
             confirmer: Arc::new(Mutex::new(confirmer)),
-            hooks: Some(HookEngine::new(config.hooks.clone())),
+            hooks: Some(HookEngine::new(config.hooks.clone(), cwd)),
             session_manager,
             current_session: Some(session),
             output,

--- a/crates/aion-agent/src/spawner.rs
+++ b/crates/aion-agent/src/spawner.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -29,13 +30,15 @@ pub use aion_types::spawner::{ForkOverrides, Spawner, SubAgentConfig, SubAgentRe
 pub struct AgentSpawner {
     provider: Arc<dyn LlmProvider>,
     base_config: Config,
+    cwd: PathBuf,
 }
 
 impl AgentSpawner {
-    pub fn new(provider: Arc<dyn LlmProvider>, config: Config) -> Self {
+    pub fn new(provider: Arc<dyn LlmProvider>, config: Config, cwd: PathBuf) -> Self {
         Self {
             provider,
             base_config: config,
+            cwd,
         }
     }
 
@@ -50,10 +53,15 @@ impl AgentSpawner {
         config.session.enabled = false;
         config.tools.auto_approve = true;
 
-        let tools = build_tool_registry(&[]);
+        let tools = build_tool_registry(&[], &self.cwd);
         let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-        let mut engine =
-            AgentEngine::new_with_provider(self.provider.clone(), config, tools, output);
+        let mut engine = AgentEngine::new_with_provider(
+            self.provider.clone(),
+            config,
+            tools,
+            output,
+            self.cwd.clone(),
+        );
 
         match engine.run(&sub_config.prompt, "").await {
             Ok(result) => SubAgentResult {
@@ -103,6 +111,7 @@ impl AgentSpawner {
         Self {
             provider: self.provider.clone(),
             base_config: self.base_config.clone(),
+            cwd: self.cwd.clone(),
         }
     }
 }
@@ -126,10 +135,15 @@ impl Spawner for AgentSpawner {
             config.model = model;
         }
 
-        let tools = build_tool_registry(&overrides.allowed_tools);
+        let tools = build_tool_registry(&overrides.allowed_tools, &self.cwd);
         let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-        let mut engine =
-            AgentEngine::new_with_provider(self.provider.clone(), config, tools, output);
+        let mut engine = AgentEngine::new_with_provider(
+            self.provider.clone(),
+            config,
+            tools,
+            output,
+            self.cwd.clone(),
+        );
         engine.set_initial_reasoning_effort(overrides.effort.clone());
 
         match engine.run(&sub_config.prompt, "").await {
@@ -151,22 +165,20 @@ impl Spawner for AgentSpawner {
     }
 }
 
-type ToolFactory = fn() -> Box<dyn aion_tools::Tool>;
-
-fn build_tool_registry(allowed: &[String]) -> ToolRegistry {
-    let all: &[(&str, ToolFactory)] = &[
-        ("Read", || Box::new(ReadTool::new(None))),
-        ("Write", || Box::new(WriteTool::new(None))),
-        ("Edit", || Box::new(EditTool::new(None))),
-        ("Bash", || Box::new(BashTool)),
-        ("Grep", || Box::new(GrepTool)),
-        ("Glob", || Box::new(GlobTool)),
+fn build_tool_registry(allowed: &[String], cwd: &Path) -> ToolRegistry {
+    let all_tools: Vec<(&str, Box<dyn aion_tools::Tool>)> = vec![
+        ("Read", Box::new(ReadTool::new(None))),
+        ("Write", Box::new(WriteTool::new(None))),
+        ("Edit", Box::new(EditTool::new(None))),
+        ("Bash", Box::new(BashTool::new(cwd.to_path_buf()))),
+        ("Grep", Box::new(GrepTool::new(cwd.to_path_buf()))),
+        ("Glob", Box::new(GlobTool::new(cwd.to_path_buf()))),
     ];
 
     let mut registry = ToolRegistry::new();
-    for (name, make_tool) in all {
-        if allowed.is_empty() || allowed.iter().any(|a| a.as_str() == *name) {
-            registry.register(make_tool());
+    for (name, tool) in all_tools {
+        if allowed.is_empty() || allowed.iter().any(|a| a.as_str() == name) {
+            registry.register(tool);
         }
     }
     registry
@@ -186,7 +198,7 @@ mod phase7_tests {
 
     #[test]
     fn tc_7_40_build_tool_registry_empty_allowed_registers_all() {
-        let registry = build_tool_registry(&[]);
+        let registry = build_tool_registry(&[], &std::env::temp_dir());
         for name in &["Read", "Write", "Edit", "Bash", "Grep", "Glob"] {
             assert!(
                 registry.get(name).is_some(),
@@ -198,7 +210,7 @@ mod phase7_tests {
     #[test]
     fn tc_7_43_build_tool_registry_filters_to_allowed() {
         let allowed = vec!["Bash".to_string(), "Read".to_string()];
-        let registry = build_tool_registry(&allowed);
+        let registry = build_tool_registry(&allowed, &std::env::temp_dir());
         assert!(registry.get("Bash").is_some());
         assert!(registry.get("Read").is_some());
         assert!(registry.get("Write").is_none());

--- a/crates/aion-agent/src/spawner.rs
+++ b/crates/aion-agent/src/spawner.rs
@@ -53,6 +53,8 @@ impl AgentSpawner {
         config.session.enabled = false;
         config.tools.auto_approve = true;
 
+        tracing::info!(target: "aion_agent", cwd = %self.cwd.display(), "sub-agent spawned with workspace cwd");
+
         let tools = build_tool_registry(&[], &self.cwd);
         let output: Arc<dyn OutputSink> = Arc::new(NullSink);
         let mut engine = AgentEngine::new_with_provider(

--- a/crates/aion-agent/tests/cwd_injection_test.rs
+++ b/crates/aion-agent/tests/cwd_injection_test.rs
@@ -1,0 +1,86 @@
+//! Integration tests verifying that tools use the injected workspace cwd
+//! rather than the process working directory.
+
+use std::fs;
+
+use aion_tools::Tool;
+use aion_tools::bash::BashTool;
+use aion_tools::glob::GlobTool;
+use aion_tools::grep::GrepTool;
+use serde_json::json;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn bash_tool_executes_in_injected_cwd_not_process_cwd() {
+    let workspace = tempdir().unwrap();
+    let tool = BashTool::new(workspace.path().to_path_buf());
+
+    let cmd = if cfg!(windows) { "cd" } else { "pwd" };
+    let result = tool.execute(json!({"command": cmd})).await;
+
+    assert!(!result.is_error, "unexpected error: {}", result.content);
+    let expected = workspace
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.path().to_path_buf());
+    assert!(
+        result.content.contains(expected.to_string_lossy().as_ref()),
+        "BashTool should run in injected cwd '{}', got: {}",
+        expected.display(),
+        result.content
+    );
+}
+
+#[tokio::test]
+async fn glob_tool_finds_files_relative_to_injected_cwd() {
+    let workspace = tempdir().unwrap();
+    fs::write(workspace.path().join("cwd_marker.txt"), "hello").unwrap();
+
+    let tool = GlobTool::new(workspace.path().to_path_buf());
+    let result = tool.execute(json!({"pattern": "cwd_marker.txt"})).await;
+
+    assert!(!result.is_error, "unexpected error: {}", result.content);
+    assert!(
+        result.content.contains("cwd_marker.txt"),
+        "GlobTool should find file relative to injected cwd, got: {}",
+        result.content
+    );
+}
+
+#[tokio::test]
+async fn grep_tool_searches_relative_to_injected_cwd() {
+    let workspace = tempdir().unwrap();
+    fs::write(
+        workspace.path().join("searchable.txt"),
+        "unique_cwd_injection_marker_99",
+    )
+    .unwrap();
+
+    let tool = GrepTool::new(workspace.path().to_path_buf());
+    let result = tool
+        .execute(json!({"pattern": "unique_cwd_injection_marker_99", "path": "."}))
+        .await;
+
+    assert!(!result.is_error, "unexpected error: {}", result.content);
+    assert!(
+        result.content.contains("unique_cwd_injection_marker_99"),
+        "GrepTool should search in injected cwd, got: {}",
+        result.content
+    );
+}
+
+#[tokio::test]
+async fn bash_tool_with_file_operations_uses_correct_cwd() {
+    let workspace = tempdir().unwrap();
+    fs::write(workspace.path().join("canary.txt"), "found_it").unwrap();
+
+    let tool = BashTool::new(workspace.path().to_path_buf());
+    let result = tool.execute(json!({"command": "cat canary.txt"})).await;
+
+    assert!(!result.is_error, "unexpected error: {}", result.content);
+    assert!(
+        result.content.contains("found_it"),
+        "BashTool should be able to read files in injected cwd, got: {}",
+        result.content
+    );
+}

--- a/crates/aion-agent/tests/cwd_injection_test.rs
+++ b/crates/aion-agent/tests/cwd_injection_test.rs
@@ -10,13 +10,15 @@ use aion_tools::grep::GrepTool;
 use serde_json::json;
 use tempfile::tempdir;
 
+// Windows `cd` outputs 8.3 short names (RUNNER~1) that don't match canonicalized paths;
+// bash_tool_with_file_operations_uses_correct_cwd covers the same behavior reliably.
+#[cfg(not(windows))]
 #[tokio::test]
 async fn bash_tool_executes_in_injected_cwd_not_process_cwd() {
     let workspace = tempdir().unwrap();
     let tool = BashTool::new(workspace.path().to_path_buf());
 
-    let cmd = if cfg!(windows) { "cd" } else { "pwd" };
-    let result = tool.execute(json!({"command": cmd})).await;
+    let result = tool.execute(json!({"command": "pwd"})).await;
 
     assert!(!result.is_error, "unexpected error: {}", result.content);
     let expected = workspace

--- a/crates/aion-agent/tests/e2e/anthropic.rs
+++ b/crates/aion-agent/tests/e2e/anthropic.rs
@@ -65,7 +65,7 @@ async fn test_anthropic_single_turn_completion() {
     let output: Arc<dyn OutputSink> = Arc::new(TerminalSink::new(true));
     let registry = ToolRegistry::new();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Say 'hello world' and nothing else.", "")
         .await
@@ -100,7 +100,7 @@ async fn test_anthropic_tool_use() {
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(ReadTool::new(None)));
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let prompt = format!(
         "Read the file at path '{}' and tell me what it contains. Be brief.",
         path

--- a/crates/aion-agent/tests/e2e/anthropic.rs
+++ b/crates/aion-agent/tests/e2e/anthropic.rs
@@ -65,7 +65,8 @@ async fn test_anthropic_single_turn_completion() {
     let output: Arc<dyn OutputSink> = Arc::new(TerminalSink::new(true));
     let registry = ToolRegistry::new();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Say 'hello world' and nothing else.", "")
         .await
@@ -100,7 +101,8 @@ async fn test_anthropic_tool_use() {
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(ReadTool::new(None)));
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let prompt = format!(
         "Read the file at path '{}' and tell me what it contains. Be brief.",
         path

--- a/crates/aion-agent/tests/e2e/compaction.rs
+++ b/crates/aion-agent/tests/e2e/compaction.rs
@@ -188,7 +188,7 @@ async fn case_9_off_vs_safe_content() {
     let mut registry2 = ToolRegistry::new();
     registry2.register(Box::new(FixedOutputTool::new("check_tool", TEST_OUTPUT)));
     let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry2, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry2, output, std::env::temp_dir());
 
     let prompt = "Call check_tool, then answer: does the tool output contain ANSI color escape codes (sequences starting with \\x1b)? Answer only 'yes' or 'no'.";
     let result = engine
@@ -251,7 +251,7 @@ async fn case_10_off_vs_full_token_savings() {
     registry_off.register(Box::new(FixedOutputTool::new("big_tool", &large_output)));
     let output_off: Arc<dyn OutputSink> = Arc::new(NullSink);
     let mut engine_off =
-        AgentEngine::new_with_provider(provider_off, config_off, registry_off, output_off);
+        AgentEngine::new_with_provider(provider_off, config_off, registry_off, output_off, std::env::temp_dir());
 
     let prompt = "Call big_tool, then say 'done'.";
     let result_off = engine_off
@@ -267,7 +267,7 @@ async fn case_10_off_vs_full_token_savings() {
     registry_full.register(Box::new(FixedOutputTool::new("big_tool", &large_output)));
     let output_full: Arc<dyn OutputSink> = Arc::new(NullSink);
     let mut engine_full =
-        AgentEngine::new_with_provider(provider_full, config_full, registry_full, output_full);
+        AgentEngine::new_with_provider(provider_full, config_full, registry_full, output_full, std::env::temp_dir());
 
     let result_full = engine_full
         .run(prompt, "")
@@ -357,7 +357,7 @@ async fn case_11_toon_comprehension_and_system_prompt() {
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(FixedOutputTool::new("data_tool", TOON_INPUT)));
     let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
 
     let prompt = "Call data_tool, then answer: what is the name of the second record? Answer with just the name, nothing else.";
     let result = engine

--- a/crates/aion-agent/tests/e2e/compaction.rs
+++ b/crates/aion-agent/tests/e2e/compaction.rs
@@ -188,7 +188,8 @@ async fn case_9_off_vs_safe_content() {
     let mut registry2 = ToolRegistry::new();
     registry2.register(Box::new(FixedOutputTool::new("check_tool", TEST_OUTPUT)));
     let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry2, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry2, output, std::env::temp_dir());
 
     let prompt = "Call check_tool, then answer: does the tool output contain ANSI color escape codes (sequences starting with \\x1b)? Answer only 'yes' or 'no'.";
     let result = engine
@@ -250,8 +251,13 @@ async fn case_10_off_vs_full_token_savings() {
     let mut registry_off = ToolRegistry::new();
     registry_off.register(Box::new(FixedOutputTool::new("big_tool", &large_output)));
     let output_off: Arc<dyn OutputSink> = Arc::new(NullSink);
-    let mut engine_off =
-        AgentEngine::new_with_provider(provider_off, config_off, registry_off, output_off, std::env::temp_dir());
+    let mut engine_off = AgentEngine::new_with_provider(
+        provider_off,
+        config_off,
+        registry_off,
+        output_off,
+        std::env::temp_dir(),
+    );
 
     let prompt = "Call big_tool, then say 'done'.";
     let result_off = engine_off
@@ -266,8 +272,13 @@ async fn case_10_off_vs_full_token_savings() {
     let mut registry_full = ToolRegistry::new();
     registry_full.register(Box::new(FixedOutputTool::new("big_tool", &large_output)));
     let output_full: Arc<dyn OutputSink> = Arc::new(NullSink);
-    let mut engine_full =
-        AgentEngine::new_with_provider(provider_full, config_full, registry_full, output_full, std::env::temp_dir());
+    let mut engine_full = AgentEngine::new_with_provider(
+        provider_full,
+        config_full,
+        registry_full,
+        output_full,
+        std::env::temp_dir(),
+    );
 
     let result_full = engine_full
         .run(prompt, "")
@@ -357,7 +368,8 @@ async fn case_11_toon_comprehension_and_system_prompt() {
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(FixedOutputTool::new("data_tool", TOON_INPUT)));
     let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
 
     let prompt = "Call data_tool, then answer: what is the name of the second record? Answer with just the name, nothing else.";
     let result = engine

--- a/crates/aion-agent/tests/e2e/openai.rs
+++ b/crates/aion-agent/tests/e2e/openai.rs
@@ -64,7 +64,7 @@ async fn test_openai_single_turn_completion() {
     let output: Arc<dyn OutputSink> = Arc::new(TerminalSink::new(true));
     let registry = ToolRegistry::new();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Say 'hello world' and nothing else.", "")
         .await
@@ -97,7 +97,7 @@ async fn test_openai_tool_use() {
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(ReadTool::new(None)));
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let prompt = format!(
         "Read the file at '{}' and tell me what it contains. Be brief.",
         path

--- a/crates/aion-agent/tests/e2e/openai.rs
+++ b/crates/aion-agent/tests/e2e/openai.rs
@@ -64,7 +64,8 @@ async fn test_openai_single_turn_completion() {
     let output: Arc<dyn OutputSink> = Arc::new(TerminalSink::new(true));
     let registry = ToolRegistry::new();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Say 'hello world' and nothing else.", "")
         .await
@@ -97,7 +98,8 @@ async fn test_openai_tool_use() {
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(ReadTool::new(None)));
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let prompt = format!(
         "Read the file at '{}' and tell me what it contains. Be brief.",
         path

--- a/crates/aion-agent/tests/engine_compact_test.rs
+++ b/crates/aion-agent/tests/engine_compact_test.rs
@@ -117,7 +117,13 @@ async fn tc_2_6_01_first_turn_no_compaction() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output, std::env::temp_dir());
+    let mut engine = AgentEngine::new_with_provider(
+        provider.clone(),
+        config,
+        registry,
+        output,
+        std::env::temp_dir(),
+    );
     let result = engine.run("Hi", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "Hello");
@@ -169,7 +175,13 @@ async fn tc_2_6_03_emergency_returns_error() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output, std::env::temp_dir());
+    let mut engine = AgentEngine::new_with_provider(
+        provider.clone(),
+        config,
+        registry,
+        output,
+        std::env::temp_dir(),
+    );
     let err = engine.run("Do something", "msg-1").await.unwrap_err();
 
     match err {
@@ -230,7 +242,13 @@ async fn tc_2_6_04_autocompact_then_continue() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output, std::env::temp_dir());
+    let mut engine = AgentEngine::new_with_provider(
+        provider.clone(),
+        config,
+        registry,
+        output,
+        std::env::temp_dir(),
+    );
     let result = engine
         .run("Start work", "msg-1")
         .await
@@ -286,7 +304,8 @@ async fn tc_2_6_05_session_save_after_compact() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine
         .init_session("test", "/tmp", None)
         .expect("init session");
@@ -336,7 +355,13 @@ async fn tc_2_6_06_disabled_skips_micro_auto() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output, std::env::temp_dir());
+    let mut engine = AgentEngine::new_with_provider(
+        provider.clone(),
+        config,
+        registry,
+        output,
+        std::env::temp_dir(),
+    );
     let result = engine.run("Hi", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "Normal response");
@@ -381,7 +406,8 @@ async fn tc_2_6_06b_disabled_still_fires_emergency() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let err = engine.run("Go", "msg-1").await.unwrap_err();
 
     assert!(
@@ -425,7 +451,8 @@ async fn tc_2_6_07_input_tokens_tracked() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Work", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.turns, 2);
@@ -564,7 +591,8 @@ async fn tc_2_6_02_micro_before_auto_execution_order() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Start", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "Done after compact");
@@ -719,7 +747,8 @@ async fn tc_2_6_e2e_02_micro_and_auto_cooperative() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Work", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "After cooperative compact");
@@ -841,7 +870,8 @@ async fn tc_2_6_e2e_03_circuit_breaker_stops_retries() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Work", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "Final");

--- a/crates/aion-agent/tests/engine_compact_test.rs
+++ b/crates/aion-agent/tests/engine_compact_test.rs
@@ -117,7 +117,7 @@ async fn tc_2_6_01_first_turn_no_compaction() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output, std::env::temp_dir());
     let result = engine.run("Hi", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "Hello");
@@ -169,7 +169,7 @@ async fn tc_2_6_03_emergency_returns_error() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output, std::env::temp_dir());
     let err = engine.run("Do something", "msg-1").await.unwrap_err();
 
     match err {
@@ -230,7 +230,7 @@ async fn tc_2_6_04_autocompact_then_continue() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Start work", "msg-1")
         .await
@@ -286,7 +286,7 @@ async fn tc_2_6_05_session_save_after_compact() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine
         .init_session("test", "/tmp", None)
         .expect("init session");
@@ -336,7 +336,7 @@ async fn tc_2_6_06_disabled_skips_micro_auto() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider.clone(), config, registry, output, std::env::temp_dir());
     let result = engine.run("Hi", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "Normal response");
@@ -381,7 +381,7 @@ async fn tc_2_6_06b_disabled_still_fires_emergency() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let err = engine.run("Go", "msg-1").await.unwrap_err();
 
     assert!(
@@ -425,7 +425,7 @@ async fn tc_2_6_07_input_tokens_tracked() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Work", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.turns, 2);
@@ -564,7 +564,7 @@ async fn tc_2_6_02_micro_before_auto_execution_order() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Start", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "Done after compact");
@@ -719,7 +719,7 @@ async fn tc_2_6_e2e_02_micro_and_auto_cooperative() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Work", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "After cooperative compact");
@@ -841,7 +841,7 @@ async fn tc_2_6_e2e_03_circuit_breaker_stops_retries() {
     )));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Work", "msg-1").await.expect("should succeed");
 
     assert_eq!(result.text, "Final");

--- a/crates/aion-agent/tests/engine_test.rs
+++ b/crates/aion-agent/tests/engine_test.rs
@@ -36,7 +36,8 @@ async fn test_engine_text_response_ends_turn() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Hi", "").await.expect("engine should succeed");
 
     assert_eq!(result.text, "Hello, world!");
@@ -91,7 +92,8 @@ async fn test_engine_tool_use_executes_and_continues() {
     registry.register(Box::new(MockTool::new("mock_tool", "tool output", false)));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Use the tool", "")
         .await
@@ -127,7 +129,8 @@ async fn test_engine_max_tokens_handling() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Give me a long answer", "")
         .await
@@ -186,7 +189,13 @@ async fn test_engine_message_accumulation() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config.clone(), registry, output, std::env::temp_dir());
+    let mut engine = AgentEngine::new_with_provider(
+        provider,
+        config.clone(),
+        registry,
+        output,
+        std::env::temp_dir(),
+    );
 
     // Initialize session so save_session() has a session to persist
     engine
@@ -263,7 +272,8 @@ async fn test_engine_token_usage_tracking() {
     registry.register(Box::new(MockTool::new("mock_tool", "result", false)));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Do work", "")
         .await
@@ -322,7 +332,8 @@ async fn test_engine_max_turns_returns_ok() {
     registry.register(Box::new(MockTool::new("mock_tool", "result", false)));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Keep calling tools", "")
         .await
@@ -347,7 +358,8 @@ async fn test_engine_api_error_handling() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let err = engine
         .run("Hello", "")
         .await

--- a/crates/aion-agent/tests/engine_test.rs
+++ b/crates/aion-agent/tests/engine_test.rs
@@ -36,7 +36,7 @@ async fn test_engine_text_response_ends_turn() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine.run("Hi", "").await.expect("engine should succeed");
 
     assert_eq!(result.text, "Hello, world!");
@@ -91,7 +91,7 @@ async fn test_engine_tool_use_executes_and_continues() {
     registry.register(Box::new(MockTool::new("mock_tool", "tool output", false)));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Use the tool", "")
         .await
@@ -127,7 +127,7 @@ async fn test_engine_max_tokens_handling() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Give me a long answer", "")
         .await
@@ -186,7 +186,7 @@ async fn test_engine_message_accumulation() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config.clone(), registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config.clone(), registry, output, std::env::temp_dir());
 
     // Initialize session so save_session() has a session to persist
     engine
@@ -263,7 +263,7 @@ async fn test_engine_token_usage_tracking() {
     registry.register(Box::new(MockTool::new("mock_tool", "result", false)));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Do work", "")
         .await
@@ -322,7 +322,7 @@ async fn test_engine_max_turns_returns_ok() {
     registry.register(Box::new(MockTool::new("mock_tool", "result", false)));
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let result = engine
         .run("Keep calling tools", "")
         .await
@@ -347,7 +347,7 @@ async fn test_engine_api_error_handling() {
     let registry = ToolRegistry::new();
     let output = silent_output();
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     let err = engine
         .run("Hello", "")
         .await

--- a/crates/aion-agent/tests/json_stream_approval_test.rs
+++ b/crates/aion-agent/tests/json_stream_approval_test.rs
@@ -67,7 +67,7 @@ async fn test_tool_approval_approve_flow() {
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 
@@ -136,7 +136,7 @@ async fn test_tool_approval_deny_flow() {
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 
@@ -198,7 +198,7 @@ async fn test_auto_approve_bypasses_approval() {
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 
@@ -251,7 +251,7 @@ async fn test_session_auto_approve_category() {
     approval_manager.add_auto_approve("exec");
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 
@@ -296,7 +296,7 @@ async fn test_client_disconnect_aborts() {
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 

--- a/crates/aion-agent/tests/json_stream_approval_test.rs
+++ b/crates/aion-agent/tests/json_stream_approval_test.rs
@@ -67,7 +67,8 @@ async fn test_tool_approval_approve_flow() {
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 
@@ -136,7 +137,8 @@ async fn test_tool_approval_deny_flow() {
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 
@@ -198,7 +200,8 @@ async fn test_auto_approve_bypasses_approval() {
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 
@@ -251,7 +254,8 @@ async fn test_session_auto_approve_category() {
     approval_manager.add_auto_approve("exec");
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 
@@ -296,7 +300,8 @@ async fn test_client_disconnect_aborts() {
     let approval_manager = Arc::new(ToolApprovalManager::new());
     let writer = Arc::new(ProtocolWriter::new());
 
-    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let mut engine =
+        AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
     engine.set_approval_manager(approval_manager.clone());
     engine.set_protocol_writer(writer);
 

--- a/crates/aion-agent/tests/orchestration_test.rs
+++ b/crates/aion-agent/tests/orchestration_test.rs
@@ -240,7 +240,7 @@ async fn test_pre_hook_blocks_tool() {
         post_tool_use: vec![],
         stop: vec![],
     };
-    let mut hook_engine = HookEngine::new(hook_config);
+    let mut hook_engine = HookEngine::new(hook_config, std::env::temp_dir());
 
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(MockTool::new("echo", "should not appear", false)));
@@ -286,7 +286,7 @@ async fn test_post_hook_runs_after_tool() {
         post_tool_use: vec![make_post_hook("post-logger", "echo", "echo done")],
         stop: vec![],
     };
-    let mut hook_engine = HookEngine::new(hook_config);
+    let mut hook_engine = HookEngine::new(hook_config, std::env::temp_dir());
 
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(MockTool::new("echo", "result", false)));

--- a/crates/aion-agent/tests/output_compaction_test.rs
+++ b/crates/aion-agent/tests/output_compaction_test.rs
@@ -307,7 +307,7 @@ async fn case_6_compressed_content_reaches_llm() {
     registry.register(Box::new(MockTool::new("test_tool", TEST_OUTPUT, false)));
 
     let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-    let mut engine = AgentEngine::new_with_provider(Arc::new(provider), config, registry, output);
+    let mut engine = AgentEngine::new_with_provider(Arc::new(provider), config, registry, output, std::env::temp_dir());
 
     engine
         .run("call test_tool", "")
@@ -410,6 +410,7 @@ async fn case_7_runtime_compaction_switch() {
         config,
         registry_engine,
         output,
+        std::env::temp_dir(),
     );
     assert_eq!(engine.compaction_level(), CompactionLevel::Off);
 

--- a/crates/aion-agent/tests/output_compaction_test.rs
+++ b/crates/aion-agent/tests/output_compaction_test.rs
@@ -307,7 +307,13 @@ async fn case_6_compressed_content_reaches_llm() {
     registry.register(Box::new(MockTool::new("test_tool", TEST_OUTPUT, false)));
 
     let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-    let mut engine = AgentEngine::new_with_provider(Arc::new(provider), config, registry, output, std::env::temp_dir());
+    let mut engine = AgentEngine::new_with_provider(
+        Arc::new(provider),
+        config,
+        registry,
+        output,
+        std::env::temp_dir(),
+    );
 
     engine
         .run("call test_tool", "")

--- a/crates/aion-agent/tests/spawn_description_test.rs
+++ b/crates/aion-agent/tests/spawn_description_test.rs
@@ -14,7 +14,11 @@ use common::{MockLlmProvider, test_config};
 
 fn make_spawn_tool() -> SpawnTool {
     let provider = Arc::new(MockLlmProvider::with_text_response("ok"));
-    let spawner = Arc::new(AgentSpawner::new(provider, test_config(), std::env::temp_dir()));
+    let spawner = Arc::new(AgentSpawner::new(
+        provider,
+        test_config(),
+        std::env::temp_dir(),
+    ));
     SpawnTool::new(spawner)
 }
 

--- a/crates/aion-agent/tests/spawn_description_test.rs
+++ b/crates/aion-agent/tests/spawn_description_test.rs
@@ -14,7 +14,7 @@ use common::{MockLlmProvider, test_config};
 
 fn make_spawn_tool() -> SpawnTool {
     let provider = Arc::new(MockLlmProvider::with_text_response("ok"));
-    let spawner = Arc::new(AgentSpawner::new(provider, test_config()));
+    let spawner = Arc::new(AgentSpawner::new(provider, test_config(), std::env::temp_dir()));
     SpawnTool::new(spawner)
 }
 

--- a/crates/aion-agent/tests/spawn_test.rs
+++ b/crates/aion-agent/tests/spawn_test.rs
@@ -125,7 +125,11 @@ async fn test_spawn_shares_provider() {
 
     // Both sub-agents share the same underlying provider via Arc.
     let provider_dyn: Arc<dyn aion_providers::LlmProvider> = provider;
-    let spawner = AgentSpawner::new(Arc::clone(&provider_dyn), test_config(), std::env::temp_dir());
+    let spawner = AgentSpawner::new(
+        Arc::clone(&provider_dyn),
+        test_config(),
+        std::env::temp_dir(),
+    );
 
     let result1 = spawner.spawn_one(make_sub_config("seq-1")).await;
     let result2 = spawner.spawn_one(make_sub_config("seq-2")).await;

--- a/crates/aion-agent/tests/spawn_test.rs
+++ b/crates/aion-agent/tests/spawn_test.rs
@@ -29,7 +29,7 @@ fn make_sub_config(name: &str) -> SubAgentConfig {
 #[tokio::test]
 async fn test_spawn_single_agent() {
     let provider = Arc::new(MockLlmProvider::with_text_response("Sub-agent done"));
-    let spawner = AgentSpawner::new(provider, test_config());
+    let spawner = AgentSpawner::new(provider, test_config(), std::env::temp_dir());
 
     let result = spawner.spawn_one(make_sub_config("agent-1")).await;
 
@@ -64,7 +64,7 @@ async fn test_spawn_parallel_agents() {
         make_turn("result-C"),
     ]));
 
-    let spawner = AgentSpawner::new(provider, test_config());
+    let spawner = AgentSpawner::new(provider, test_config(), std::env::temp_dir());
 
     let sub_configs = vec![
         make_sub_config("agent-A"),
@@ -125,7 +125,7 @@ async fn test_spawn_shares_provider() {
 
     // Both sub-agents share the same underlying provider via Arc.
     let provider_dyn: Arc<dyn aion_providers::LlmProvider> = provider;
-    let spawner = AgentSpawner::new(Arc::clone(&provider_dyn), test_config());
+    let spawner = AgentSpawner::new(Arc::clone(&provider_dyn), test_config(), std::env::temp_dir());
 
     let result1 = spawner.spawn_one(make_sub_config("seq-1")).await;
     let result2 = spawner.spawn_one(make_sub_config("seq-2")).await;
@@ -145,7 +145,7 @@ async fn test_spawn_agent_error_captured() {
         "provider failed".to_string(),
     )]));
 
-    let spawner = AgentSpawner::new(provider, test_config());
+    let spawner = AgentSpawner::new(provider, test_config(), std::env::temp_dir());
 
     let result = spawner.spawn_one(make_sub_config("error-agent")).await;
 

--- a/crates/aion-config/src/hooks.rs
+++ b/crates/aion-config/src/hooks.rs
@@ -112,7 +112,8 @@ impl HookEngine {
     pub async fn run_stop(&self) -> Vec<String> {
         let mut messages = Vec::new();
         for hook in &self.config.stop {
-            match run_hook_command(&hook.command, &HashMap::new(), hook.timeout_ms, &self.cwd).await {
+            match run_hook_command(&hook.command, &HashMap::new(), hook.timeout_ms, &self.cwd).await
+            {
                 Ok(result) => {
                     if !result.output.is_empty() {
                         messages.push(format!("[hook:{}] {}", hook.name, result.output.trim()));
@@ -459,7 +460,8 @@ mod phase11_tests {
     // TC-11.33: merging empty config doesn't change existing hooks
     #[test]
     fn tc_11_33_merge_empty_does_not_change_existing() {
-        let mut engine = HookEngine::new(make_config_pre(&["pre-a", "pre-b"]), std::env::temp_dir());
+        let mut engine =
+            HookEngine::new(make_config_pre(&["pre-a", "pre-b"]), std::env::temp_dir());
         engine.merge_hooks(HooksConfig::default());
         assert_eq!(engine.config.pre_tool_use.len(), 2);
     }

--- a/crates/aion-config/src/hooks.rs
+++ b/crates/aion-config/src/hooks.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -40,11 +41,12 @@ fn default_hook_timeout() -> u64 {
 /// Event-driven hook engine
 pub struct HookEngine {
     config: HooksConfig,
+    cwd: PathBuf,
 }
 
 impl HookEngine {
-    pub fn new(config: HooksConfig) -> Self {
-        Self { config }
+    pub fn new(config: HooksConfig, cwd: PathBuf) -> Self {
+        Self { config, cwd }
     }
 
     /// Run pre-tool-use hooks. Returns Err if any hook blocks execution.
@@ -62,7 +64,7 @@ impl HookEngine {
 
         for hook in matching {
             let env = build_env_vars(tool_name, tool_input);
-            let result = run_hook_command(&hook.command, &env, hook.timeout_ms).await?;
+            let result = run_hook_command(&hook.command, &env, hook.timeout_ms, &self.cwd).await?;
             if !result.success {
                 return Err(HookError::Blocked {
                     hook_name: hook.name.clone(),
@@ -92,7 +94,7 @@ impl HookEngine {
             let mut env = build_env_vars(tool_name, tool_input);
             env.insert("TOOL_OUTPUT".to_string(), tool_output.to_string());
 
-            match run_hook_command(&hook.command, &env, hook.timeout_ms).await {
+            match run_hook_command(&hook.command, &env, hook.timeout_ms, &self.cwd).await {
                 Ok(result) => {
                     if !result.output.is_empty() {
                         messages.push(format!("[hook:{}] {}", hook.name, result.output.trim()));
@@ -110,7 +112,7 @@ impl HookEngine {
     pub async fn run_stop(&self) -> Vec<String> {
         let mut messages = Vec::new();
         for hook in &self.config.stop {
-            match run_hook_command(&hook.command, &HashMap::new(), hook.timeout_ms).await {
+            match run_hook_command(&hook.command, &HashMap::new(), hook.timeout_ms, &self.cwd).await {
                 Ok(result) => {
                     if !result.output.is_empty() {
                         messages.push(format!("[hook:{}] {}", hook.name, result.output.trim()));
@@ -223,6 +225,7 @@ async fn run_hook_command(
     command: &str,
     env_vars: &HashMap<String, String>,
     timeout_ms: u64,
+    cwd: &Path,
 ) -> Result<HookResult, HookError> {
     let interpolated = interpolate_command(command, env_vars);
     let timeout = Duration::from_millis(timeout_ms);
@@ -230,6 +233,7 @@ async fn run_hook_command(
     let result = tokio::time::timeout(timeout, async {
         shell_command_builder(&interpolated)
             .envs(env_vars)
+            .current_dir(cwd)
             .output()
             .await
     })
@@ -307,7 +311,7 @@ mod tests {
 
     #[test]
     fn test_has_hooks_empty() {
-        let engine = HookEngine::new(HooksConfig::default());
+        let engine = HookEngine::new(HooksConfig::default(), std::env::temp_dir());
         assert!(!engine.has_hooks());
     }
 
@@ -318,7 +322,7 @@ mod tests {
             post_tool_use: vec![],
             stop: vec![],
         };
-        let engine = HookEngine::new(config);
+        let engine = HookEngine::new(config, std::env::temp_dir());
         assert!(engine.has_hooks());
     }
 
@@ -331,7 +335,7 @@ mod tests {
             post_tool_use: vec![],
             stop: vec![],
         };
-        let engine = HookEngine::new(config);
+        let engine = HookEngine::new(config, std::env::temp_dir());
         let result = engine.run_pre_tool_use("Read", &json!({})).await;
         assert!(result.is_ok());
     }
@@ -343,7 +347,7 @@ mod tests {
             post_tool_use: vec![],
             stop: vec![],
         };
-        let engine = HookEngine::new(config);
+        let engine = HookEngine::new(config, std::env::temp_dir());
         let result = engine.run_pre_tool_use("Read", &json!({})).await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), HookError::Blocked { .. }));
@@ -356,7 +360,7 @@ mod tests {
             post_tool_use: vec![make_hook("post", vec!["Read"], "echo done")],
             stop: vec![],
         };
-        let engine = HookEngine::new(config);
+        let engine = HookEngine::new(config, std::env::temp_dir());
         let messages = engine.run_post_tool_use("Read", &json!({}), "output").await;
         assert!(!messages.is_empty());
         assert!(messages[0].contains("done"));
@@ -375,7 +379,7 @@ mod tests {
             post_tool_use: vec![],
             stop: vec![],
         };
-        let engine = HookEngine::new(config);
+        let engine = HookEngine::new(config, std::env::temp_dir());
         let result = engine.run_pre_tool_use("Read", &json!({})).await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), HookError::Timeout(_)));
@@ -411,7 +415,7 @@ mod phase11_tests {
     // TC-11.30: pre_tool_use count accumulates correctly
     #[test]
     fn tc_11_30_pre_tool_use_count_accumulates() {
-        let mut engine = HookEngine::new(make_config_pre(&["pre-a"]));
+        let mut engine = HookEngine::new(make_config_pre(&["pre-a"]), std::env::temp_dir());
         let additional = HooksConfig {
             pre_tool_use: vec![make_hook("pre-b"), make_hook("pre-c")],
             post_tool_use: vec![],
@@ -424,7 +428,7 @@ mod phase11_tests {
     // TC-11.31: post_tool_use count accumulates correctly
     #[test]
     fn tc_11_31_post_tool_use_count_accumulates() {
-        let mut engine = HookEngine::new(HooksConfig::default());
+        let mut engine = HookEngine::new(HooksConfig::default(), std::env::temp_dir());
         let additional = HooksConfig {
             pre_tool_use: vec![],
             post_tool_use: vec![make_hook("post-a")],
@@ -442,7 +446,7 @@ mod phase11_tests {
             post_tool_use: vec![],
             stop: vec![make_hook("stop-a")],
         };
-        let mut engine = HookEngine::new(initial);
+        let mut engine = HookEngine::new(initial, std::env::temp_dir());
         let additional = HooksConfig {
             pre_tool_use: vec![],
             post_tool_use: vec![],
@@ -455,7 +459,7 @@ mod phase11_tests {
     // TC-11.33: merging empty config doesn't change existing hooks
     #[test]
     fn tc_11_33_merge_empty_does_not_change_existing() {
-        let mut engine = HookEngine::new(make_config_pre(&["pre-a", "pre-b"]));
+        let mut engine = HookEngine::new(make_config_pre(&["pre-a", "pre-b"]), std::env::temp_dir());
         engine.merge_hooks(HooksConfig::default());
         assert_eq!(engine.config.pre_tool_use.len(), 2);
     }
@@ -463,7 +467,7 @@ mod phase11_tests {
     // TC-11.34: has_hooks() is true after merging
     #[test]
     fn tc_11_34_has_hooks_true_after_merge() {
-        let mut engine = HookEngine::new(HooksConfig::default());
+        let mut engine = HookEngine::new(HooksConfig::default(), std::env::temp_dir());
         assert!(
             !engine.has_hooks(),
             "precondition: engine starts with no hooks"
@@ -478,7 +482,7 @@ mod phase11_tests {
     // TC-11.35: multiple successive merges accumulate correctly (different names)
     #[test]
     fn tc_11_35_successive_merges_accumulate() {
-        let mut engine = HookEngine::new(HooksConfig::default());
+        let mut engine = HookEngine::new(HooksConfig::default(), std::env::temp_dir());
         engine.merge_hooks(make_config_pre(&["a"]));
         engine.merge_hooks(make_config_pre(&["b"]));
         engine.merge_hooks(make_config_pre(&["c"]));
@@ -488,7 +492,7 @@ mod phase11_tests {
     // TC-11.36: merging stop hooks does not affect pre_tool_use
     #[test]
     fn tc_11_36_merge_stop_does_not_affect_pre() {
-        let mut engine = HookEngine::new(make_config_pre(&["pre-a"]));
+        let mut engine = HookEngine::new(make_config_pre(&["pre-a"]), std::env::temp_dir());
         let additional = HooksConfig {
             pre_tool_use: vec![],
             post_tool_use: vec![],
@@ -506,7 +510,7 @@ mod phase11_tests {
     // TC-11.37: same-name hook not duplicated (idempotent dedup — C-4)
     #[test]
     fn tc_11_37_same_name_hook_not_duplicated() {
-        let mut engine = HookEngine::new(HooksConfig::default());
+        let mut engine = HookEngine::new(HooksConfig::default(), std::env::temp_dir());
         let config = make_config_pre(&["skill:my-skill:pre_tool_use:0"]);
         engine.merge_hooks(config.clone());
         engine.merge_hooks(config);
@@ -520,7 +524,7 @@ mod phase11_tests {
     // TC-11.38: different-name hooks both appended (no false dedup — C-4)
     #[test]
     fn tc_11_38_different_name_hooks_both_appended() {
-        let mut engine = HookEngine::new(HooksConfig::default());
+        let mut engine = HookEngine::new(HooksConfig::default(), std::env::temp_dir());
         engine.merge_hooks(make_config_pre(&["hook-a"]));
         engine.merge_hooks(make_config_pre(&["hook-b"]));
         assert_eq!(

--- a/crates/aion-config/src/hooks.rs
+++ b/crates/aion-config/src/hooks.rs
@@ -231,6 +231,8 @@ async fn run_hook_command(
     let interpolated = interpolate_command(command, env_vars);
     let timeout = Duration::from_millis(timeout_ms);
 
+    tracing::debug!(cwd = %cwd.display(), command = %interpolated, "hook executing");
+
     let result = tokio::time::timeout(timeout, async {
         shell_command_builder(&interpolated)
             .envs(env_vars)

--- a/crates/aion-tools/src/bash.rs
+++ b/crates/aion-tools/src/bash.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
-use aion_config::shell::shell_command;
+use aion_config::shell::shell_command_builder;
 use aion_protocol::events::ToolCategory;
 use aion_types::tool::{JsonSchema, ToolResult};
 
@@ -12,7 +13,15 @@ use crate::Tool;
 const DEFAULT_TIMEOUT_MS: u64 = 120_000;
 const MAX_TIMEOUT_MS: u64 = 600_000;
 
-pub struct BashTool;
+pub struct BashTool {
+    cwd: PathBuf,
+}
+
+impl BashTool {
+    pub fn new(cwd: PathBuf) -> Self {
+        Self { cwd }
+    }
+}
 
 #[async_trait]
 impl Tool for BashTool {
@@ -74,7 +83,14 @@ impl Tool for BashTool {
 
         let timeout = Duration::from_millis(timeout_ms);
 
-        let result = tokio::time::timeout(timeout, async { shell_command(command).await }).await;
+        let cwd = self.cwd.clone();
+        let result = tokio::time::timeout(timeout, async {
+            shell_command_builder(command)
+                .current_dir(&cwd)
+                .output()
+                .await
+        })
+        .await;
 
         match result {
             Ok(Ok(output)) => {
@@ -120,7 +136,7 @@ mod tests {
 
     #[tokio::test]
     async fn execute_echo_returns_stdout() {
-        let tool = BashTool;
+        let tool = BashTool::new(std::env::temp_dir());
         let input = json!({"command": "echo hello_bash"});
         let result = tool.execute(input).await;
         assert!(!result.is_error, "unexpected error: {}", result.content);
@@ -129,9 +145,26 @@ mod tests {
 
     #[tokio::test]
     async fn execute_invalid_command_returns_error() {
-        let tool = BashTool;
+        let tool = BashTool::new(std::env::temp_dir());
         let input = json!({"command": "nonexistent_command_xyz_123"});
         let result = tool.execute(input).await;
         assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn execute_respects_cwd() {
+        let tmp = std::env::temp_dir();
+        let tool = BashTool::new(tmp.clone());
+        let cmd = if cfg!(windows) { "cd" } else { "pwd" };
+        let input = json!({"command": cmd});
+        let result = tool.execute(input).await;
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        let expected = tmp.canonicalize().unwrap_or(tmp);
+        assert!(
+            result.content.contains(expected.to_string_lossy().as_ref()),
+            "output should contain cwd '{}', got: {}",
+            expected.display(),
+            result.content
+        );
     }
 }

--- a/crates/aion-tools/src/bash.rs
+++ b/crates/aion-tools/src/bash.rs
@@ -76,6 +76,8 @@ impl Tool for BashTool {
             };
         };
 
+        tracing::debug!(cwd = %self.cwd.display(), command = %command, "BashTool executing");
+
         let timeout_ms = input["timeout"]
             .as_u64()
             .unwrap_or(DEFAULT_TIMEOUT_MS)

--- a/crates/aion-tools/src/bash.rs
+++ b/crates/aion-tools/src/bash.rs
@@ -155,17 +155,20 @@ mod tests {
 
     #[tokio::test]
     async fn execute_respects_cwd() {
-        let tmp = std::env::temp_dir();
-        let tool = BashTool::new(tmp.clone());
-        let cmd = if cfg!(windows) { "cd" } else { "pwd" };
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("cwd_proof.txt"), "proof").unwrap();
+        let tool = BashTool::new(dir.path().to_path_buf());
+        let cmd = if cfg!(windows) {
+            "type cwd_proof.txt"
+        } else {
+            "cat cwd_proof.txt"
+        };
         let input = json!({"command": cmd});
         let result = tool.execute(input).await;
         assert!(!result.is_error, "unexpected error: {}", result.content);
-        let expected = tmp.canonicalize().unwrap_or(tmp);
         assert!(
-            result.content.contains(expected.to_string_lossy().as_ref()),
-            "output should contain cwd '{}', got: {}",
-            expected.display(),
+            result.content.contains("proof"),
+            "BashTool should execute in injected cwd, got: {}",
             result.content
         );
     }

--- a/crates/aion-tools/src/glob.rs
+++ b/crates/aion-tools/src/glob.rs
@@ -71,6 +71,8 @@ impl Tool for GlobTool {
             PathBuf::from(root)
         };
 
+        tracing::debug!(cwd = %self.cwd.display(), resolved_root = %root_path.display(), pattern = %pattern, "GlobTool scanning");
+
         // Build full glob pattern
         let full_pattern = if pattern.starts_with('/') {
             pattern.to_string()

--- a/crates/aion-tools/src/glob.rs
+++ b/crates/aion-tools/src/glob.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -10,7 +10,15 @@ use crate::Tool;
 
 const MAX_RESULTS: usize = 100;
 
-pub struct GlobTool;
+pub struct GlobTool {
+    cwd: PathBuf,
+}
+
+impl GlobTool {
+    pub fn new(cwd: PathBuf) -> Self {
+        Self { cwd }
+    }
+}
 
 #[async_trait]
 impl Tool for GlobTool {
@@ -57,7 +65,11 @@ impl Tool for GlobTool {
         };
 
         let root = input["path"].as_str().unwrap_or(".");
-        let root_path = Path::new(root);
+        let root_path = if Path::new(root).is_relative() {
+            self.cwd.join(root)
+        } else {
+            PathBuf::from(root)
+        };
 
         // Build full glob pattern
         let full_pattern = if pattern.starts_with('/') {
@@ -97,7 +109,7 @@ impl Tool for GlobTool {
 
             // Make path relative to root
             let display_path = path
-                .strip_prefix(root_path)
+                .strip_prefix(&root_path)
                 .unwrap_or(&path)
                 .display()
                 .to_string();
@@ -137,12 +149,13 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::fs;
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     use aion_types::tool::ToolResult;
 
     async fn run_glob(pattern: &str, path: &str) -> ToolResult {
-        let tool = GlobTool;
+        let tool = GlobTool::new(PathBuf::from(path));
         let input = json!({ "pattern": pattern, "path": path });
         tool.execute(input).await
     }
@@ -249,6 +262,22 @@ mod tests {
         assert!(
             !result.content.contains("skip.rs"),
             "should not include .rs files"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_uses_cwd_for_relative_path() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("marker.txt"), "hello").unwrap();
+
+        let tool = GlobTool::new(tmp.path().to_path_buf());
+        let input = json!({"pattern": "marker.txt"});
+        let result = tool.execute(input).await;
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert!(
+            result.content.contains("marker.txt"),
+            "should find marker.txt, got: {}",
+            result.content
         );
     }
 }

--- a/crates/aion-tools/src/grep.rs
+++ b/crates/aion-tools/src/grep.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use tokio::process::Command;
@@ -7,7 +9,15 @@ use aion_types::tool::{JsonSchema, ToolResult};
 
 use crate::Tool;
 
-pub struct GrepTool;
+pub struct GrepTool {
+    cwd: PathBuf,
+}
+
+impl GrepTool {
+    pub fn new(cwd: PathBuf) -> Self {
+        Self { cwd }
+    }
+}
 
 #[async_trait]
 impl Tool for GrepTool {
@@ -62,19 +72,24 @@ impl Tool for GrepTool {
             };
         };
 
-        let path = input["path"].as_str().unwrap_or(".");
+        let raw_path = input["path"].as_str().unwrap_or(".");
+        let path = if std::path::Path::new(raw_path).is_relative() {
+            self.cwd.join(raw_path).to_string_lossy().into_owned()
+        } else {
+            raw_path.to_owned()
+        };
 
         let glob_pattern = input["glob"].as_str();
         let case_insensitive = input["case_insensitive"].as_bool().unwrap_or(false);
 
         // Try ripgrep first, fallback to grep
-        let result = try_ripgrep(pattern, path, glob_pattern, case_insensitive).await;
+        let result = try_ripgrep(pattern, &path, glob_pattern, case_insensitive).await;
 
         match result {
             Ok(output) => output,
             Err(_) => {
                 // Fallback to grep
-                try_grep(pattern, path, case_insensitive).await
+                try_grep(pattern, &path, case_insensitive).await
             }
         }
     }
@@ -89,8 +104,8 @@ impl Tool for GrepTool {
 
     fn describe(&self, input: &Value) -> String {
         let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
-        let path = input.get("path").and_then(|v| v.as_str()).unwrap_or(".");
-        format!("Grep '{}' in {}", pattern, path)
+        let raw_path = input.get("path").and_then(|v| v.as_str()).unwrap_or(".");
+        format!("Grep '{}' in {}", pattern, raw_path)
     }
 }
 
@@ -187,7 +202,7 @@ mod tests {
 
     #[tokio::test]
     async fn grep_tool_finds_pattern_in_own_source() {
-        let tool = GrepTool;
+        let tool = GrepTool::new(PathBuf::from(env!("CARGO_MANIFEST_DIR")));
         let input = json!({
             "pattern": "GrepTool",
             "path": env!("CARGO_MANIFEST_DIR")
@@ -195,5 +210,22 @@ mod tests {
         let result = tool.execute(input).await;
         assert!(!result.is_error, "grep failed: {}", result.content);
         assert!(result.content.contains("GrepTool"));
+    }
+
+    #[tokio::test]
+    async fn execute_uses_cwd_for_relative_path() {
+        use std::fs;
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("searchable.txt"), "unique_grep_marker_xyz").unwrap();
+
+        let tool = GrepTool::new(tmp.path().to_path_buf());
+        let input = json!({"pattern": "unique_grep_marker_xyz", "path": "."});
+        let result = tool.execute(input).await;
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert!(
+            result.content.contains("unique_grep_marker_xyz"),
+            "should find pattern, got: {}",
+            result.content
+        );
     }
 }

--- a/crates/aion-tools/src/grep.rs
+++ b/crates/aion-tools/src/grep.rs
@@ -79,6 +79,8 @@ impl Tool for GrepTool {
             raw_path.to_owned()
         };
 
+        tracing::debug!(cwd = %self.cwd.display(), resolved_path = %path, pattern = %pattern, "GrepTool searching");
+
         let glob_pattern = input["glob"].as_str();
         let case_insensitive = input["case_insensitive"].as_bool().unwrap_or(false);
 

--- a/crates/aion-tools/tests/tool_description_test.rs
+++ b/crates/aion-tools/tests/tool_description_test.rs
@@ -3,6 +3,8 @@
 //! These are black-box tests that verify each tool's description contains
 //! the key guidance information specified in the test plan.
 
+use std::path::PathBuf;
+
 use aion_tools::Tool;
 use aion_tools::bash::BashTool;
 use aion_tools::edit::EditTool;
@@ -12,11 +14,16 @@ use aion_tools::read::ReadTool;
 use aion_tools::registry::ToolRegistry;
 use aion_tools::write::WriteTool;
 
+fn test_cwd() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
 // --- TC-4.2-01: Bash tool description contains key guidance ---
 
 #[test]
 fn bash_description_references_dedicated_tools() {
-    let desc = BashTool.description();
+    let tool = BashTool::new(test_cwd());
+    let desc = tool.description();
     assert!(
         desc.contains("Glob"),
         "Bash description should cross-reference Glob tool"
@@ -37,7 +44,8 @@ fn bash_description_references_dedicated_tools() {
 
 #[test]
 fn bash_description_contains_timeout_info() {
-    let desc = BashTool.description();
+    let tool = BashTool::new(test_cwd());
+    let desc = tool.description();
     assert!(
         desc.contains("120") || desc.to_lowercase().contains("timeout"),
         "Bash description should mention timeout"
@@ -46,7 +54,8 @@ fn bash_description_contains_timeout_info() {
 
 #[test]
 fn bash_description_contains_parallel_guidance() {
-    let desc = BashTool.description();
+    let tool = BashTool::new(test_cwd());
+    let desc = tool.description();
     assert!(
         desc.contains("parallel") || desc.contains("&&"),
         "Bash description should contain parallel command guidance"
@@ -153,7 +162,8 @@ fn write_description_prefers_edit() {
 
 #[test]
 fn glob_description_mentions_result_limit() {
-    let desc = GlobTool.description();
+    let tool = GlobTool::new(test_cwd());
+    let desc = tool.description();
     assert!(
         desc.contains("100"),
         "Glob description should mention the 100 result limit"
@@ -162,7 +172,8 @@ fn glob_description_mentions_result_limit() {
 
 #[test]
 fn glob_description_mentions_sort_order() {
-    let desc = GlobTool.description();
+    let tool = GlobTool::new(test_cwd());
+    let desc = tool.description();
     let lower = desc.to_lowercase();
     assert!(
         lower.contains("modification time") || lower.contains("newest"),
@@ -174,7 +185,8 @@ fn glob_description_mentions_sort_order() {
 
 #[test]
 fn grep_description_forbids_bash_grep() {
-    let desc = GrepTool.description();
+    let tool = GrepTool::new(test_cwd());
+    let desc = tool.description();
     assert!(
         desc.contains("NEVER") || desc.contains("never"),
         "Grep description should forbid using grep in Bash"
@@ -183,7 +195,8 @@ fn grep_description_forbids_bash_grep() {
 
 #[test]
 fn grep_description_mentions_regex() {
-    let desc = GrepTool.description();
+    let tool = GrepTool::new(test_cwd());
+    let desc = tool.description();
     assert!(
         desc.contains("regex"),
         "Grep description should mention regex support"
@@ -192,7 +205,8 @@ fn grep_description_mentions_regex() {
 
 #[test]
 fn grep_description_mentions_result_limit() {
-    let desc = GrepTool.description();
+    let tool = GrepTool::new(test_cwd());
+    let desc = tool.description();
     assert!(
         desc.contains("250"),
         "Grep description should mention the 250 result limit"
@@ -203,7 +217,8 @@ fn grep_description_mentions_result_limit() {
 
 #[test]
 fn grep_description_does_not_say_at_most_matches() {
-    let desc = GrepTool.description();
+    let tool = GrepTool::new(test_cwd());
+    let desc = tool.description();
     assert!(
         !desc.contains("at most 250 matches"),
         "Grep description should not say 'at most 250 matches' (was per-file, not global)"
@@ -219,12 +234,12 @@ fn grep_description_does_not_say_at_most_matches() {
 #[test]
 fn tool_def_description_matches_tool_instance() {
     let mut registry = ToolRegistry::new();
-    registry.register(Box::new(BashTool));
+    registry.register(Box::new(BashTool::new(test_cwd())));
     registry.register(Box::new(ReadTool::new(None)));
     registry.register(Box::new(EditTool::new(None)));
     registry.register(Box::new(WriteTool::new(None)));
-    registry.register(Box::new(GlobTool));
-    registry.register(Box::new(GrepTool));
+    registry.register(Box::new(GlobTool::new(test_cwd())));
+    registry.register(Box::new(GrepTool::new(test_cwd())));
 
     let defs = registry.to_tool_defs();
 


### PR DESCRIPTION
## Summary

- Add `cwd: PathBuf` field to `BashTool`, `GlobTool`, `GrepTool`, and `HookEngine` so they execute in the correct workspace directory instead of inheriting the process cwd
- Wire the workspace path through `AgentEngine`, `AgentBootstrap`, and `AgentSpawner` constructors
- Add tracing diagnostics (info at bootstrap, debug at each tool execution) for production debugging

## Motivation

When aionrs runs as a library inside AionCore (Electron desktop app), the process cwd is the Electron installation directory, not the user's project. Tools that default to `"."` or omit `current_dir` would operate in the wrong location.

Fixes: ELECTRON-1H6 (#122097136)

## Test Plan

- [x] Unit tests for BashTool, GlobTool, GrepTool cwd injection
- [x] Unit tests for HookEngine cwd injection
- [x] Integration tests verifying tools use injected cwd (not process cwd)
- [x] All existing tests pass (`cargo test --workspace`: 1859 passed)
- [x] `cargo clippy --workspace -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean
- [x] Verified in AionUI-Dev: logs confirm correct workspace path in production