### PR TITLE
fix(mcp): tolerate CRLF line endings in SSE responses

### DIFF
--- a/crates/aion-mcp/src/transport/sse.rs
+++ b/crates/aion-mcp/src/transport/sse.rs
@@ -67,7 +67,10 @@ impl SseTransport {
         // Read initial events to get the endpoint URL
         while let Some(chunk) = bytes_stream.next().await {
             let chunk = chunk.map_err(|e| McpError::Transport(format!("SSE read error: {}", e)))?;
-            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            // Normalize CRLF to LF: Python `fastmcp` / MCP SDK servers emit
+            // `\r\n` separators (via `sse-starlette`), so event boundaries are
+            // `\r\n\r\n` and would not match a `\n\n` search otherwise.
+            buffer.push_str(&String::from_utf8_lossy(&chunk).replace('\r', ""));
 
             // Parse SSE events from buffer
             while let Some(event_end) = buffer.find("\n\n") {
@@ -102,7 +105,7 @@ impl SseTransport {
             let mut buf = buffer; // carry over remaining buffer
             while let Some(chunk) = bytes_stream.next().await {
                 let Ok(chunk) = chunk else { break };
-                buf.push_str(&String::from_utf8_lossy(&chunk));
+                buf.push_str(&String::from_utf8_lossy(&chunk).replace('\r', ""));
 
                 while let Some(event_end) = buf.find("\n\n") {
                     let event_block = buf[..event_end].to_string();

--- a/crates/aion-mcp/src/transport/streamable_http.rs
+++ b/crates/aion-mcp/src/transport/streamable_http.rs
@@ -107,25 +107,8 @@ impl StreamableHttpTransport {
             let chunk = chunk.map_err(|e| McpError::Transport(format!("SSE read error: {}", e)))?;
             buffer.push_str(&String::from_utf8_lossy(&chunk));
 
-            // Parse SSE events
-            while let Some(event_end) = buffer.find("\n\n") {
-                let event_block = buffer[..event_end].to_string();
-                buffer = buffer[event_end + 2..].to_string();
-
-                // Extract data lines
-                let mut data_lines = Vec::new();
-                for line in event_block.lines() {
-                    if let Some(value) = line.strip_prefix("data:") {
-                        data_lines.push(value.trim().to_string());
-                    }
-                }
-
-                let data = data_lines.join("\n");
-                if !data.is_empty()
-                    && let Ok(rpc_response) = serde_json::from_str::<JsonRpcResponse>(&data)
-                {
-                    return Ok(rpc_response);
-                }
+            if let Some(rpc_response) = extract_jsonrpc_from_sse_buffer(&buffer) {
+                return Ok(rpc_response);
             }
         }
 
@@ -133,6 +116,36 @@ impl StreamableHttpTransport {
             "SSE stream ended without JSON-RPC response".into(),
         ))
     }
+}
+
+/// Extract the first complete JSON-RPC response from an accumulated SSE buffer.
+///
+/// Tolerant of both LF (`\n`) and CRLF (`\r\n`) line endings: Node
+/// `@modelcontextprotocol/sdk` servers emit LF, while Python `fastmcp` / MCP
+/// SDK servers (via `sse-starlette`, whose default separator is CRLF) emit
+/// `\r\n\r\n` event terminators. Returns `None` until the buffer holds a
+/// complete event carrying a parseable JSON-RPC response.
+fn extract_jsonrpc_from_sse_buffer(buffer: &str) -> Option<JsonRpcResponse> {
+    // Normalize CRLF to LF so blank-line event boundaries are detectable.
+    let normalized = buffer.replace('\r', "");
+
+    for event_block in normalized.split("\n\n") {
+        let mut data_lines = Vec::new();
+        for line in event_block.lines() {
+            if let Some(value) = line.strip_prefix("data:") {
+                data_lines.push(value.trim());
+            }
+        }
+
+        let data = data_lines.join("\n");
+        if !data.is_empty()
+            && let Ok(rpc_response) = serde_json::from_str::<JsonRpcResponse>(&data)
+        {
+            return Some(rpc_response);
+        }
+    }
+
+    None
 }
 
 #[async_trait]
@@ -182,5 +195,46 @@ impl McpTransport for StreamableHttpTransport {
     async fn close(&self) -> Result<(), McpError> {
         // No persistent connection to close for HTTP
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Servers built on the MCP Python SDK / `fastmcp` use `sse-starlette`,
+    /// whose default SSE line separator is CRLF (`\r\n`). The event terminator
+    /// is therefore `\r\n\r\n`, which does not contain `\n\n`. The parser must
+    /// still recover the JSON-RPC response, otherwise such servers connect but
+    /// expose no tools to the model.
+    #[test]
+    fn extracts_jsonrpc_from_crlf_delimited_sse() {
+        let body = "event: message\r\ndata: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}\r\n\r\n";
+        let resp = extract_jsonrpc_from_sse_buffer(body).expect("should parse CRLF SSE");
+        assert_eq!(resp.id, Some(2));
+        assert!(resp.result.is_some());
+    }
+
+    /// Node `@modelcontextprotocol/sdk` servers emit LF-delimited SSE.
+    #[test]
+    fn extracts_jsonrpc_from_lf_delimited_sse() {
+        let body = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n";
+        let resp = extract_jsonrpc_from_sse_buffer(body).expect("should parse LF SSE");
+        assert_eq!(resp.id, Some(1));
+    }
+
+    /// Data split across multiple `data:` lines must be reassembled.
+    #[test]
+    fn reassembles_multiline_data() {
+        let body = "data: {\"jsonrpc\":\"2.0\",\r\ndata: \"id\":7,\"result\":{}}\r\n\r\n";
+        let resp = extract_jsonrpc_from_sse_buffer(body).expect("should join data lines");
+        assert_eq!(resp.id, Some(7));
+    }
+
+    /// Notifications (no `id`) and comment/ping lines must be skipped.
+    #[test]
+    fn returns_none_without_complete_response() {
+        let body = ": keep-alive\r\n\r\nevent: message\r\ndata: not-json\r\n\r\n";
+        assert!(extract_jsonrpc_from_sse_buffer(body).is_none());
     }
 }

--- a/crates/aion-mcp/tests/streamable_http_crlf.rs
+++ b/crates/aion-mcp/tests/streamable_http_crlf.rs
@@ -1,0 +1,118 @@
+//! End-to-end test: a stateful Streamable-HTTP MCP server that emits SSE with
+//! CRLF (`\r\n`) line endings, exactly like Python `fastmcp` / the MCP Python
+//! SDK do via `sse-starlette` (whose default separator is `\r\n`).
+//!
+//! Regression guard for the issue where such servers connect successfully but
+//! expose no tools to the model: the runtime SSE parser searched for `\n\n`
+//! event boundaries, which never appear in a `\r\n\r\n`-delimited stream.
+
+use std::collections::HashMap;
+
+use aion_mcp::config::{McpServerConfig, TransportType};
+use aion_mcp::manager::McpManager;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Build an HTTP response whose body is a single SSE `message` event using
+/// CRLF separators — byte-for-byte what `sse-starlette` produces.
+fn sse_response(json_rpc: &str, session_id: Option<&str>) -> Vec<u8> {
+    let body = format!("event: message\r\ndata: {json_rpc}\r\n\r\n");
+    let mut head = String::from("HTTP/1.1 200 OK\r\n");
+    head.push_str("Content-Type: text/event-stream\r\n");
+    if let Some(sid) = session_id {
+        head.push_str(&format!("mcp-session-id: {sid}\r\n"));
+    }
+    head.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    head.push_str("Connection: close\r\n\r\n");
+    head.push_str(&body);
+    head.into_bytes()
+}
+
+fn accepted_204() -> Vec<u8> {
+    b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_vec()
+}
+
+/// Read one full HTTP request (headers + Content-Length body) from the socket.
+async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 1024];
+    // Read headers.
+    let header_end = loop {
+        let n = socket.read(&mut tmp).await.unwrap();
+        if n == 0 {
+            return String::from_utf8_lossy(&buf).into_owned();
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            break pos + 4;
+        }
+    };
+    let headers = String::from_utf8_lossy(&buf[..header_end]).to_lowercase();
+    let content_length = headers
+        .lines()
+        .find_map(|l| l.strip_prefix("content-length:"))
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+    while buf.len() < header_end + content_length {
+        let n = socket.read(&mut tmp).await.unwrap();
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+    }
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+#[tokio::test]
+async fn stateful_fastmcp_style_server_exposes_tools() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://{addr}/mcp");
+
+    // Faithful stateful server: returns Mcp-Session-Id on initialize and serves
+    // every JSON-RPC response as CRLF-delimited SSE.
+    tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await;
+
+            let response = if request.contains("\"initialize\"") {
+                sse_response(
+                    r#"{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{"tools":{}},"serverInfo":{"name":"fastmcp-test","version":"1.0"}}}"#,
+                    Some("session-abc-123"),
+                )
+            } else if request.contains("\"tools/list\"") {
+                sse_response(
+                    r#"{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"meta_ads_query","description":"Query Meta ads","inputSchema":{"type":"object"}}]}}"#,
+                    Some("session-abc-123"),
+                )
+            } else {
+                // notifications/initialized and anything else
+                accepted_204()
+            };
+
+            socket.write_all(&response).await.unwrap();
+            let _ = socket.flush().await;
+        }
+    });
+
+    let config = McpServerConfig {
+        transport: TransportType::StreamableHttp,
+        command: None,
+        args: None,
+        env: None,
+        url: Some(url),
+        headers: None,
+        deferred: None,
+        startup_timeout_ms: Some(5_000),
+    };
+    let configs = HashMap::from([("meta-ads".to_string(), config)]);
+
+    let manager = McpManager::connect_all(&configs).await.unwrap();
+
+    assert!(
+        manager.has_tool_name("meta_ads_query"),
+        "stateful CRLF-SSE server tools must be discovered and exposed to the model"
+    );
+    assert_eq!(manager.tool_name_count("meta_ads_query"), 1);
+}


