### PR TITLE
fix(aionrs): add platform context regressions

### DIFF
--- a/crates/aion-agent/src/context.rs
+++ b/crates/aion-agent/src/context.rs
@@ -164,9 +164,11 @@ pub fn build_system_prompt_with_shell(
              Working directory: {cwd}\n\
              Current date: {}\n\
              Operating system: {}\n\
+             Architecture: {}\n\
              {}",
             chrono::Local::now().format("%Y-%m-%d"),
             std::env::consts::OS,
+            std::env::consts::ARCH,
             shell_prompt
         )
     });
@@ -717,6 +719,10 @@ mod tests {
         );
 
         assert!(result.contains("Operating system:"));
+        assert!(
+            result.contains(&format!("Architecture: {}", std::env::consts::ARCH)),
+            "system prompt should include current CPU architecture"
+        );
         assert!(result.contains("Default shell: powershell"));
         assert!(result.contains(r"Shell path: C:\Program Files\PowerShell\7\pwsh.exe"));
         assert!(result.contains("Shell syntax: powershell"));

--- a/crates/aion-skills/src/shell_supplemental_tests.rs
+++ b/crates/aion-skills/src/shell_supplemental_tests.rs
@@ -238,6 +238,19 @@ async fn tc_4_5_cwd_used() {
     );
 }
 
+#[cfg(windows)]
+#[tokio::test]
+async fn tc_windows_skill_shell_powershell_stdout_preserved() {
+    let result = run("before !`Write-Output aion_skill_stdout_probe` after")
+        .await
+        .unwrap();
+
+    assert!(
+        result.contains("aion_skill_stdout_probe"),
+        "skill embedded shell stdout should be preserved, got: {result}"
+    );
+}
+
 // TC-4.6: 命令输出为空 → output 为空字符串
 #[tokio::test]
 async fn tc_4_6_empty_output() {

--- a/crates/aion-tools/src/exec_command.rs
+++ b/crates/aion-tools/src/exec_command.rs
@@ -191,4 +191,44 @@ mod tests {
             result.content
         );
     }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn execute_powershell_write_output_returns_stdout() {
+        let tool = ExecCommandTool::new(std::env::temp_dir());
+        let input = json!({
+            "cmd": "Write-Output aion_powershell_stdout_probe",
+            "shell": "powershell"
+        });
+
+        let result = tool.execute(input).await;
+
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert!(
+            result.content.contains("STDOUT:\n")
+                && result.content.contains("aion_powershell_stdout_probe"),
+            "PowerShell stdout should be preserved, got: {}",
+            result.content
+        );
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn execute_cmd_echo_returns_stdout() {
+        let tool = ExecCommandTool::new(std::env::temp_dir());
+        let input = json!({
+            "cmd": "echo aion_cmd_stdout_probe",
+            "shell": "cmd"
+        });
+
+        let result = tool.execute(input).await;
+
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert!(
+            result.content.contains("STDOUT:\n")
+                && result.content.contains("aion_cmd_stdout_probe"),
+            "cmd stdout should be preserved, got: {}",
+            result.content
+        );
+    }
 }


### PR DESCRIPTION
Linked Multica issue: [AIO-63](https://multica.ai/aionui-dev/issues/68bd1f3e-a931-422f-951f-424ae832c35b)
Related GitHub issue: https://github.com/iOfficeAI/AionUi/issues/3124

## Root Cause

Recent aionrs code already migrated the tool surface to `ExecCommand` and injects OS/shell details, but the system prompt still omitted CPU architecture and there was no Windows-specific regression coverage for stdout preservation in `ExecCommand` or skill-embedded shell execution.

## Changes

- Add current CPU architecture to the agent system prompt.
- Add Windows-only `ExecCommand` stdout regression tests for PowerShell and cmd.
- Add Windows-only skill embedded shell stdout coverage for PowerShell commands.
- Refresh `Cargo.lock` package versions to match the workspace `0.1.29` manifests after running cargo verification.

## Verification

- `cargo test -p aion-agent test_build_system_prompt_includes_shell_info -- --nocapture`
- `cargo test -p aion-tools -- --nocapture`
- `cargo test -p aion-skills tc_4_ -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -p aion-agent -p aion-tools -p aion-skills -- -D warnings`

Note: Windows-specific regression tests are guarded with `#[cfg(windows)]`; local verification was run on macOS, so those tests are compiled/executed by Windows CI or a Windows host.
