### PR TITLE
Fix tool call ID correlation on abort

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,16 @@ Supports the same arguments as `git push` (e.g. `just push -u origin branch`).
   - Never silently swallow errors; never `unwrap()` in production code
     unless the invariant is proven and commented
 
+## Logging
+
+When changing a critical path, explicitly evaluate whether logs are needed for development diagnosis and production troubleshooting. Add structured logs with appropriate levels:
+- `debug` for detailed, high-frequency internal flow that helps verify behavior and diagnose issues in development
+- `info` for low-volume lifecycle boundaries useful in production
+- `warn` for malformed or unexpected data that is safely handled
+- `error` for contract violations or failed operations
+
+Production-visible logs must not include sensitive payloads such as prompts, tool input/output, file contents, command bodies, tokens, secrets, or raw provider requests/responses. If such payloads are needed for local debugging, they must be behind explicit development-only guards and never enabled by default.
+
 ## File Organization
 
 - Each module (`.rs` file) follows the **single responsibility principle** —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "regex",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aion-config",
  "chrono",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aion-types",
  "rstest",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-agent/src/commands/help.rs
+++ b/crates/aion-agent/src/commands/help.rs
@@ -68,8 +68,8 @@ mod tests {
     impl OutputSink for CaptureSink {
         fn emit_text_delta(&self, _: &str, _: &str) {}
         fn emit_thinking(&self, _: &str, _: &str) {}
-        fn emit_tool_call(&self, _: &str, _: &str) {}
-        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: &str, _: bool, _: &str) {}
         fn emit_stream_start(&self, _: &str) {}
         fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
         fn emit_error(&self, _: &str) {}

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -533,6 +533,20 @@ impl AgentEngine {
                         input,
                         extra,
                     } => {
+                        if id.trim().is_empty() {
+                            tracing::error!(
+                                target: "aion_agent",
+                                tool = %name,
+                                "provider emitted tool call with empty tool_use_id"
+                            );
+                        } else {
+                            tracing::debug!(
+                                target: "aion_agent",
+                                tool_use_id = %id,
+                                tool = %name,
+                                "provider tool call received"
+                            );
+                        }
                         let input_str = serde_json::to_string(&input).unwrap_or_default();
                         self.output.emit_tool_call(&id, &name, &input_str);
                         tool_calls.push(ContentBlock::ToolUse {
@@ -706,6 +720,23 @@ impl AgentEngine {
                             None
                         })
                         .unwrap_or("unknown");
+                    let status = if *is_error { "error" } else { "completed" };
+                    if tool_use_id.trim().is_empty() {
+                        tracing::error!(
+                            target: "aion_agent",
+                            tool = %tool_name,
+                            status,
+                            "tool result has empty tool_use_id"
+                        );
+                    } else {
+                        tracing::debug!(
+                            target: "aion_agent",
+                            tool_use_id = %tool_use_id,
+                            tool = %tool_name,
+                            status,
+                            "tool result emitted"
+                        );
+                    }
                     self.output
                         .emit_tool_result(tool_use_id, tool_name, *is_error, content);
                 }

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -534,7 +534,7 @@ impl AgentEngine {
                         extra,
                     } => {
                         let input_str = serde_json::to_string(&input).unwrap_or_default();
-                        self.output.emit_tool_call(&name, &input_str);
+                        self.output.emit_tool_call(&id, &name, &input_str);
                         tool_calls.push(ContentBlock::ToolUse {
                             id,
                             name,
@@ -690,14 +690,15 @@ impl AgentEngine {
             // Display tool results
             for result in &outcome.results {
                 if let ContentBlock::ToolResult {
-                    content, is_error, ..
+                    tool_use_id,
+                    content,
+                    is_error,
                 } = result
                 {
                     let tool_name = tool_calls
                         .iter()
                         .find_map(|c| {
                             if let ContentBlock::ToolUse { id, name, .. } = c
-                                && let ContentBlock::ToolResult { tool_use_id, .. } = result
                                 && id == tool_use_id
                             {
                                 return Some(name.as_str());
@@ -705,7 +706,8 @@ impl AgentEngine {
                             None
                         })
                         .unwrap_or("unknown");
-                    self.output.emit_tool_result(tool_name, *is_error, content);
+                    self.output
+                        .emit_tool_result(tool_use_id, tool_name, *is_error, content);
                 }
             }
 
@@ -910,8 +912,8 @@ mod set_config_tests {
     impl OutputSink for NullOutput {
         fn emit_text_delta(&self, _: &str, _: &str) {}
         fn emit_thinking(&self, _: &str, _: &str) {}
-        fn emit_tool_call(&self, _: &str, _: &str) {}
-        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: &str, _: bool, _: &str) {}
         fn emit_stream_start(&self, _: &str) {}
         fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
         fn emit_error(&self, _: &str) {}
@@ -1238,8 +1240,8 @@ mod phase6_tests {
     impl OutputSink for NullOutput {
         fn emit_text_delta(&self, _: &str, _: &str) {}
         fn emit_thinking(&self, _: &str, _: &str) {}
-        fn emit_tool_call(&self, _: &str, _: &str) {}
-        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: &str, _: bool, _: &str) {}
         fn emit_stream_start(&self, _: &str) {}
         fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
         fn emit_error(&self, _: &str) {}
@@ -1437,8 +1439,8 @@ mod compact_tests {
     impl OutputSink for NullOutput {
         fn emit_text_delta(&self, _: &str, _: &str) {}
         fn emit_thinking(&self, _: &str, _: &str) {}
-        fn emit_tool_call(&self, _: &str, _: &str) {}
-        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: &str, _: bool, _: &str) {}
         fn emit_stream_start(&self, _: &str) {}
         fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
         fn emit_error(&self, _: &str) {}
@@ -1707,8 +1709,8 @@ mod plan_mode_tests {
     impl OutputSink for NullOutput {
         fn emit_text_delta(&self, _: &str, _: &str) {}
         fn emit_thinking(&self, _: &str, _: &str) {}
-        fn emit_tool_call(&self, _: &str, _: &str) {}
-        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: &str, _: bool, _: &str) {}
         fn emit_stream_start(&self, _: &str) {}
         fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
         fn emit_error(&self, _: &str) {}
@@ -1920,8 +1922,8 @@ mod handle_command_tests {
     impl OutputSink for NullOutput {
         fn emit_text_delta(&self, _: &str, _: &str) {}
         fn emit_thinking(&self, _: &str, _: &str) {}
-        fn emit_tool_call(&self, _: &str, _: &str) {}
-        fn emit_tool_result(&self, _: &str, _: bool, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: &str, _: bool, _: &str) {}
         fn emit_stream_start(&self, _: &str) {}
         fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
         fn emit_error(&self, _: &str) {}

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -922,6 +922,59 @@ impl AgentEngine {
             }
         }
     }
+
+    /// Close a partially recorded turn after the host cancels execution.
+    ///
+    /// Providers in the Anthropic family require every assistant `tool_use` to
+    /// be followed immediately by user `tool_result` blocks. If the host drops
+    /// `run()` while tools are executing, the assistant `tool_use` message may
+    /// already be in memory without its matching results. Add synthetic error
+    /// results so the next request can safely reuse this history.
+    pub fn abort_current_turn(&mut self, reason: &str) {
+        let Some(last_message) = self.messages.last() else {
+            return;
+        };
+        if last_message.role != Role::Assistant {
+            return;
+        }
+
+        let pending_results: Vec<_> = last_message
+            .content
+            .iter()
+            .filter_map(|block| {
+                let ContentBlock::ToolUse { id, name, .. } = block else {
+                    return None;
+                };
+                Some((id.clone(), name.clone()))
+            })
+            .collect();
+
+        if pending_results.is_empty() {
+            return;
+        }
+
+        let result_blocks = pending_results
+            .into_iter()
+            .map(|(tool_use_id, name)| {
+                tracing::info!(
+                    target: "aion_agent",
+                    tool_use_id = %tool_use_id,
+                    tool = %name,
+                    "closing pending tool_use after abort"
+                );
+                self.output
+                    .emit_tool_result(&tool_use_id, &name, true, reason);
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content: reason.to_string(),
+                    is_error: true,
+                }
+            })
+            .collect();
+
+        self.messages.push(Message::now(Role::User, result_blocks));
+        self.save_session();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1478,6 +1531,29 @@ mod compact_tests {
         fn emit_info(&self, _: &str) {}
     }
 
+    #[derive(Default)]
+    struct RecordingOutput {
+        tool_results: Mutex<Vec<(String, String, bool, String)>>,
+    }
+
+    impl OutputSink for RecordingOutput {
+        fn emit_text_delta(&self, _: &str, _: &str) {}
+        fn emit_thinking(&self, _: &str, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str, _: &str) {}
+        fn emit_tool_result(&self, tool_use_id: &str, name: &str, is_error: bool, content: &str) {
+            self.tool_results.lock().unwrap().push((
+                tool_use_id.to_string(),
+                name.to_string(),
+                is_error,
+                content.to_string(),
+            ));
+        }
+        fn emit_stream_start(&self, _: &str) {}
+        fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
+        fn emit_error(&self, _: &str) {}
+        fn emit_info(&self, _: &str) {}
+    }
+
     struct NullProvider;
     #[async_trait::async_trait]
     impl LlmProvider for NullProvider {
@@ -1495,6 +1571,20 @@ mod compact_tests {
         compact_state: CompactState,
         messages: Vec<Message>,
     ) -> super::AgentEngine {
+        make_compact_engine_with_output(
+            compact_config,
+            compact_state,
+            messages,
+            Arc::new(NullOutput),
+        )
+    }
+
+    fn make_compact_engine_with_output(
+        compact_config: CompactConfig,
+        compact_state: CompactState,
+        messages: Vec<Message>,
+        output: Arc<dyn OutputSink>,
+    ) -> super::AgentEngine {
         super::AgentEngine {
             provider: Arc::new(NullProvider),
             tools: ToolRegistry::new(),
@@ -1510,7 +1600,7 @@ mod compact_tests {
             hooks: None,
             session_manager: None,
             current_session: None,
-            output: Arc::new(NullOutput),
+            output,
             current_msg_id: String::new(),
             approval_manager: None,
             protocol_writer: None,
@@ -1539,6 +1629,26 @@ mod compact_tests {
         )
     }
 
+    fn tool_use_msg_with_two_calls(first_id: &str, second_id: &str) -> Message {
+        Message::new(
+            Role::Assistant,
+            vec![
+                ContentBlock::ToolUse {
+                    id: first_id.to_string(),
+                    name: "Read".to_string(),
+                    input: json!({}),
+                    extra: None,
+                },
+                ContentBlock::ToolUse {
+                    id: second_id.to_string(),
+                    name: "Bash".to_string(),
+                    input: json!({}),
+                    extra: None,
+                },
+            ],
+        )
+    }
+
     fn tool_result_msg(id: &str, content: &str) -> Message {
         Message::new(
             Role::User,
@@ -1548,6 +1658,60 @@ mod compact_tests {
                 is_error: false,
             }],
         )
+    }
+
+    #[test]
+    fn abort_current_turn_closes_pending_tool_uses() {
+        let output = Arc::new(RecordingOutput::default());
+        let mut engine = make_compact_engine_with_output(
+            CompactConfig::default(),
+            CompactState::new(),
+            vec![
+                Message::new(
+                    Role::User,
+                    vec![ContentBlock::Text {
+                        text: "run tools".to_string(),
+                    }],
+                ),
+                tool_use_msg_with_two_calls("call_read", "call_bash"),
+            ],
+            output.clone(),
+        );
+
+        engine.abort_current_turn("Tool execution canceled by user");
+
+        let last = engine.messages.last().expect("synthetic result message");
+        assert_eq!(last.role, Role::User);
+        assert_eq!(last.content.len(), 2);
+        assert!(
+            matches!(&last.content[0], ContentBlock::ToolResult { tool_use_id, content, is_error }
+                if tool_use_id == "call_read" && content == "Tool execution canceled by user" && *is_error)
+        );
+        assert!(
+            matches!(&last.content[1], ContentBlock::ToolResult { tool_use_id, content, is_error }
+                if tool_use_id == "call_bash" && content == "Tool execution canceled by user" && *is_error)
+        );
+
+        let emitted = output.tool_results.lock().unwrap();
+        assert_eq!(emitted.len(), 2);
+        assert_eq!(
+            emitted[0],
+            (
+                "call_read".into(),
+                "Read".into(),
+                true,
+                "Tool execution canceled by user".into()
+            )
+        );
+        assert_eq!(
+            emitted[1],
+            (
+                "call_bash".into(),
+                "Bash".into(),
+                true,
+                "Tool execution canceled by user".into()
+            )
+        );
     }
 
     // -- Emergency check fires when at limit --

--- a/crates/aion-agent/src/output/mod.rs
+++ b/crates/aion-agent/src/output/mod.rs
@@ -12,10 +12,10 @@ pub trait OutputSink: Send + Sync {
     fn emit_text_delta(&self, text: &str, msg_id: &str);
     /// Stream thinking content from LLM
     fn emit_thinking(&self, text: &str, msg_id: &str);
-    /// Announce a tool call
-    fn emit_tool_call(&self, name: &str, input: &str);
-    /// Display tool result
-    fn emit_tool_result(&self, name: &str, is_error: bool, content: &str);
+    /// Announce a tool call.
+    fn emit_tool_call(&self, tool_use_id: &str, name: &str, input: &str);
+    /// Display tool result.
+    fn emit_tool_result(&self, tool_use_id: &str, name: &str, is_error: bool, content: &str);
     /// Signal start of a new message stream
     fn emit_stream_start(&self, msg_id: &str);
     /// Signal end of a message stream with usage stats

--- a/crates/aion-agent/src/output/null_sink.rs
+++ b/crates/aion-agent/src/output/null_sink.rs
@@ -12,8 +12,8 @@ pub struct NullSink;
 impl OutputSink for NullSink {
     fn emit_text_delta(&self, _text: &str, _msg_id: &str) {}
     fn emit_thinking(&self, _text: &str, _msg_id: &str) {}
-    fn emit_tool_call(&self, _name: &str, _input: &str) {}
-    fn emit_tool_result(&self, _name: &str, _is_error: bool, _content: &str) {}
+    fn emit_tool_call(&self, _tool_use_id: &str, _name: &str, _input: &str) {}
+    fn emit_tool_result(&self, _tool_use_id: &str, _name: &str, _is_error: bool, _content: &str) {}
     fn emit_stream_start(&self, _msg_id: &str) {}
     fn emit_stream_end(
         &self,
@@ -38,8 +38,8 @@ mod tests {
         let sink = NullSink;
         sink.emit_text_delta("hello", "msg1");
         sink.emit_thinking("thought", "msg1");
-        sink.emit_tool_call("Read", "{}");
-        sink.emit_tool_result("Read", false, "ok");
+        sink.emit_tool_call("call_read_1", "Read", "{}");
+        sink.emit_tool_result("call_read_1", "Read", false, "ok");
         sink.emit_stream_start("msg1");
         sink.emit_stream_end("msg1", 1, 100, 50, 0, 0);
         sink.emit_error("err");

--- a/crates/aion-agent/src/output/protocol_sink.rs
+++ b/crates/aion-agent/src/output/protocol_sink.rs
@@ -75,7 +75,7 @@ impl OutputSink for ProtocolSink {
         });
     }
 
-    fn emit_tool_call(&self, name: &str, _input: &str) {
+    fn emit_tool_call(&self, _tool_use_id: &str, name: &str, _input: &str) {
         // In protocol mode, tool_call is handled by tool_request/tool_running events.
         // This is a fallback for compatibility.
         let _ = self.writer.emit(&ProtocolEvent::Info {
@@ -84,7 +84,7 @@ impl OutputSink for ProtocolSink {
         });
     }
 
-    fn emit_tool_result(&self, name: &str, is_error: bool, content: &str) {
+    fn emit_tool_result(&self, _tool_use_id: &str, name: &str, is_error: bool, content: &str) {
         // In protocol mode, tool results are emitted via explicit ToolResult events
         // with call_id. This fallback emits an info event.
         let status = if is_error { "error" } else { "success" };

--- a/crates/aion-agent/src/output/terminal.rs
+++ b/crates/aion-agent/src/output/terminal.rs
@@ -27,11 +27,11 @@ impl OutputSink for TerminalSink {
         self.formatter.thinking(text);
     }
 
-    fn emit_tool_call(&self, name: &str, input: &str) {
+    fn emit_tool_call(&self, _tool_use_id: &str, name: &str, input: &str) {
         self.formatter.tool_call(name, input);
     }
 
-    fn emit_tool_result(&self, name: &str, is_error: bool, content: &str) {
+    fn emit_tool_result(&self, _tool_use_id: &str, name: &str, is_error: bool, content: &str) {
         self.formatter.tool_result(name, is_error, content);
     }
 

--- a/crates/aion-agent/tests/engine_test.rs
+++ b/crates/aion-agent/tests/engine_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use aion_agent::engine::{AgentEngine, AgentError};
 use aion_agent::output::OutputSink;
@@ -19,6 +19,45 @@ use common::{MockLlmProvider, MockTool, test_config};
 // ---------------------------------------------------------------------------
 fn silent_output() -> Arc<dyn OutputSink> {
     Arc::new(TerminalSink::new(true))
+}
+
+#[derive(Default)]
+struct RecordingOutputSink {
+    tool_calls: Mutex<Vec<(String, String)>>,
+    tool_results: Mutex<Vec<(String, String, bool)>>,
+}
+
+impl OutputSink for RecordingOutputSink {
+    fn emit_text_delta(&self, _text: &str, _msg_id: &str) {}
+    fn emit_thinking(&self, _text: &str, _msg_id: &str) {}
+
+    fn emit_tool_call(&self, tool_use_id: &str, name: &str, _input: &str) {
+        self.tool_calls
+            .lock()
+            .unwrap()
+            .push((tool_use_id.to_owned(), name.to_owned()));
+    }
+
+    fn emit_tool_result(&self, tool_use_id: &str, name: &str, is_error: bool, _content: &str) {
+        self.tool_results
+            .lock()
+            .unwrap()
+            .push((tool_use_id.to_owned(), name.to_owned(), is_error));
+    }
+
+    fn emit_stream_start(&self, _msg_id: &str) {}
+    fn emit_stream_end(
+        &self,
+        _msg_id: &str,
+        _turns: usize,
+        _input_tokens: u64,
+        _output_tokens: u64,
+        _cache_creation_tokens: u64,
+        _cache_read_tokens: u64,
+    ) {
+    }
+    fn emit_error(&self, _msg: &str) {}
+    fn emit_info(&self, _msg: &str) {}
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +140,79 @@ async fn test_engine_tool_use_executes_and_continues() {
 
     assert_eq!(result.turns, 2);
     assert_eq!(result.text, "Done");
+}
+
+#[tokio::test]
+async fn duplicate_tool_names_emit_distinct_tool_use_ids() {
+    let turn1 = vec![
+        LlmEvent::ToolUse {
+            id: "call_a".to_string(),
+            name: "Glob".to_string(),
+            input: json!({"pattern": "*.rs"}),
+            extra: None,
+        },
+        LlmEvent::ToolUse {
+            id: "call_b".to_string(),
+            name: "Glob".to_string(),
+            input: json!({"pattern": "*.toml"}),
+            extra: None,
+        },
+        LlmEvent::Done {
+            stop_reason: StopReason::ToolUse,
+            usage: TokenUsage {
+                input_tokens: 80,
+                output_tokens: 30,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+            },
+        },
+    ];
+    let turn2 = vec![
+        LlmEvent::TextDelta("Done".to_string()),
+        LlmEvent::Done {
+            stop_reason: StopReason::EndTurn,
+            usage: TokenUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+            },
+        },
+    ];
+
+    let provider = Arc::new(MockLlmProvider::with_turns(vec![turn1, turn2]));
+    let config = test_config();
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(MockTool::new("Glob", "tool output", false)));
+    let output = Arc::new(RecordingOutputSink::default());
+
+    let mut engine = AgentEngine::new_with_provider(
+        provider,
+        config,
+        registry,
+        output.clone(),
+        std::env::temp_dir(),
+    );
+    let result = engine
+        .run("Use Glob twice", "")
+        .await
+        .expect("engine should succeed");
+
+    assert_eq!(result.text, "Done");
+    assert_eq!(
+        *output.tool_calls.lock().unwrap(),
+        vec![
+            ("call_a".to_string(), "Glob".to_string()),
+            ("call_b".to_string(), "Glob".to_string()),
+        ]
+    );
+    assert_eq!(
+        *output.tool_results.lock().unwrap(),
+        vec![
+            ("call_a".to_string(), "Glob".to_string(), false),
+            ("call_b".to_string(), "Glob".to_string(), false),
+        ]
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Preserve provider tool call IDs through tool execution and output events.
- Add info/debug logging for tool_use_id and call_id correlation.
- Close pending tool uses with error tool_result messages when a turn is aborted, so resumed conversations keep valid provider history.

## Test Plan
- `vx just push -u origin fix/tool-call-id-correlation`
  - ran cargo fix
  - ran workspace clippy fix with `-D warnings`
  - ran cargo fmt
  - ran `vx cargo nextest run --workspace --profile default`
  - result: 1861 tests passed, 2 skipped