### PR DESCRIPTION
## Problem

Remote MCP servers added as `streamable_http` connect successfully (green status in AionUi's MCP Manager) but their tools never reach the model's tool catalog — **when the server is built on the Python MCP SDK / `fastmcp`**. Node `@modelcontextprotocol/sdk` servers work fine.

Reported downstream as [AionUi#3365](https://github.com/iOfficeAI/AionUi/issues/3365).

## Root cause

Not a stateful-vs-stateless issue — it's an SSE **line-ending** issue:

- `StreamableHttpTransport::parse_sse_response` and `SseTransport` split SSE events on `find("\n\n")` **without normalizing CRLF**.
- The MCP Python SDK / `fastmcp` serve SSE via [`sse-starlette`](https://github.com/sysid/sse-starlette), whose `DEFAULT_SEPARATOR = "\r\n"`. Their event terminator is therefore `\r\n\r\n`, which contains no `\n\n` substring → the event is never split → the JSON-RPC response is never extracted → `connect_server` fails (non-fatally, only a `warn!`) → the server's tools are silently dropped.
- Node `@modelcontextprotocol/sdk` emits `\n`-delimited SSE (`writeSSEEvent` uses `\n`), so it matched and worked.

This also explains the "green status but invisible" discrepancy: the AionCore connection test parses SSE via `.lines()` (CRLF-tolerant), so the test passes, while this runtime parser failed.

## Fix

Normalize CRLF → LF (`replace('\r', "")`) before scanning for event boundaries, in both transports. Extract the streamable-HTTP buffer scan into a pure `extract_jsonrpc_from_sse_buffer` helper.

## Tests

- Unit tests for `extract_jsonrpc_from_sse_buffer`: CRLF, LF, multi-line `data:`, and no-complete-response cases.
- End-to-end test (`tests/streamable_http_crlf.rs`): a real TCP server emitting **stateful CRLF SSE exactly like `sse-starlette`/`fastmcp`** (returns `Mcp-Session-Id`, `\r\n`-delimited events), driven through `McpManager::connect_all`, asserting tools are discovered. Verified this test **fails against the pre-fix parser** (connects, 0 tools — the exact reported symptom) and passes with the fix.

`cargo test -p aion-mcp` (46 unit + 1 e2e), `cargo fmt --check`, `cargo clippy --all-targets` all clean.