### PR TITLE
fix(shell): use runner for hooks and skills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "regex",
  "serde",
@@ -79,9 +79,10 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aion-compact",
+ "aion-process",
  "aion-types",
  "anyhow",
  "chrono",
@@ -105,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -125,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aion-config",
  "chrono",
@@ -141,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "libc",
  "tokio",
@@ -151,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aion-types",
  "rstest",
@@ -164,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -193,10 +194,11 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aion-config",
  "aion-mcp",
+ "aion-process",
  "aion-types",
  "anyhow",
  "async-trait",
@@ -221,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -242,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-config/Cargo.toml
+++ b/crates/aion-config/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 aion-types.workspace   = true
 aion-compact.workspace = true
+aion-process.workspace = true
 
 serde.workspace      = true
 serde_json.workspace = true

--- a/crates/aion-config/src/hooks.rs
+++ b/crates/aion-config/src/hooks.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use aion_process::CommandRunner;
 use serde::{Deserialize, Serialize};
 
 use crate::shell::{default_shell, shell_command_builder};
@@ -222,6 +223,18 @@ struct HookResult {
     output: String,
 }
 
+fn combine_output(stdout: &[u8], stderr: &[u8]) -> String {
+    let stdout = String::from_utf8_lossy(stdout).to_string();
+    let stderr = String::from_utf8_lossy(stderr).to_string();
+    if stderr.is_empty() {
+        stdout
+    } else if stdout.is_empty() {
+        stderr
+    } else {
+        format!("{}\n{}", stdout, stderr)
+    }
+}
+
 async fn run_hook_command(
     command: &str,
     env_vars: &HashMap<String, String>,
@@ -240,37 +253,26 @@ async fn run_hook_command(
         "hook executing"
     );
 
-    // TODO(aio-168): migrate hook command execution to aion-process so timeout
-    // results can preserve partial stdout/stderr. Keep behavior unchanged in
-    // this patch because hooks have their own blocking semantics.
-    let result = tokio::time::timeout(timeout, async {
-        shell_command_builder(&shell, &interpolated, false)
-            .envs(env_vars)
-            .current_dir(cwd)
-            .output()
-            .await
-    })
-    .await;
+    let mut command_builder = shell_command_builder(&shell, &interpolated, false);
+    command_builder.envs(env_vars).current_dir(cwd);
 
-    match result {
-        Ok(Ok(output)) => {
-            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            let combined = if stderr.is_empty() {
-                stdout
-            } else if stdout.is_empty() {
-                stderr
-            } else {
-                format!("{}\n{}", stdout, stderr)
-            };
-
+    match CommandRunner::new(command_builder)
+        .timeout(timeout)
+        .run()
+        .await
+    {
+        Ok(result) if result.timed_out => Err(HookError::Timeout {
+            timeout_ms,
+            output: combine_output(&result.stdout, &result.stderr),
+        }),
+        Ok(result) => {
+            let exit_code = result.exit_code.unwrap_or(-1);
             Ok(HookResult {
-                success: output.status.success(),
-                output: combined,
+                success: exit_code == 0,
+                output: combine_output(&result.stdout, &result.stderr),
             })
         }
-        Ok(Err(e)) => Err(HookError::ExecutionFailed(e.to_string())),
-        Err(_) => Err(HookError::Timeout(timeout_ms)),
+        Err(e) => Err(HookError::ExecutionFailed(e.to_string())),
     }
 }
 
@@ -280,13 +282,14 @@ pub enum HookError {
     Blocked { hook_name: String, output: String },
     #[error("Hook execution failed: {0}")]
     ExecutionFailed(String),
-    #[error("Hook timed out after {0}ms")]
-    Timeout(u64),
+    #[error("Hook timed out after {timeout_ms}ms\n{output}")]
+    Timeout { timeout_ms: u64, output: String },
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shell::{ShellKind, default_shell};
     use serde_json::json;
 
     fn make_hook(name: &str, tool_match: Vec<&str>, command: &str) -> HookDef {
@@ -296,6 +299,18 @@ mod tests {
             file_match: vec![],
             command: command.to_string(),
             timeout_ms: 30_000,
+        }
+    }
+
+    fn slow_stdout_command(message: &str) -> String {
+        match default_shell().kind {
+            ShellKind::PowerShell => {
+                format!("Write-Output {message}; Start-Sleep -Seconds 5")
+            }
+            ShellKind::Cmd => format!("echo {message} & ping -n 6 127.0.0.1 > nul"),
+            ShellKind::Bash | ShellKind::Zsh | ShellKind::Sh => {
+                format!("printf '{message}\\n'; sleep 5")
+            }
         }
     }
 
@@ -395,7 +410,28 @@ mod tests {
         let engine = HookEngine::new(config, std::env::temp_dir());
         let result = engine.run_pre_tool_use("Read", &json!({})).await;
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), HookError::Timeout(_)));
+        assert!(matches!(result.unwrap_err(), HookError::Timeout { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_hook_timeout_preserves_stdout_emitted_before_timeout() {
+        let command = slow_stdout_command("hook_stdout_before_timeout");
+
+        let result = run_hook_command(&command, &HashMap::new(), 100, &std::env::temp_dir()).await;
+
+        let err = match result {
+            Ok(_) => panic!("hook command should time out"),
+            Err(err) => err,
+        };
+        let message = err.to_string();
+        assert!(
+            message.contains("Hook timed out after 100ms"),
+            "timeout message missing: {message}"
+        );
+        assert!(
+            message.contains("hook_stdout_before_timeout"),
+            "stdout emitted before timeout should be preserved, got: {message}"
+        );
     }
 }
 

--- a/crates/aion-config/src/hooks.rs
+++ b/crates/aion-config/src/hooks.rs
@@ -416,8 +416,10 @@ mod tests {
     #[tokio::test]
     async fn test_hook_timeout_preserves_stdout_emitted_before_timeout() {
         let command = slow_stdout_command("hook_stdout_before_timeout");
+        let timeout_ms = if cfg!(windows) { 1500 } else { 100 };
 
-        let result = run_hook_command(&command, &HashMap::new(), 100, &std::env::temp_dir()).await;
+        let result =
+            run_hook_command(&command, &HashMap::new(), timeout_ms, &std::env::temp_dir()).await;
 
         let err = match result {
             Ok(_) => panic!("hook command should time out"),
@@ -425,7 +427,7 @@ mod tests {
         };
         let message = err.to_string();
         assert!(
-            message.contains("Hook timed out after 100ms"),
+            message.contains(&format!("Hook timed out after {timeout_ms}ms")),
             "timeout message missing: {message}"
         );
         assert!(

--- a/crates/aion-skills/Cargo.toml
+++ b/crates/aion-skills/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 aion-types.workspace   = true
 aion-config.workspace  = true
 aion-mcp.workspace     = true
+aion-process.workspace = true
 
 tracing.workspace      = true
 serde.workspace        = true

--- a/crates/aion-skills/src/shell.rs
+++ b/crates/aion-skills/src/shell.rs
@@ -2,6 +2,8 @@ use futures::future::join_all;
 use regex::Regex;
 use std::sync::OnceLock;
 
+use aion_process::{CommandRunner, DEFAULT_TIMEOUT};
+
 use crate::types::LoadedFrom;
 
 // ---------------------------------------------------------------------------
@@ -190,30 +192,44 @@ fn extract_shell_matches(content: &str) -> Vec<ShellMatch> {
 /// Execute a single shell command and return its combined stdout/stderr output.
 async fn execute_command(command: &str, cwd: &str) -> Result<String, ShellExecutionError> {
     let shell = aion_config::shell::default_shell();
-    // TODO(aio-168): migrate embedded skill shell execution to aion-process so
-    // future timeout handling can preserve partial stdout/stderr. Keep behavior
-    // unchanged in this patch because skill shell output formatting differs
-    // from ExecCommand tool output.
-    let output = aion_config::shell::shell_command_builder(&shell, command, false)
-        .current_dir(cwd)
-        .output()
+    let mut command_builder = aion_config::shell::shell_command_builder(&shell, command, false);
+    command_builder.current_dir(cwd);
+
+    let result = CommandRunner::new(command_builder)
+        .run()
         .await
         .map_err(|e| ShellExecutionError::CommandFailed {
             pattern: command.to_owned(),
             output: e.to_string(),
         })?;
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    let formatted = format_output(stdout.trim_end(), stderr.trim_end());
 
-    if !output.status.success() && stdout.is_empty() && stderr.is_empty() {
+    if result.timed_out {
+        let output = if formatted.is_empty() {
+            format!("timed out after {}ms", DEFAULT_TIMEOUT.as_millis())
+        } else {
+            format!(
+                "timed out after {}ms\n{formatted}",
+                DEFAULT_TIMEOUT.as_millis()
+            )
+        };
         return Err(ShellExecutionError::CommandFailed {
             pattern: command.to_owned(),
-            output: format!("exit code {}", output.status.code().unwrap_or(-1)),
+            output,
         });
     }
 
-    Ok(format_output(stdout.trim_end(), stderr.trim_end()))
+    if result.exit_code != Some(0) && stdout.is_empty() && stderr.is_empty() {
+        return Err(ShellExecutionError::CommandFailed {
+            pattern: command.to_owned(),
+            output: format!("exit code {}", result.exit_code.unwrap_or(-1)),
+        });
+    }
+
+    Ok(formatted)
 }
 
 /// Format stdout and stderr into a single string.

--- a/crates/aion-skills/src/shell_supplemental_tests.rs
+++ b/crates/aion-skills/src/shell_supplemental_tests.rs
@@ -281,6 +281,21 @@ async fn tc_4_7_nonexistent_command_returns_err() {
     }
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn tc_4_8_returns_before_background_process_closes_inherited_pipe() {
+    let content = "!`printf 'skill_background_parent_done\\n'; sleep 5 &`";
+    let result = tokio::time::timeout(std::time::Duration::from_millis(700), run(content)).await;
+
+    let output = result
+        .expect("skill shell command should not wait for the background child")
+        .expect("skill shell command should succeed");
+    assert!(
+        output.contains("skill_background_parent_done"),
+        "stdout emitted by shell parent should be preserved, got: {output}"
+    );
+}
+
 // -----------------------------------------------------------------------
 // TC-5: format_output
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Route hook shell execution through `aion_process::CommandRunner` so timeout results preserve buffered stdout/stderr.
- Route embedded skill shell execution through `CommandRunner` to avoid inherited pipe hangs and keep timeout output visible.
- Remove the remaining AIO-168 TODOs and add regression coverage for hooks and skill shell behavior.

## Test Plan
- [x] `cargo test -p aion-config -p aion-skills -- --nocapture`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p aion-config -p aion-skills --all-targets -- -D warnings`
- [x] `just push -u origin boii/fix/aio-168-shell-runner` (includes `cargo fix`, workspace clippy/fmt, and `cargo nextest run --workspace --profile default`: 1971 passed, 2 skipped)