### PR TITLE
fix: preserve Anthropic thinking signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "regex",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aion-config",
  "chrono",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aion-types",
  "rstest",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-agent/src/compact/estimate.rs
+++ b/crates/aion-agent/src/compact/estimate.rs
@@ -18,7 +18,7 @@ pub fn estimate_tokens_from_messages(messages: &[Message]) -> u64 {
                 ContentBlock::Text { text } => {
                     total_chars += text.len();
                 }
-                ContentBlock::Thinking { thinking } => {
+                ContentBlock::Thinking { thinking, .. } => {
                     total_chars += thinking.len();
                 }
                 ContentBlock::ToolUse { name, input, .. } => {
@@ -129,7 +129,13 @@ mod tests {
     #[test]
     fn thinking_block_counted() {
         let thinking = "t".repeat(4000);
-        let msg = Message::new(Role::Assistant, vec![ContentBlock::Thinking { thinking }]);
+        let msg = Message::new(
+            Role::Assistant,
+            vec![ContentBlock::Thinking {
+                thinking,
+                signature: None,
+            }],
+        );
         assert_eq!(estimate_tokens_from_messages(&[msg]), 1000);
     }
 

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -517,6 +517,7 @@ impl AgentEngine {
             let mut rx = self.provider.stream(&request).await?;
             let mut assistant_text = String::new();
             let mut thinking_text = String::new();
+            let mut thinking_signature: Option<String> = None;
             let mut tool_calls: Vec<ContentBlock> = Vec::new();
             let mut stop_reason = StopReason::EndTurn;
             let mut turn_usage = TokenUsage::default();
@@ -559,6 +560,9 @@ impl AgentEngine {
                     LlmEvent::ThinkingDelta(text) => {
                         self.output.emit_thinking(&text, &self.current_msg_id);
                         thinking_text.push_str(&text);
+                    }
+                    LlmEvent::ThinkingSignature(signature) => {
+                        thinking_signature = Some(signature);
                     }
                     LlmEvent::Done {
                         stop_reason: sr,
@@ -626,9 +630,10 @@ impl AgentEngine {
             }
 
             let mut assistant_content: Vec<ContentBlock> = Vec::new();
-            if !thinking_text.is_empty() {
+            if !thinking_text.is_empty() || thinking_signature.is_some() {
                 assistant_content.push(ContentBlock::Thinking {
                     thinking: thinking_text,
+                    signature: thinking_signature,
                 });
             }
             if !assistant_text.is_empty() {

--- a/crates/aion-agent/tests/engine_test.rs
+++ b/crates/aion-agent/tests/engine_test.rs
@@ -6,11 +6,14 @@ use aion_agent::engine::{AgentEngine, AgentError};
 use aion_agent::output::OutputSink;
 use aion_agent::output::terminal::TerminalSink;
 use aion_agent::session::SessionManager;
+use aion_providers::{LlmProvider, ProviderError};
 use aion_tools::registry::ToolRegistry;
-use aion_types::llm::LlmEvent;
-use aion_types::message::{StopReason, TokenUsage};
+use aion_types::llm::{LlmEvent, LlmRequest};
+use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
+use async_trait::async_trait;
 use serde_json::json;
 use tempfile::tempdir;
+use tokio::sync::mpsc;
 
 use common::{MockLlmProvider, MockTool, test_config};
 
@@ -58,6 +61,42 @@ impl OutputSink for RecordingOutputSink {
     }
     fn emit_error(&self, _msg: &str) {}
     fn emit_info(&self, _msg: &str) {}
+}
+
+struct RecordingRequestProvider {
+    requests: Arc<Mutex<Vec<Vec<Message>>>>,
+    responses: Mutex<Vec<Vec<LlmEvent>>>,
+}
+
+impl RecordingRequestProvider {
+    fn new(responses: Vec<Vec<LlmEvent>>) -> Self {
+        Self {
+            requests: Arc::new(Mutex::new(Vec::new())),
+            responses: Mutex::new(responses),
+        }
+    }
+
+    fn requests(&self) -> Arc<Mutex<Vec<Vec<Message>>>> {
+        Arc::clone(&self.requests)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for RecordingRequestProvider {
+    async fn stream(
+        &self,
+        request: &LlmRequest,
+    ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+        self.requests.lock().unwrap().push(request.messages.clone());
+        let events = self.responses.lock().unwrap().remove(0);
+        let (tx, rx) = mpsc::channel(64);
+        tokio::spawn(async move {
+            for event in events {
+                let _ = tx.send(event).await;
+            }
+        });
+        Ok(rx)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -140,6 +179,71 @@ async fn test_engine_tool_use_executes_and_continues() {
 
     assert_eq!(result.turns, 2);
     assert_eq!(result.text, "Done");
+}
+
+#[tokio::test]
+async fn test_engine_round_trips_thinking_signature_into_tool_followup_request() {
+    let provider = Arc::new(RecordingRequestProvider::new(vec![
+        vec![
+            LlmEvent::ThinkingDelta("need a tool".to_string()),
+            LlmEvent::ThinkingSignature("sig-123".to_string()),
+            LlmEvent::ToolUse {
+                id: "call_1".to_string(),
+                name: "mock_tool".to_string(),
+                input: json!({}),
+                extra: None,
+            },
+            LlmEvent::Done {
+                stop_reason: StopReason::ToolUse,
+                usage: TokenUsage::default(),
+            },
+        ],
+        vec![
+            LlmEvent::TextDelta("done".to_string()),
+            LlmEvent::Done {
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+            },
+        ],
+    ]));
+    let requests = provider.requests();
+
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(MockTool::new("mock_tool", "tool result", false)));
+
+    let mut engine = AgentEngine::new_with_provider(
+        provider,
+        test_config(),
+        registry,
+        silent_output(),
+        std::env::temp_dir(),
+    );
+
+    let result = engine
+        .run("use tool", "")
+        .await
+        .expect("engine should succeed");
+
+    assert_eq!(result.text, "done");
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+
+    let followup_messages = &requests[1];
+    let assistant_message = followup_messages
+        .iter()
+        .find(|message| message.role == Role::Assistant)
+        .expect("assistant message should be present");
+
+    match &assistant_message.content[0] {
+        ContentBlock::Thinking {
+            thinking,
+            signature,
+        } => {
+            assert_eq!(thinking, "need a tool");
+            assert_eq!(signature.as_deref(), Some("sig-123"));
+        }
+        other => panic!("expected thinking block, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -56,10 +56,19 @@ pub fn build_messages(messages: &[Message], compat: &ProviderCompat) -> Vec<Valu
                     "content": content,
                     "is_error": is_error
                 }),
-                ContentBlock::Thinking { thinking } => json!({
-                    "type": "thinking",
-                    "thinking": thinking
-                }),
+                ContentBlock::Thinking {
+                    thinking,
+                    signature,
+                } => {
+                    let mut value = json!({
+                        "type": "thinking",
+                        "thinking": thinking
+                    });
+                    if let Some(signature) = signature {
+                        value["signature"] = json!(signature);
+                    }
+                    value
+                }
             })
             .collect();
 
@@ -277,6 +286,7 @@ pub async fn process_sse_stream(
                             event,
                             LlmEvent::TextDelta(_)
                                 | LlmEvent::ThinkingDelta(_)
+                                | LlmEvent::ThinkingSignature(_)
                                 | LlmEvent::ToolUse { .. }
                         ) {
                             emitted_content = true;
@@ -342,6 +352,11 @@ pub fn parse_sse_data(event_type: &str, data: &str, state: &mut StreamState) -> 
                 "thinking_delta" => {
                     if let Some(thinking) = delta["thinking"].as_str() {
                         events.push(LlmEvent::ThinkingDelta(thinking.to_string()));
+                    }
+                }
+                "signature_delta" => {
+                    if let Some(signature) = delta["signature"].as_str() {
+                        events.push(LlmEvent::ThinkingSignature(signature.to_string()));
                     }
                 }
                 _ => {}
@@ -485,6 +500,7 @@ mod tests {
             Role::Assistant,
             vec![ContentBlock::Thinking {
                 thinking: "Let me think...".to_string(),
+                signature: None,
             }],
         )];
         let result = build_messages(&messages, &default_compat());
@@ -493,6 +509,24 @@ mod tests {
         let content = result[0]["content"].as_array().unwrap();
         assert_eq!(content[0]["type"], "thinking");
         assert_eq!(content[0]["thinking"], "Let me think...");
+    }
+
+    #[test]
+    fn test_build_messages_with_thinking_signature() {
+        let messages = vec![Message::new(
+            Role::Assistant,
+            vec![ContentBlock::Thinking {
+                thinking: "Let me think...".to_string(),
+                signature: Some("sig-123".to_string()),
+            }],
+        )];
+
+        let result = build_messages(&messages, &default_compat());
+
+        let content = result[0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[0]["thinking"], "Let me think...");
+        assert_eq!(content[0]["signature"], "sig-123");
     }
 
     // --- compat-driven behavior tests ---
@@ -754,6 +788,20 @@ mod tests {
         match &events[0] {
             LlmEvent::ThinkingDelta(t) => assert_eq!(t, "reasoning step"),
             _ => panic!("expected ThinkingDelta"),
+        }
+    }
+
+    #[test]
+    fn test_parse_anthropic_event_thinking_signature() {
+        let mut state = StreamState::new();
+        let data = r#"{"delta":{"type":"signature_delta","signature":"sig-123"}}"#;
+
+        let events = parse_sse_data("content_block_delta", data, &mut state);
+
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            LlmEvent::ThinkingSignature(signature) => assert_eq!(signature, "sig-123"),
+            _ => panic!("expected ThinkingSignature"),
         }
     }
 

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -351,6 +351,7 @@ async fn process_aws_event_stream(
                                     event,
                                     LlmEvent::TextDelta(_)
                                         | LlmEvent::ThinkingDelta(_)
+                                        | LlmEvent::ThinkingSignature(_)
                                         | LlmEvent::ToolUse { .. }
                                 ) {
                                     emitted_content = true;

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -116,7 +116,7 @@ impl OpenAIProvider {
                         .content
                         .iter()
                         .filter_map(|b| {
-                            if let ContentBlock::Thinking { thinking } = b {
+                            if let ContentBlock::Thinking { thinking, .. } = b {
                                 Some(thinking.as_str())
                             } else {
                                 None

--- a/crates/aion-types/src/llm.rs
+++ b/crates/aion-types/src/llm.rs
@@ -38,6 +38,8 @@ pub enum LlmEvent {
     },
     /// Thinking content (Anthropic only)
     ThinkingDelta(String),
+    /// Opaque provider signature for the current thinking block.
+    ThinkingSignature(String),
     /// Response complete
     Done {
         stop_reason: StopReason,
@@ -111,6 +113,16 @@ mod tests {
                 assert_eq!(input["cmd"], "ls");
             }
             _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn test_llm_event_thinking_signature_carries_content() {
+        let event = LlmEvent::ThinkingSignature("sig-123".to_string());
+
+        match event {
+            LlmEvent::ThinkingSignature(signature) => assert_eq!(signature, "sig-123"),
+            _ => panic!("expected ThinkingSignature"),
         }
     }
 }

--- a/crates/aion-types/src/message.rs
+++ b/crates/aion-types/src/message.rs
@@ -36,7 +36,12 @@ pub enum ContentBlock {
     /// Thinking / reasoning block. Serialized as `thinking` for Anthropic
     /// and as `reasoning_content` for OpenAI-compatible providers.
     #[serde(rename = "thinking")]
-    Thinking { thinking: String },
+    Thinking {
+        thinking: String,
+        /// Opaque provider signature required when round-tripping Anthropic thinking blocks.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
 }
 
 /// A message in the conversation
@@ -265,6 +270,40 @@ mod tests {
         assert_eq!(value["type"], "tool_result");
         assert_eq!(value["tool_use_id"], "call_1");
         assert_eq!(value["is_error"], false);
+    }
+
+    #[test]
+    fn thinking_block_deserializes_without_signature() {
+        let block: ContentBlock = serde_json::from_value(json!({
+            "type": "thinking",
+            "thinking": "reasoning"
+        }))
+        .unwrap();
+
+        match block {
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => {
+                assert_eq!(thinking, "reasoning");
+                assert!(signature.is_none());
+            }
+            _ => panic!("expected thinking block"),
+        }
+    }
+
+    #[test]
+    fn thinking_block_serializes_signature_when_present() {
+        let block = ContentBlock::Thinking {
+            thinking: "reasoning".to_string(),
+            signature: Some("sig-123".to_string()),
+        };
+
+        let value = serde_json::to_value(block).unwrap();
+
+        assert_eq!(value["type"], "thinking");
+        assert_eq!(value["thinking"], "reasoning");
+        assert_eq!(value["signature"], "sig-123");
     }
 
     // --- StopReason variants ---


### PR DESCRIPTION
## Summary
- Preserve Anthropic extended-thinking signatures from streaming events through stored assistant messages.
- Round-trip thinking signatures when building Anthropic and Bedrock follow-up requests after tool use.
- Add coverage for signature serialization, legacy thinking deserialization, and engine follow-up replay.

## Test Plan
- `just push origin issue-123632667-thinking-signature`