### PR TITLE
build: activate cargo-hakari workspace-hack for faster builds

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -1,0 +1,23 @@
+# This file contains settings for `cargo hakari`.
+# See https://docs.rs/cargo-hakari/latest/cargo_hakari/config for a full list of options.
+
+hakari-package = "workspace-hack"
+
+# Format for `workspace-hack = ...` lines in other Cargo.tomls.
+dep-format-version = "4"
+
+# Setting workspace.resolver = "2" or higher in the workspace Cargo.toml is HIGHLY recommended.
+# Hakari works much better with the v2 resolver.
+resolver = "2"
+
+# Add triples corresponding to platforms commonly used by developers here.
+# https://doc.rust-lang.org/rustc/platform-support.html
+platforms = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+
+# Write out exact versions rather than a semver range. (Defaults to false.)
+# exact-versions = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,16 @@ jobs:
         with:
           tool: cargo-audit
 
+      - name: Install cargo-hakari
+        if: matrix.os == 'ubuntu-latest'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hakari
+
+      - name: Verify workspace-hack is up to date
+        if: matrix.os == 'ubuntu-latest'
+        run: vx just hakari-verify
+
       - name: Check formatting
         run: vx just fmt-check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -237,6 +238,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4113,6 +4115,48 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
+dependencies = [
+ "bitflags 2.11.0",
+ "cc",
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "getrandom 0.2.17",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "log",
+ "memchr",
+ "mio",
+ "num-traits",
+ "percent-encoding",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "rustix",
+ "rustls",
+ "rustls-webpki",
+ "serde_core",
+ "slab",
+ "smallvec",
+ "subtle",
+ "syn",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "toml_datetime",
+ "toml_parser",
+ "tracing",
+ "tracing-core",
+ "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zeroize",
+]
 
 [[package]]
 name = "writeable"

--- a/crates/aion-agent/Cargo.toml
+++ b/crates/aion-agent/Cargo.toml
@@ -30,8 +30,7 @@ chrono.workspace      = true
 dirs.workspace        = true
 crossterm.workspace   = true
 is-terminal.workspace = true
-
-workspace-hack.workspace = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
 aion-mcp = { path = "../aion-mcp", features = ["test-utils"] }

--- a/crates/aion-cli/Cargo.toml
+++ b/crates/aion-cli/Cargo.toml
@@ -28,5 +28,4 @@ anyhow.workspace             = true
 clap.workspace               = true
 tracing.workspace            = true
 tracing-subscriber.workspace = true
-
-workspace-hack.workspace = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/crates/aion-compact/Cargo.toml
+++ b/crates/aion-compact/Cargo.toml
@@ -9,5 +9,6 @@ tracing.workspace = true
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]

--- a/crates/aion-config/Cargo.toml
+++ b/crates/aion-config/Cargo.toml
@@ -25,8 +25,7 @@ which.workspace      = true
 tracing.workspace            = true
 tracing-appender.workspace   = true
 tracing-subscriber.workspace = true
-
-workspace-hack.workspace = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
 wiremock.workspace            = true

--- a/crates/aion-mcp/Cargo.toml
+++ b/crates/aion-mcp/Cargo.toml
@@ -21,8 +21,7 @@ thiserror.workspace   = true
 anyhow.workspace      = true
 reqwest.workspace     = true
 futures.workspace     = true
-
-workspace-hack.workspace = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [features]
 test-utils = []

--- a/crates/aion-memory/Cargo.toml
+++ b/crates/aion-memory/Cargo.toml
@@ -14,8 +14,7 @@ serde.workspace      = true
 serde_yaml.workspace = true
 chrono.workspace     = true
 thiserror.workspace  = true
-
-workspace-hack.workspace = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
 tempfile.workspace    = true

--- a/crates/aion-protocol/Cargo.toml
+++ b/crates/aion-protocol/Cargo.toml
@@ -13,8 +13,7 @@ tracing.workspace    = true
 serde.workspace      = true
 serde_json.workspace = true
 tokio.workspace      = true
-
-workspace-hack.workspace = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/aion-providers/Cargo.toml
+++ b/crates/aion-providers/Cargo.toml
@@ -30,8 +30,7 @@ aws-config.workspace           = true
 aws-sdk-sts.workspace          = true
 
 tracing.workspace        = true
-
-workspace-hack.workspace = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
 wiremock.workspace   = true

--- a/crates/aion-skills/Cargo.toml
+++ b/crates/aion-skills/Cargo.toml
@@ -25,6 +25,7 @@ dirs.workspace         = true
 regex.workspace        = true
 notify.workspace       = true
 unicode-width.workspace = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/aion-tools/Cargo.toml
+++ b/crates/aion-tools/Cargo.toml
@@ -20,8 +20,7 @@ async-trait.workspace = true
 anyhow.workspace      = true
 glob.workspace        = true
 lru.workspace         = true
-
-workspace-hack.workspace = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/aion-types/Cargo.toml
+++ b/crates/aion-types/Cargo.toml
@@ -11,3 +11,4 @@ serde.workspace       = true
 serde_json.workspace  = true
 async-trait.workspace = true
 chrono.workspace      = true
+workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -7,8 +7,110 @@
 [package]
 name = "workspace-hack"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
-# Hakari-managed dependency list will be placed here after first `cargo hakari generate`.
+### BEGIN HAKARI SECTION
 [dependencies]
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-core = { version = "0.3" }
+futures-sink = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+hyper = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2", "server"] }
+memchr = { version = "2" }
+num-traits = { version = "0.2", default-features = false, features = ["i128", "std"] }
+percent-encoding = { version = "2" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-syntax = { version = "0.8" }
+serde_core = { version = "1", default-features = false, features = ["alloc", "result", "std"] }
+slab = { version = "0.4" }
+smallvec = { version = "1", default-features = false, features = ["const_new"] }
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+tokio = { version = "1", features = ["full", "test-util"] }
+toml_datetime = { version = "1", features = ["serde"] }
+toml_parser = { version = "1" }
+tracing = { version = "0.1" }
+tracing-core = { version = "0.1" }
+winnow = { version = "1" }
+
+[build-dependencies]
+memchr = { version = "2" }
+proc-macro2 = { version = "1" }
+quote = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-syntax = { version = "0.8" }
+serde_core = { version = "1", default-features = false, features = ["alloc", "result", "std"] }
+syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+toml_datetime = { version = "1", features = ["serde"] }
+toml_parser = { version = "1" }
+winnow = { version = "1" }
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+bitflags = { version = "2", default-features = false, features = ["std"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+log = { version = "0.4", default-features = false, features = ["std"] }
+mio = { version = "1", features = ["net", "os-ext"] }
+rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+rustls = { version = "0.23", default-features = false, features = ["prefer-post-quantum", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+subtle = { version = "2" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+zeroize = { version = "1", features = ["derive"] }
+
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+cc = { version = "1", default-features = false, features = ["parallel"] }
+
+[target.x86_64-apple-darwin.dependencies]
+bitflags = { version = "2", default-features = false, features = ["std"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+log = { version = "0.4", default-features = false, features = ["std"] }
+mio = { version = "1", features = ["net", "os-ext"] }
+rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+rustls = { version = "0.23", default-features = false, features = ["prefer-post-quantum", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+subtle = { version = "2" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+zeroize = { version = "1", features = ["derive"] }
+
+[target.x86_64-apple-darwin.build-dependencies]
+cc = { version = "1", default-features = false, features = ["parallel"] }
+
+[target.aarch64-apple-darwin.dependencies]
+bitflags = { version = "2", default-features = false, features = ["std"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+log = { version = "0.4", default-features = false, features = ["std"] }
+mio = { version = "1", features = ["net", "os-ext"] }
+rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+rustls = { version = "0.23", default-features = false, features = ["prefer-post-quantum", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+subtle = { version = "2" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+zeroize = { version = "1", features = ["derive"] }
+
+[target.aarch64-apple-darwin.build-dependencies]
+cc = { version = "1", default-features = false, features = ["parallel"] }
+
+[target.x86_64-pc-windows-msvc.dependencies]
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+rustls = { version = "0.23", default-features = false, features = ["prefer-post-quantum", "ring", "std", "tls12"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+subtle = { version = "2" }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_SystemInformation"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+zeroize = { version = "1", features = ["derive"] }
+
+[target.x86_64-pc-windows-msvc.build-dependencies]
+cc = { version = "1", default-features = false, features = ["parallel"] }
+
+### END HAKARI SECTION


### PR DESCRIPTION
## What

The `workspace-hack` crate and the `hakari-generate` / `hakari-verify` recipes in `justfile` were scaffolded long ago, but `cargo hakari` was never actually run. As a result:

- `workspace-hack/Cargo.toml` had an **empty** dependency list
- `.config/hakari.toml` (required config) **did not exist**
- The crate was wired into 9 of 11 member crates as a no-op dependency

So it provided **zero** build-speed benefit — pure dead scaffolding.

This PR actually activates it.

## Changes

- **Add `.config/hakari.toml`** targeting the four CI/release platforms (linux-gnu, x86_64/aarch64 darwin, windows-msvc)
- **Generate** the `workspace-hack` dependency list via `cargo hakari generate` — unifies feature flags across the workspace so shared deps (tokio, hyper, rustls, regex, etc.) compile once
- **`cargo hakari manage-deps`** wired `workspace-hack` into *every* member crate — `aion-types` and `aion-compact` were previously missing it
- Align `workspace-hack` edition with the workspace (`2021` → `2024`)
- **Add a `hakari-verify` step to CI** (ubuntu only) so the generated list cannot silently drift out of date as dependencies change

## How it speeds up builds

`cargo-hakari` declares the union of all features each shared dependency needs in one central crate. Cargo's feature unification then compiles each dependency a single time instead of once per distinct feature set, cutting redundant rebuilds.

## Verification

- `cargo build` ✅
- `cargo fmt --all` ✅
- `cargo hakari verify` → `workspace-hack works correctly` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)