### PR TITLE
refactor(provider): Provider contract baseline for wire dialects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "chrono",
  "dirs",
  "futures",
+ "insta",
  "jsonwebtoken",
  "reqwest",
  "serde",
@@ -939,6 +940,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,7 +1283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1889,6 +1907,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,7 +1943,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2445,7 +2476,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2687,7 +2718,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3010,6 +3041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,7 +3155,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3779,7 +3816,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,4 @@ tempfile    = "3"
 mockall     = "0.14"
 rstest      = "0.26"
 serial_test = "3"
+insta       = { version = "1", features = ["json"] }

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -1478,9 +1478,11 @@ mod tests_set_config {
     #[test]
     fn set_config_all_fields_at_once() {
         let compat = aion_config::compat::ProviderCompat {
-            supports_thinking: Some(true),
-            supports_effort: Some(true),
-            effort_levels: Some(vec!["low".into()]),
+            reasoning: aion_config::compat::ReasoningCompat {
+                supports_thinking: Some(true),
+                supports_effort: Some(true),
+                effort_levels: Some(vec!["low".into()]),
+            },
             ..Default::default()
         };
         let mut engine = make_engine_with_compat("old-model", compat);
@@ -1535,13 +1537,16 @@ mod tests_set_config {
     #[test]
     fn set_config_effort_valid_values() {
         let compat = aion_config::compat::ProviderCompat {
-            supports_effort: Some(true),
-            effort_levels: Some(vec![
-                "low".into(),
-                "medium".into(),
-                "high".into(),
-                "max".into(),
-            ]),
+            reasoning: aion_config::compat::ReasoningCompat {
+                supports_effort: Some(true),
+                effort_levels: Some(vec![
+                    "low".into(),
+                    "medium".into(),
+                    "high".into(),
+                    "max".into(),
+                ]),
+                ..Default::default()
+            },
             ..Default::default()
         };
         for value in ["low", "medium", "high", "max"] {

--- a/crates/aion-config/src/compat.rs
+++ b/crates/aion-config/src/compat.rs
@@ -5,20 +5,37 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Provider-level compatibility settings.
-/// Each field is Option — None means "use provider-type default".
+/// Each child struct is flattened so on-disk TOML remains backward-compatible.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ProviderCompat {
+    #[serde(flatten)]
+    pub transport: TransportCompat,
+    #[serde(flatten)]
+    pub messages: MessageCompat,
+    #[serde(flatten)]
+    pub tools: ToolCompat,
+    #[serde(flatten)]
+    pub schema: SchemaCompat,
+    #[serde(flatten)]
+    pub reasoning: ReasoningCompat,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct TransportCompat {
     /// Field name for max tokens in request body.
     /// Default: "max_tokens" for all providers.
     pub max_tokens_field: Option<String>,
 
+    /// Custom API path appended to base_url for chat completions.
+    /// Default: "/v1/chat/completions" for OpenAI provider.
+    pub api_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct MessageCompat {
     /// Merge consecutive assistant messages (text concat + tool_calls merge).
     /// Default: true for openai.
     pub merge_assistant_messages: Option<bool>,
-
-    /// Remove tool_use blocks that have no corresponding tool_result.
-    /// Default: true for openai.
-    pub clean_orphan_tool_calls: Option<bool>,
 
     /// Remove tool_result blocks that have no corresponding tool_use.
     /// Default: true for provider families that support tool results.
@@ -28,12 +45,6 @@ pub struct ProviderCompat {
     /// Default: true for openai.
     pub dedup_tool_results: Option<bool>,
 
-    /// Downgrade malformed tool_calls (empty function name) to text in the
-    /// outgoing request, and drop their paired tool results. History is never
-    /// mutated; only the projected request body is affected.
-    /// Default: true for all providers.
-    pub sanitize_malformed_tool_calls: Option<bool>,
-
     /// Ensure messages alternate user/assistant (insert filler if needed).
     /// Default: true for anthropic/bedrock/vertex.
     pub ensure_alternation: Option<bool>,
@@ -42,48 +53,126 @@ pub struct ProviderCompat {
     /// Default: true for anthropic/bedrock/vertex.
     pub merge_same_role: Option<bool>,
 
-    /// Sanitize JSON schemas for strict providers (remove additionalProperties, etc.).
-    /// Default: true for bedrock.
-    pub sanitize_schema: Option<bool>,
-
     /// Text patterns to strip from message history before sending.
     /// Default: empty.
     pub strip_patterns: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct ToolCompat {
+    /// Remove tool_use blocks that have no corresponding tool_result.
+    /// Default: true for openai.
+    pub clean_orphan_tool_calls: Option<bool>,
+
+    /// Downgrade malformed tool_calls in the projected request body.
+    /// Default: true for all providers.
+    pub sanitize_malformed_tool_calls: Option<bool>,
 
     /// Auto-generate tool IDs when missing.
     /// Default: true for anthropic/bedrock/vertex.
     pub auto_tool_id: Option<bool>,
+}
 
-    /// Custom API path appended to base_url for chat completions.
-    /// Default: "/v1/chat/completions" for OpenAI provider.
-    /// Override to "/chat/completions" for providers like Gemini that include
-    /// version prefix in the base URL itself.
-    pub api_path: Option<String>,
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SchemaCompat {
+    /// Sanitize JSON schemas for strict providers.
+    /// Default: true for bedrock.
+    pub sanitize_schema: Option<bool>,
+}
 
-    /// Whether this provider supports extended thinking (Anthropic-style).
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct ReasoningCompat {
+    /// Whether this provider supports extended thinking.
     /// Default: true for anthropic/bedrock/vertex, false for openai.
     pub supports_thinking: Option<bool>,
 
-    /// Whether this provider supports reasoning_effort (OpenAI-style).
+    /// Whether this provider supports reasoning_effort.
     /// Default: false for anthropic/bedrock/vertex, true for openai.
     pub supports_effort: Option<bool>,
 
-    /// Available effort levels for this provider (e.g., ["low", "medium", "high"]).
+    /// Available effort levels for this provider.
     /// Only meaningful when supports_effort is true.
     pub effort_levels: Option<Vec<String>>,
+}
+
+impl TransportCompat {
+    fn merge(defaults: Self, user: Self) -> Self {
+        Self {
+            max_tokens_field: user.max_tokens_field.or(defaults.max_tokens_field),
+            api_path: user.api_path.or(defaults.api_path),
+        }
+    }
+}
+
+impl MessageCompat {
+    fn merge(defaults: Self, user: Self) -> Self {
+        Self {
+            merge_assistant_messages: user
+                .merge_assistant_messages
+                .or(defaults.merge_assistant_messages),
+            clean_orphan_tool_results: user
+                .clean_orphan_tool_results
+                .or(defaults.clean_orphan_tool_results),
+            dedup_tool_results: user.dedup_tool_results.or(defaults.dedup_tool_results),
+            ensure_alternation: user.ensure_alternation.or(defaults.ensure_alternation),
+            merge_same_role: user.merge_same_role.or(defaults.merge_same_role),
+            strip_patterns: user.strip_patterns.or(defaults.strip_patterns),
+        }
+    }
+}
+
+impl ToolCompat {
+    fn merge(defaults: Self, user: Self) -> Self {
+        Self {
+            clean_orphan_tool_calls: user
+                .clean_orphan_tool_calls
+                .or(defaults.clean_orphan_tool_calls),
+            sanitize_malformed_tool_calls: user
+                .sanitize_malformed_tool_calls
+                .or(defaults.sanitize_malformed_tool_calls),
+            auto_tool_id: user.auto_tool_id.or(defaults.auto_tool_id),
+        }
+    }
+}
+
+impl SchemaCompat {
+    fn merge(defaults: Self, user: Self) -> Self {
+        Self {
+            sanitize_schema: user.sanitize_schema.or(defaults.sanitize_schema),
+        }
+    }
+}
+
+impl ReasoningCompat {
+    fn merge(defaults: Self, user: Self) -> Self {
+        Self {
+            supports_thinking: user.supports_thinking.or(defaults.supports_thinking),
+            supports_effort: user.supports_effort.or(defaults.supports_effort),
+            effort_levels: user.effort_levels.or(defaults.effort_levels),
+        }
+    }
 }
 
 impl ProviderCompat {
     /// Defaults for Anthropic-family providers (Anthropic, Vertex)
     pub fn anthropic_defaults() -> Self {
         Self {
-            ensure_alternation: Some(true),
-            merge_same_role: Some(true),
-            auto_tool_id: Some(true),
-            supports_thinking: Some(true),
-            supports_effort: Some(false),
-            sanitize_malformed_tool_calls: Some(true),
-            clean_orphan_tool_results: Some(true),
+            messages: MessageCompat {
+                ensure_alternation: Some(true),
+                merge_same_role: Some(true),
+                clean_orphan_tool_results: Some(true),
+                ..Default::default()
+            },
+            tools: ToolCompat {
+                auto_tool_id: Some(true),
+                sanitize_malformed_tool_calls: Some(true),
+                ..Default::default()
+            },
+            reasoning: ReasoningCompat {
+                supports_thinking: Some(true),
+                supports_effort: Some(false),
+                ..Default::default()
+            },
             ..Default::default()
         }
     }
@@ -91,14 +180,25 @@ impl ProviderCompat {
     /// Defaults for Bedrock (Anthropic + schema sanitization)
     pub fn bedrock_defaults() -> Self {
         Self {
-            ensure_alternation: Some(true),
-            merge_same_role: Some(true),
-            auto_tool_id: Some(true),
-            sanitize_schema: Some(true),
-            supports_thinking: Some(true),
-            supports_effort: Some(false),
-            sanitize_malformed_tool_calls: Some(true),
-            clean_orphan_tool_results: Some(true),
+            messages: MessageCompat {
+                ensure_alternation: Some(true),
+                merge_same_role: Some(true),
+                clean_orphan_tool_results: Some(true),
+                ..Default::default()
+            },
+            tools: ToolCompat {
+                auto_tool_id: Some(true),
+                sanitize_malformed_tool_calls: Some(true),
+                ..Default::default()
+            },
+            schema: SchemaCompat {
+                sanitize_schema: Some(true),
+            },
+            reasoning: ReasoningCompat {
+                supports_thinking: Some(true),
+                supports_effort: Some(false),
+                ..Default::default()
+            },
             ..Default::default()
         }
     }
@@ -106,16 +206,26 @@ impl ProviderCompat {
     /// Defaults for OpenAI-compatible providers
     pub fn openai_defaults() -> Self {
         Self {
-            max_tokens_field: Some("max_tokens".into()),
-            merge_assistant_messages: Some(true),
-            clean_orphan_tool_calls: Some(true),
-            clean_orphan_tool_results: Some(true),
-            dedup_tool_results: Some(true),
-            auto_tool_id: Some(true),
-            supports_thinking: Some(false),
-            supports_effort: Some(true),
-            effort_levels: Some(vec!["low".into(), "medium".into(), "high".into()]),
-            sanitize_malformed_tool_calls: Some(true),
+            transport: TransportCompat {
+                max_tokens_field: Some("max_tokens".into()),
+                ..Default::default()
+            },
+            messages: MessageCompat {
+                merge_assistant_messages: Some(true),
+                clean_orphan_tool_results: Some(true),
+                dedup_tool_results: Some(true),
+                ..Default::default()
+            },
+            tools: ToolCompat {
+                clean_orphan_tool_calls: Some(true),
+                sanitize_malformed_tool_calls: Some(true),
+                auto_tool_id: Some(true),
+            },
+            reasoning: ReasoningCompat {
+                supports_thinking: Some(false),
+                supports_effort: Some(true),
+                effort_levels: Some(vec!["low".into(), "medium".into(), "high".into()]),
+            },
             ..Default::default()
         }
     }
@@ -123,84 +233,76 @@ impl ProviderCompat {
     /// Merge user config over defaults (user wins on non-None fields)
     pub fn merge(defaults: Self, user: Self) -> Self {
         Self {
-            max_tokens_field: user.max_tokens_field.or(defaults.max_tokens_field),
-            merge_assistant_messages: user
-                .merge_assistant_messages
-                .or(defaults.merge_assistant_messages),
-            clean_orphan_tool_calls: user
-                .clean_orphan_tool_calls
-                .or(defaults.clean_orphan_tool_calls),
-            clean_orphan_tool_results: user
-                .clean_orphan_tool_results
-                .or(defaults.clean_orphan_tool_results),
-            dedup_tool_results: user.dedup_tool_results.or(defaults.dedup_tool_results),
-            sanitize_malformed_tool_calls: user
-                .sanitize_malformed_tool_calls
-                .or(defaults.sanitize_malformed_tool_calls),
-            ensure_alternation: user.ensure_alternation.or(defaults.ensure_alternation),
-            merge_same_role: user.merge_same_role.or(defaults.merge_same_role),
-            sanitize_schema: user.sanitize_schema.or(defaults.sanitize_schema),
-            strip_patterns: user.strip_patterns.or(defaults.strip_patterns),
-            auto_tool_id: user.auto_tool_id.or(defaults.auto_tool_id),
-            api_path: user.api_path.or(defaults.api_path),
-            supports_thinking: user.supports_thinking.or(defaults.supports_thinking),
-            supports_effort: user.supports_effort.or(defaults.supports_effort),
-            effort_levels: user.effort_levels.or(defaults.effort_levels),
+            transport: TransportCompat::merge(defaults.transport, user.transport),
+            messages: MessageCompat::merge(defaults.messages, user.messages),
+            tools: ToolCompat::merge(defaults.tools, user.tools),
+            schema: SchemaCompat::merge(defaults.schema, user.schema),
+            reasoning: ReasoningCompat::merge(defaults.reasoning, user.reasoning),
         }
     }
 
     // --- Resolved accessors (Option<bool> → bool with false default) ---
 
+    pub fn max_tokens_field(&self) -> &str {
+        self.transport
+            .max_tokens_field
+            .as_deref()
+            .unwrap_or("max_tokens")
+    }
+
     pub fn merge_assistant_messages(&self) -> bool {
-        self.merge_assistant_messages.unwrap_or(false)
+        self.messages.merge_assistant_messages.unwrap_or(false)
     }
 
     pub fn clean_orphan_tool_calls(&self) -> bool {
-        self.clean_orphan_tool_calls.unwrap_or(false)
+        self.tools.clean_orphan_tool_calls.unwrap_or(false)
     }
 
     pub fn clean_orphan_tool_results(&self) -> bool {
-        self.clean_orphan_tool_results.unwrap_or(false)
+        self.messages.clean_orphan_tool_results.unwrap_or(false)
     }
 
     pub fn dedup_tool_results(&self) -> bool {
-        self.dedup_tool_results.unwrap_or(false)
+        self.messages.dedup_tool_results.unwrap_or(false)
     }
 
     pub fn sanitize_malformed_tool_calls(&self) -> bool {
-        self.sanitize_malformed_tool_calls.unwrap_or(false)
+        self.tools.sanitize_malformed_tool_calls.unwrap_or(false)
     }
 
     pub fn ensure_alternation(&self) -> bool {
-        self.ensure_alternation.unwrap_or(false)
+        self.messages.ensure_alternation.unwrap_or(false)
     }
 
     pub fn merge_same_role(&self) -> bool {
-        self.merge_same_role.unwrap_or(false)
+        self.messages.merge_same_role.unwrap_or(false)
     }
 
     pub fn sanitize_schema(&self) -> bool {
-        self.sanitize_schema.unwrap_or(false)
+        self.schema.sanitize_schema.unwrap_or(false)
     }
 
     pub fn auto_tool_id(&self) -> bool {
-        self.auto_tool_id.unwrap_or(false)
+        self.tools.auto_tool_id.unwrap_or(false)
     }
 
     pub fn api_path(&self) -> &str {
-        self.api_path.as_deref().unwrap_or("/v1/chat/completions")
+        self.transport
+            .api_path
+            .as_deref()
+            .unwrap_or("/v1/chat/completions")
     }
 
     pub fn supports_thinking(&self) -> bool {
-        self.supports_thinking.unwrap_or(false)
+        self.reasoning.supports_thinking.unwrap_or(false)
     }
 
     pub fn supports_effort(&self) -> bool {
-        self.supports_effort.unwrap_or(false)
+        self.reasoning.supports_effort.unwrap_or(false)
     }
 
     pub fn effort_levels(&self) -> &[String] {
-        self.effort_levels.as_deref().unwrap_or(&[])
+        self.reasoning.effort_levels.as_deref().unwrap_or(&[])
     }
 }
 
@@ -265,6 +367,191 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn test_flattened_compat_deserializes_legacy_toml_keys() {
+        let toml_str = r#"
+max_tokens_field = "max_completion_tokens"
+api_path = "/chat/completions"
+merge_assistant_messages = true
+clean_orphan_tool_results = false
+dedup_tool_results = true
+clean_orphan_tool_calls = true
+sanitize_malformed_tool_calls = false
+ensure_alternation = true
+merge_same_role = true
+sanitize_schema = true
+strip_patterns = ["__REASONING__"]
+auto_tool_id = true
+supports_thinking = true
+supports_effort = false
+effort_levels = ["low", "medium"]
+"#;
+
+        let compat: ProviderCompat = toml::from_str(toml_str).unwrap();
+
+        assert_eq!(
+            compat.transport.max_tokens_field.as_deref(),
+            Some("max_completion_tokens")
+        );
+        assert_eq!(
+            compat.transport.api_path.as_deref(),
+            Some("/chat/completions")
+        );
+        assert_eq!(compat.messages.merge_assistant_messages, Some(true));
+        assert_eq!(compat.messages.clean_orphan_tool_results, Some(false));
+        assert_eq!(compat.messages.dedup_tool_results, Some(true));
+        assert_eq!(compat.messages.ensure_alternation, Some(true));
+        assert_eq!(compat.messages.merge_same_role, Some(true));
+        assert_eq!(
+            compat.messages.strip_patterns,
+            Some(vec!["__REASONING__".to_string()])
+        );
+        assert_eq!(compat.tools.clean_orphan_tool_calls, Some(true));
+        assert_eq!(compat.tools.sanitize_malformed_tool_calls, Some(false));
+        assert_eq!(compat.tools.auto_tool_id, Some(true));
+        assert_eq!(compat.schema.sanitize_schema, Some(true));
+        assert_eq!(compat.reasoning.supports_thinking, Some(true));
+        assert_eq!(compat.reasoning.supports_effort, Some(false));
+        assert_eq!(
+            compat.reasoning.effort_levels,
+            Some(vec!["low".to_string(), "medium".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_flattened_compat_serializes_to_legacy_toml_keys() {
+        let compat = ProviderCompat {
+            transport: TransportCompat {
+                max_tokens_field: Some("max_completion_tokens".to_string()),
+                api_path: Some("/chat/completions".to_string()),
+            },
+            messages: MessageCompat {
+                merge_assistant_messages: Some(true),
+                clean_orphan_tool_results: Some(false),
+                dedup_tool_results: Some(true),
+                ensure_alternation: Some(true),
+                merge_same_role: Some(true),
+                strip_patterns: Some(vec!["__REASONING__".to_string()]),
+            },
+            tools: ToolCompat {
+                clean_orphan_tool_calls: Some(true),
+                sanitize_malformed_tool_calls: Some(false),
+                auto_tool_id: Some(true),
+            },
+            schema: SchemaCompat {
+                sanitize_schema: Some(true),
+            },
+            reasoning: ReasoningCompat {
+                supports_thinking: Some(true),
+                supports_effort: Some(false),
+                effort_levels: Some(vec!["low".to_string(), "medium".to_string()]),
+            },
+        };
+
+        let toml = toml::to_string(&compat).unwrap();
+
+        assert!(toml.contains("max_tokens_field = \"max_completion_tokens\""));
+        assert!(toml.contains("api_path = \"/chat/completions\""));
+        assert!(toml.contains("merge_assistant_messages = true"));
+        assert!(toml.contains("clean_orphan_tool_results = false"));
+        assert!(toml.contains("dedup_tool_results = true"));
+        assert!(toml.contains("clean_orphan_tool_calls = true"));
+        assert!(toml.contains("sanitize_malformed_tool_calls = false"));
+        assert!(toml.contains("ensure_alternation = true"));
+        assert!(toml.contains("merge_same_role = true"));
+        assert!(toml.contains("sanitize_schema = true"));
+        assert!(toml.contains("strip_patterns = [\"__REASONING__\"]"));
+        assert!(toml.contains("auto_tool_id = true"));
+        assert!(toml.contains("supports_thinking = true"));
+        assert!(toml.contains("supports_effort = false"));
+        assert!(toml.contains("effort_levels = [\"low\", \"medium\"]"));
+        assert!(!toml.contains("[transport]"));
+        assert!(!toml.contains("[messages]"));
+        assert!(!toml.contains("[tools]"));
+        assert!(!toml.contains("[schema]"));
+        assert!(!toml.contains("[reasoning]"));
+    }
+
+    #[test]
+    fn test_domain_merge_preserves_user_overrides_and_defaults() {
+        let defaults = ProviderCompat::openai_defaults();
+        let user = ProviderCompat {
+            transport: TransportCompat {
+                max_tokens_field: Some("max_completion_tokens".to_string()),
+                api_path: Some("/chat/completions".to_string()),
+            },
+            messages: MessageCompat {
+                merge_assistant_messages: Some(false),
+                clean_orphan_tool_results: Some(false),
+                dedup_tool_results: None,
+                ensure_alternation: None,
+                merge_same_role: None,
+                strip_patterns: Some(vec!["strip-me".to_string()]),
+            },
+            tools: ToolCompat {
+                clean_orphan_tool_calls: Some(false),
+                sanitize_malformed_tool_calls: Some(false),
+                auto_tool_id: Some(false),
+            },
+            schema: SchemaCompat {
+                sanitize_schema: Some(true),
+            },
+            reasoning: ReasoningCompat {
+                supports_thinking: Some(true),
+                supports_effort: None,
+                effort_levels: Some(vec!["custom".to_string()]),
+            },
+        };
+
+        let merged = ProviderCompat::merge(defaults, user);
+
+        assert_eq!(
+            merged.transport.max_tokens_field.as_deref(),
+            Some("max_completion_tokens")
+        );
+        assert_eq!(
+            merged.transport.api_path.as_deref(),
+            Some("/chat/completions")
+        );
+        assert!(!merged.merge_assistant_messages());
+        assert!(!merged.clean_orphan_tool_calls());
+        assert!(!merged.clean_orphan_tool_results());
+        assert!(merged.dedup_tool_results());
+        assert!(!merged.sanitize_malformed_tool_calls());
+        assert!(merged.sanitize_schema());
+        assert!(!merged.auto_tool_id());
+        assert!(merged.supports_thinking());
+        assert!(merged.supports_effort());
+        assert_eq!(merged.effort_levels(), &["custom"]);
+        assert_eq!(
+            merged.messages.strip_patterns,
+            Some(vec!["strip-me".to_string()])
+        );
+        assert_eq!(merged.reasoning.supports_thinking, Some(true));
+        assert_eq!(merged.reasoning.supports_effort, Some(true));
+        assert_eq!(
+            merged.reasoning.effort_levels,
+            Some(vec!["custom".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_domain_merge_empty_user_keeps_all_defaults() {
+        let merged = ProviderCompat::merge(
+            ProviderCompat::anthropic_defaults(),
+            ProviderCompat::default(),
+        );
+
+        assert!(merged.ensure_alternation());
+        assert!(merged.merge_same_role());
+        assert!(merged.auto_tool_id());
+        assert!(merged.sanitize_malformed_tool_calls());
+        assert!(merged.clean_orphan_tool_results());
+        assert!(merged.supports_thinking());
+        assert!(!merged.supports_effort());
+        assert!(merged.effort_levels().is_empty());
+    }
+
+    #[test]
     fn test_anthropic_defaults() {
         let compat = ProviderCompat::anthropic_defaults();
         assert!(compat.ensure_alternation());
@@ -291,22 +578,31 @@ mod tests {
         assert!(compat.clean_orphan_tool_calls());
         assert!(compat.clean_orphan_tool_results());
         assert!(compat.dedup_tool_results());
-        assert_eq!(compat.max_tokens_field.as_deref(), Some("max_tokens"));
+        assert_eq!(
+            compat.transport.max_tokens_field.as_deref(),
+            Some("max_tokens")
+        );
         assert!(!compat.ensure_alternation());
     }
 
     #[test]
     fn test_clean_orphan_tool_results_defaults() {
         assert_eq!(
-            ProviderCompat::openai_defaults().clean_orphan_tool_results,
+            ProviderCompat::openai_defaults()
+                .messages
+                .clean_orphan_tool_results,
             Some(true)
         );
         assert_eq!(
-            ProviderCompat::anthropic_defaults().clean_orphan_tool_results,
+            ProviderCompat::anthropic_defaults()
+                .messages
+                .clean_orphan_tool_results,
             Some(true)
         );
         assert_eq!(
-            ProviderCompat::bedrock_defaults().clean_orphan_tool_results,
+            ProviderCompat::bedrock_defaults()
+                .messages
+                .clean_orphan_tool_results,
             Some(true)
         );
     }
@@ -321,14 +617,20 @@ mod tests {
     fn test_merge_user_overrides_defaults() {
         let defaults = ProviderCompat::openai_defaults();
         let user = ProviderCompat {
-            max_tokens_field: Some("max_completion_tokens".into()),
-            merge_assistant_messages: Some(false),
+            transport: TransportCompat {
+                max_tokens_field: Some("max_completion_tokens".into()),
+                ..Default::default()
+            },
+            messages: MessageCompat {
+                merge_assistant_messages: Some(false),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
         let merged = ProviderCompat::merge(defaults, user);
         assert_eq!(
-            merged.max_tokens_field.as_deref(),
+            merged.transport.max_tokens_field.as_deref(),
             Some("max_completion_tokens")
         );
         assert!(!merged.merge_assistant_messages());
@@ -342,12 +644,15 @@ mod tests {
     fn test_merge_clean_orphan_tool_results_user_overrides() {
         let defaults = ProviderCompat::openai_defaults();
         let user = ProviderCompat {
-            clean_orphan_tool_results: Some(false),
+            messages: MessageCompat {
+                clean_orphan_tool_results: Some(false),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
         let merged = ProviderCompat::merge(defaults, user);
-        assert_eq!(merged.clean_orphan_tool_results, Some(false));
+        assert_eq!(merged.messages.clean_orphan_tool_results, Some(false));
         assert!(!merged.clean_orphan_tool_results());
     }
 
@@ -421,18 +726,18 @@ mod tests {
     #[test]
     fn test_anthropic_defaults_capability_fields() {
         let compat = ProviderCompat::anthropic_defaults();
-        assert_eq!(compat.supports_thinking, Some(true));
-        assert_eq!(compat.supports_effort, Some(false));
-        assert!(compat.effort_levels.is_none());
+        assert_eq!(compat.reasoning.supports_thinking, Some(true));
+        assert_eq!(compat.reasoning.supports_effort, Some(false));
+        assert!(compat.reasoning.effort_levels.is_none());
     }
 
     #[test]
     fn test_openai_defaults_capability_fields() {
         let compat = ProviderCompat::openai_defaults();
-        assert_eq!(compat.supports_thinking, Some(false));
-        assert_eq!(compat.supports_effort, Some(true));
+        assert_eq!(compat.reasoning.supports_thinking, Some(false));
+        assert_eq!(compat.reasoning.supports_effort, Some(true));
         assert_eq!(
-            compat.effort_levels,
+            compat.reasoning.effort_levels,
             Some(vec![
                 "low".to_string(),
                 "medium".to_string(),
@@ -444,20 +749,23 @@ mod tests {
     #[test]
     fn test_bedrock_defaults_capability_fields() {
         let compat = ProviderCompat::bedrock_defaults();
-        assert_eq!(compat.supports_thinking, Some(true));
-        assert_eq!(compat.supports_effort, Some(false));
+        assert_eq!(compat.reasoning.supports_thinking, Some(true));
+        assert_eq!(compat.reasoning.supports_effort, Some(false));
     }
 
     #[test]
     fn test_merge_capability_fields_user_overrides() {
         let defaults = ProviderCompat::openai_defaults();
         let user = ProviderCompat {
-            supports_thinking: Some(true),
+            reasoning: ReasoningCompat {
+                supports_thinking: Some(true),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let merged = ProviderCompat::merge(defaults, user);
-        assert_eq!(merged.supports_thinking, Some(true));
-        assert_eq!(merged.supports_effort, Some(true));
+        assert_eq!(merged.reasoning.supports_thinking, Some(true));
+        assert_eq!(merged.reasoning.supports_effort, Some(true));
     }
 
     #[test]
@@ -477,15 +785,21 @@ mod tests {
     #[test]
     fn test_defaults_enable_sanitize_malformed_tool_calls() {
         assert_eq!(
-            ProviderCompat::openai_defaults().sanitize_malformed_tool_calls,
+            ProviderCompat::openai_defaults()
+                .tools
+                .sanitize_malformed_tool_calls,
             Some(true)
         );
         assert_eq!(
-            ProviderCompat::anthropic_defaults().sanitize_malformed_tool_calls,
+            ProviderCompat::anthropic_defaults()
+                .tools
+                .sanitize_malformed_tool_calls,
             Some(true)
         );
         assert_eq!(
-            ProviderCompat::bedrock_defaults().sanitize_malformed_tool_calls,
+            ProviderCompat::bedrock_defaults()
+                .tools
+                .sanitize_malformed_tool_calls,
             Some(true)
         );
     }
@@ -495,12 +809,15 @@ mod tests {
     fn test_merge_preserves_sanitize_field() {
         let defaults = ProviderCompat::openai_defaults();
         let user = ProviderCompat {
-            sanitize_malformed_tool_calls: Some(false),
+            tools: ToolCompat {
+                sanitize_malformed_tool_calls: Some(false),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let merged = ProviderCompat::merge(defaults, user);
-        assert_eq!(merged.sanitize_malformed_tool_calls, Some(false)); // user wins
-        assert_eq!(merged.clean_orphan_tool_calls, Some(true)); // default preserved
+        assert_eq!(merged.tools.sanitize_malformed_tool_calls, Some(false)); // user wins
+        assert_eq!(merged.tools.clean_orphan_tool_calls, Some(true)); // default preserved
     }
 
     #[test]
@@ -513,15 +830,15 @@ strip_patterns = ["__REASONING__"]
 "#;
         let compat: ProviderCompat = toml::from_str(toml_str).unwrap();
         assert_eq!(
-            compat.max_tokens_field.as_deref(),
+            compat.transport.max_tokens_field.as_deref(),
             Some("max_completion_tokens")
         );
-        assert_eq!(compat.merge_assistant_messages, Some(true));
-        assert_eq!(compat.clean_orphan_tool_results, Some(false));
+        assert_eq!(compat.messages.merge_assistant_messages, Some(true));
+        assert_eq!(compat.messages.clean_orphan_tool_results, Some(false));
         assert_eq!(
-            compat.strip_patterns,
+            compat.messages.strip_patterns,
             Some(vec!["__REASONING__".to_string()])
         );
-        assert!(compat.clean_orphan_tool_calls.is_none());
+        assert!(compat.tools.clean_orphan_tool_calls.is_none());
     }
 }

--- a/crates/aion-config/src/config.rs
+++ b/crates/aion-config/src/config.rs
@@ -1050,6 +1050,9 @@ max_sessions = 20                # auto-cleanup oldest
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compat::{
+        MessageCompat, ReasoningCompat, SchemaCompat, ToolCompat, TransportCompat,
+    };
 
     // -------------------------------------------------------------------------
     // parse_builtin_provider tests
@@ -1704,16 +1707,25 @@ base_url = "https://my-service.example.com/api/openai"
     fn test_merge_provider_configs_compat_merges_both() {
         let base = ProviderConfig {
             compat: Some(ProviderCompat {
-                merge_assistant_messages: Some(true),
-                clean_orphan_tool_calls: Some(true),
+                messages: MessageCompat {
+                    merge_assistant_messages: Some(true),
+                    ..Default::default()
+                },
+                tools: ToolCompat {
+                    clean_orphan_tool_calls: Some(true),
+                    ..Default::default()
+                },
                 ..Default::default()
             }),
             ..Default::default()
         };
         let overlay = ProviderConfig {
             compat: Some(ProviderCompat {
-                merge_assistant_messages: Some(false), // override base
-                dedup_tool_results: Some(true),        // new field
+                messages: MessageCompat {
+                    merge_assistant_messages: Some(false), // override base
+                    dedup_tool_results: Some(true),        // new field
+                    ..Default::default()
+                },
                 ..Default::default()
             }),
             ..Default::default()
@@ -1722,11 +1734,77 @@ base_url = "https://my-service.example.com/api/openai"
         let merged = merge_provider_configs(base, overlay);
         let compat = merged.compat.unwrap();
         // overlay wins
-        assert_eq!(compat.merge_assistant_messages, Some(false));
+        assert_eq!(compat.messages.merge_assistant_messages, Some(false));
         // base preserved
-        assert_eq!(compat.clean_orphan_tool_calls, Some(true));
+        assert_eq!(compat.tools.clean_orphan_tool_calls, Some(true));
         // overlay adds new
-        assert_eq!(compat.dedup_tool_results, Some(true));
+        assert_eq!(compat.messages.dedup_tool_results, Some(true));
+    }
+
+    #[test]
+    fn test_merge_provider_configs_compat_merges_across_domains() {
+        let base = ProviderConfig {
+            compat: Some(ProviderCompat {
+                transport: TransportCompat {
+                    max_tokens_field: Some("max_tokens".to_string()),
+                    ..Default::default()
+                },
+                messages: MessageCompat {
+                    merge_assistant_messages: Some(true),
+                    clean_orphan_tool_results: Some(true),
+                    ..Default::default()
+                },
+                tools: ToolCompat {
+                    auto_tool_id: Some(true),
+                    ..Default::default()
+                },
+                reasoning: ReasoningCompat {
+                    supports_effort: Some(true),
+                    effort_levels: Some(vec!["low".to_string(), "high".to_string()]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let overlay = ProviderConfig {
+            compat: Some(ProviderCompat {
+                transport: TransportCompat {
+                    api_path: Some("/chat/completions".to_string()),
+                    ..Default::default()
+                },
+                messages: MessageCompat {
+                    merge_assistant_messages: Some(false),
+                    ..Default::default()
+                },
+                schema: SchemaCompat {
+                    sanitize_schema: Some(true),
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let merged = merge_provider_configs(base, overlay);
+        let compat = merged.compat.unwrap();
+
+        assert_eq!(
+            compat.transport.max_tokens_field.as_deref(),
+            Some("max_tokens")
+        );
+        assert_eq!(
+            compat.transport.api_path.as_deref(),
+            Some("/chat/completions")
+        );
+        assert_eq!(compat.messages.merge_assistant_messages, Some(false));
+        assert_eq!(compat.messages.clean_orphan_tool_results, Some(true));
+        assert_eq!(compat.tools.auto_tool_id, Some(true));
+        assert_eq!(compat.schema.sanitize_schema, Some(true));
+        assert_eq!(compat.reasoning.supports_effort, Some(true));
+        assert_eq!(
+            compat.reasoning.effort_levels,
+            Some(vec!["low".to_string(), "high".to_string()])
+        );
     }
 
     #[test]
@@ -2137,6 +2215,71 @@ max_tool_call_failure_turns = 4
         let config = Config::resolve(&cli_args).unwrap();
         assert_eq!(config.max_tool_call_malformed_turns, Some(0));
         assert_eq!(config.max_tool_call_failure_turns, Some(0));
+    }
+
+    #[test]
+    fn test_config_resolve_loads_flat_provider_compat_after_domain_split() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".aionrs.toml"),
+            r#"
+[default]
+provider = "openai"
+model = "test-model"
+
+[providers.openai]
+api_key = "test-key"
+base_url = "https://example.test/v1"
+
+[providers.openai.compat]
+max_tokens_field = "max_completion_tokens"
+api_path = "/chat/completions"
+merge_assistant_messages = false
+clean_orphan_tool_calls = false
+clean_orphan_tool_results = false
+dedup_tool_results = true
+sanitize_malformed_tool_calls = false
+strip_patterns = ["__REASONING__"]
+auto_tool_id = false
+supports_thinking = true
+supports_effort = true
+effort_levels = ["low", "medium"]
+"#,
+        )
+        .unwrap();
+
+        let cli = CliArgs {
+            provider: None,
+            api_key: None,
+            base_url: None,
+            model: None,
+            max_tokens: None,
+            max_turns: None,
+            max_tool_call_malformed_turns: None,
+            max_tool_call_failure_turns: None,
+            system_prompt: None,
+            profile: None,
+            auto_approve: false,
+            project_dir: Some(tmp.path().to_path_buf()),
+        };
+
+        let config = Config::resolve(&cli).unwrap();
+
+        assert_eq!(config.compat.max_tokens_field(), "max_completion_tokens");
+        assert_eq!(config.compat.api_path(), "/chat/completions");
+        assert!(!config.compat.merge_assistant_messages());
+        assert!(!config.compat.clean_orphan_tool_calls());
+        assert!(!config.compat.clean_orphan_tool_results());
+        assert!(config.compat.dedup_tool_results());
+        assert!(!config.compat.sanitize_malformed_tool_calls());
+        assert!(!config.compat.auto_tool_id());
+        assert!(config.compat.supports_thinking());
+        assert!(config.compat.supports_effort());
+        assert_eq!(config.compat.effort_levels(), &["low", "medium"]);
+        assert_eq!(
+            config.compat.messages.strip_patterns,
+            Some(vec!["__REASONING__".to_string()])
+        );
     }
 
     #[test]

--- a/crates/aion-providers/Cargo.toml
+++ b/crates/aion-providers/Cargo.toml
@@ -36,3 +36,4 @@ workspace-hack.workspace = true
 [dev-dependencies]
 wiremock.workspace   = true
 tokio-test.workspace = true
+insta.workspace      = true

--- a/crates/aion-providers/src/anthropic.rs
+++ b/crates/aion-providers/src/anthropic.rs
@@ -177,3 +177,119 @@ impl LlmProvider for AnthropicProvider {
         Ok(rx)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aion_types::message::{ContentBlock, Message, Role};
+    use aion_types::tool::ToolDef;
+    use serde_json::json;
+
+    fn anthropic_golden(cache: bool) -> AnthropicProvider {
+        AnthropicProvider::new(
+            "test-key",
+            "https://example.test",
+            ProviderCompat::anthropic_defaults(),
+        )
+        .with_cache(cache)
+    }
+
+    fn areq(
+        messages: Vec<Message>,
+        tools: Vec<ToolDef>,
+        thinking: Option<ThinkingConfig>,
+    ) -> LlmRequest {
+        LlmRequest {
+            model: "test-model".to_string(),
+            system: "You are a test assistant.".to_string(),
+            messages,
+            tools,
+            max_tokens: 8192,
+            thinking,
+            reasoning_effort: None,
+        }
+    }
+
+    fn atools() -> Vec<ToolDef> {
+        vec![
+            ToolDef {
+                name: "read".to_string(),
+                description: "Read".to_string(),
+                input_schema: json!({"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}),
+                deferred: false,
+            },
+            ToolDef {
+                name: "list".to_string(),
+                description: "List".to_string(),
+                input_schema: json!({"type":"object","properties":{}}),
+                deferred: false,
+            },
+        ]
+    }
+
+    #[test]
+    fn golden_anthropic_basic() {
+        let p = anthropic_golden(false);
+        let r = areq(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            )],
+            vec![],
+            None,
+        );
+        insta::assert_json_snapshot!("anthropic_basic", p.build_request_body(&r));
+    }
+
+    #[test]
+    fn golden_anthropic_with_tools_no_cache() {
+        let p = anthropic_golden(false);
+        let r = areq(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "go".to_string(),
+                }],
+            )],
+            atools(),
+            None,
+        );
+        insta::assert_json_snapshot!("anthropic_with_tools_no_cache", p.build_request_body(&r));
+    }
+
+    #[test]
+    fn golden_anthropic_with_cache() {
+        let p = anthropic_golden(true);
+        let r = areq(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "go".to_string(),
+                }],
+            )],
+            atools(),
+            None,
+        );
+        insta::assert_json_snapshot!("anthropic_with_cache", p.build_request_body(&r));
+    }
+
+    #[test]
+    fn golden_anthropic_with_thinking() {
+        let p = anthropic_golden(false);
+        let r = areq(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "q".to_string(),
+                }],
+            )],
+            vec![],
+            Some(ThinkingConfig::Enabled {
+                budget_tokens: 4096,
+            }),
+        );
+        insta::assert_json_snapshot!("anthropic_with_thinking", p.build_request_body(&r));
+    }
+}

--- a/crates/aion-providers/src/anthropic.rs
+++ b/crates/aion-providers/src/anthropic.rs
@@ -1,11 +1,13 @@
 use async_trait::async_trait;
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
-use serde_json::{Value, json};
+use serde_json::Value;
 use tokio::sync::mpsc;
 
-use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
+use aion_types::llm::{LlmEvent, LlmRequest};
 
 use super::anthropic_shared;
+use crate::projector::{AnthropicWireProjector, WireParams};
+use crate::stream_runner::{RetryPolicy, run_stream};
 use crate::{LlmProvider, ProviderError};
 use aion_config::compat::ProviderCompat;
 
@@ -50,43 +52,48 @@ impl AnthropicProvider {
     }
 
     fn build_request_body(&self, request: &LlmRequest) -> Value {
-        // Build system prompt with optional cache_control
-        let system = if self.cache_enabled {
-            json!([{
-                "type": "text",
-                "text": &request.system,
-                "cache_control": { "type": "ephemeral" }
-            }])
-        } else {
-            json!(&request.system)
-        };
+        AnthropicWireProjector::project(
+            request,
+            &self.compat,
+            WireParams {
+                anthropic_version: None,
+                include_model_in_body: true,
+                include_stream: true,
+                cache_enabled: self.cache_enabled,
+                sanitize_schema: false,
+            },
+        )
+    }
+}
 
-        let mut body = json!({
-            "model": request.model,
-            "max_tokens": request.max_tokens,
-            "system": system,
-            "messages": anthropic_shared::build_messages(&request.messages, &self.compat),
-            "stream": true
-        });
+async fn send_anthropic_stream_request(
+    client: reqwest::Client,
+    url: String,
+    headers: HeaderMap,
+    body: Value,
+) -> Result<reqwest::Response, ProviderError> {
+    let response = client
+        .post(&url)
+        .headers(headers)
+        .json(&body)
+        .send()
+        .await?;
 
-        if !request.tools.is_empty() {
-            let mut tools = anthropic_shared::build_tools(&request.tools);
-            // Mark last tool with cache_control to cache the entire tools block
-            if let Some(last) = tools.last_mut().filter(|_| self.cache_enabled) {
-                last["cache_control"] = json!({ "type": "ephemeral" });
-            }
-            body["tools"] = json!(tools);
-        }
-
-        if let Some(ThinkingConfig::Enabled { budget_tokens }) = &request.thinking {
-            body["thinking"] = json!({
-                "type": "enabled",
-                "budget_tokens": budget_tokens
+    let status = response.status();
+    if !status.is_success() {
+        let body_text = response.text().await.unwrap_or_default();
+        if status.as_u16() == 429 {
+            return Err(ProviderError::RateLimited {
+                retry_after_ms: 5000,
             });
         }
-
-        body
+        return Err(ProviderError::Api {
+            status: status.as_u16(),
+            message: body_text,
+        });
     }
+
+    Ok(response)
 }
 
 #[async_trait]
@@ -100,87 +107,36 @@ impl LlmProvider for AnthropicProvider {
 
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
 
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.build_headers()?)
-            .json(&body)
-            .send()
-            .await?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body_text = response.text().await.unwrap_or_default();
-            if status.as_u16() == 429 {
-                return Err(ProviderError::RateLimited {
-                    retry_after_ms: 5000,
-                });
-            }
-            return Err(ProviderError::Api {
-                status: status.as_u16(),
-                message: body_text,
-            });
-        }
-
-        let (tx, rx) = mpsc::channel(64);
         let client = self.client.clone();
         let headers = self.build_headers()?;
-        let url_clone = url.clone();
-
-        tokio::spawn(async move {
-            match anthropic_shared::process_sse_stream(response, &tx).await {
-                anthropic_shared::StreamOutcome::Ok => {}
-                anthropic_shared::StreamOutcome::FailedPartial(e) => {
-                    let _ = tx.send(LlmEvent::Error(e.to_string())).await;
-                }
-                anthropic_shared::StreamOutcome::FailedEmpty(e) => {
-                    if e.is_retryable() {
-                        let mut backoff = std::time::Duration::from_secs(1);
-                        let mut final_err = Some(e);
-                        for attempt in 1..=crate::retry::MAX_STREAM_RETRIES {
-                            backoff = crate::retry::backoff_sleep(attempt, backoff).await;
-                            match crate::retry::send_and_check(&client, &url_clone, &headers, &body)
-                                .await
-                            {
-                                Ok(resp) => {
-                                    let outcome =
-                                        anthropic_shared::process_sse_stream(resp, &tx).await;
-                                    match crate::retry::evaluate_outcome(outcome, attempt) {
-                                        Ok(None) => {
-                                            final_err = None;
-                                            break;
-                                        }
-                                        Ok(Some(e)) => {
-                                            final_err = Some(e);
-                                            break;
-                                        }
-                                        Err(_) => continue,
-                                    }
-                                }
-                                Err(e) if attempt == crate::retry::MAX_STREAM_RETRIES => {
-                                    final_err = Some(e);
-                                    break;
-                                }
-                                Err(_) => continue,
-                            }
-                        }
-                        if let Some(err) = final_err {
-                            let _ = tx.send(LlmEvent::Error(err.to_string())).await;
-                        }
-                    } else {
-                        let _ = tx.send(LlmEvent::Error(e.to_string())).await;
-                    }
-                }
+        let send = {
+            let url = url.clone();
+            let body = body.clone();
+            move || {
+                let client = client.clone();
+                let url = url.clone();
+                let headers = headers.clone();
+                let body = body.clone();
+                async move { send_anthropic_stream_request(client, url, headers, body).await }
             }
-        });
+        };
+        let process = move |response, tx| async move {
+            anthropic_shared::process_sse_stream(response, &tx).await
+        };
 
-        Ok(rx)
+        run_stream(
+            send,
+            process,
+            RetryPolicy::new(crate::retry::MAX_STREAM_RETRIES, false, true),
+        )
+        .await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aion_types::llm::ThinkingConfig;
     use aion_types::message::{ContentBlock, Message, Role};
     use aion_types::tool::ToolDef;
     use serde_json::json;

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -10,6 +10,9 @@ use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 use aion_types::tool::{ToolDef, truncate_deferred_description};
 
 use crate::error::ProviderError;
+use crate::framing::SseBlockFramer;
+use crate::parser::{AnthropicParser, ResponseParser};
+pub(crate) use crate::stream_runner::StreamOutcome;
 use crate::tool_call_sanitize::{DroppedToolCallReason, format_dropped_tool_call};
 use aion_config::compat::ProviderCompat;
 
@@ -311,24 +314,16 @@ impl StreamState {
     }
 }
 
-/// Outcome of SSE stream processing — distinguishes "failed before any content
-/// was emitted" (safe to retry) from "failed after partial content" (not safe).
-pub enum StreamOutcome {
-    Ok,
-    FailedEmpty(ProviderError),
-    FailedPartial(ProviderError),
-}
-
 /// Process the SSE stream from an Anthropic-compatible API
-pub async fn process_sse_stream(
+pub(crate) async fn process_sse_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
 ) -> StreamOutcome {
     use futures::StreamExt;
 
-    let mut state = StreamState::new();
-    let mut buffer = String::new();
-    let mut current_event_type = String::new();
+    let parser = AnthropicParser;
+    let mut state = parser.new_state();
+    let mut framer = SseBlockFramer::default();
     let mut stream = response.bytes_stream();
     let mut emitted_content = false;
 
@@ -345,35 +340,29 @@ pub async fn process_sse_stream(
             }
         };
         let text = String::from_utf8_lossy(&chunk);
-        buffer.push_str(&text);
-
-        // Process complete SSE events (separated by double newlines)
-        while let Some(event_end) = buffer.find("\n\n") {
-            let event_block = buffer[..event_end].to_string();
-            buffer = buffer[event_end + 2..].to_string();
-
-            for line in event_block.lines() {
-                if let Some(event_type) = line.strip_prefix("event: ") {
-                    current_event_type = event_type.to_string();
-                } else if let Some(data) = line.strip_prefix("data: ") {
-                    tracing::debug!(target: "aion_providers", chunk = %data, "sse chunk received");
-                    let events = parse_sse_data(&current_event_type, data, &mut state);
-                    for event in events {
-                        if matches!(
-                            event,
-                            LlmEvent::TextDelta(_)
-                                | LlmEvent::ThinkingDelta(_)
-                                | LlmEvent::ThinkingSignature(_)
-                                | LlmEvent::ToolUse { .. }
-                        ) {
-                            emitted_content = true;
-                        }
-                        if tx.send(event).await.is_err() {
-                            return StreamOutcome::Ok; // receiver dropped
-                        }
-                    }
+        for frame in framer.push_text(&text) {
+            tracing::debug!(target: "aion_providers", chunk = %frame.data, "sse chunk received");
+            let events = parser.parse_frame(&frame, &mut state);
+            for event in events {
+                if matches!(
+                    event,
+                    LlmEvent::TextDelta(_)
+                        | LlmEvent::ThinkingDelta(_)
+                        | LlmEvent::ThinkingSignature(_)
+                        | LlmEvent::ToolUse { .. }
+                ) {
+                    emitted_content = true;
+                }
+                if tx.send(event).await.is_err() {
+                    return StreamOutcome::Ok; // receiver dropped
                 }
             }
+        }
+    }
+
+    for event in parser.finish(&mut state) {
+        if tx.send(event).await.is_err() {
+            return StreamOutcome::Ok;
         }
     }
 

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -37,7 +37,7 @@ pub fn build_messages(messages: &[Message], compat: &ProviderCompat) -> Vec<Valu
             match block {
                 ContentBlock::Text { text } => {
                     let mut text = text.clone();
-                    if let Some(patterns) = &compat.strip_patterns {
+                    if let Some(patterns) = &compat.messages.strip_patterns {
                         for pattern in patterns {
                             text = text.replace(pattern, "");
                         }
@@ -507,13 +507,17 @@ pub fn parse_sse_data(event_type: &str, data: &str, state: &mut StreamState) -> 
 mod tests {
     use super::*;
 
+    use aion_config::compat::{MessageCompat, ToolCompat};
     use aion_types::tool::ToolDef;
     use serde_json::json;
 
     /// Compat with merge but no alternation — matches pre-compat behavior
     fn default_compat() -> ProviderCompat {
         ProviderCompat {
-            merge_same_role: Some(true),
+            messages: MessageCompat {
+                merge_same_role: Some(true),
+                ..Default::default()
+            },
             ..Default::default()
         }
     }
@@ -626,8 +630,11 @@ mod tests {
             vec![ContentBlock::Text { text: "hi".into() }],
         )];
         let compat = ProviderCompat {
-            ensure_alternation: Some(true),
-            merge_same_role: Some(true),
+            messages: MessageCompat {
+                ensure_alternation: Some(true),
+                merge_same_role: Some(true),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = build_messages(&messages, &compat);
@@ -643,7 +650,10 @@ mod tests {
             vec![ContentBlock::Text { text: "hi".into() }],
         )];
         let compat = ProviderCompat {
-            ensure_alternation: Some(false),
+            messages: MessageCompat {
+                ensure_alternation: Some(false),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = build_messages(&messages, &compat);
@@ -658,7 +668,10 @@ mod tests {
             Message::new(Role::User, vec![ContentBlock::Text { text: "b".into() }]),
         ];
         let compat = ProviderCompat {
-            merge_same_role: Some(true),
+            messages: MessageCompat {
+                merge_same_role: Some(true),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = build_messages(&messages, &compat);
@@ -674,7 +687,10 @@ mod tests {
             Message::new(Role::User, vec![ContentBlock::Text { text: "b".into() }]),
         ];
         let compat = ProviderCompat {
-            merge_same_role: Some(false),
+            messages: MessageCompat {
+                merge_same_role: Some(false),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = build_messages(&messages, &compat);
@@ -693,7 +709,10 @@ mod tests {
             }],
         )];
         let compat = ProviderCompat {
-            auto_tool_id: Some(true),
+            tools: ToolCompat {
+                auto_tool_id: Some(true),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = build_messages(&messages, &compat);
@@ -714,7 +733,10 @@ mod tests {
             }],
         )];
         let compat = ProviderCompat {
-            auto_tool_id: Some(true),
+            tools: ToolCompat {
+                auto_tool_id: Some(true),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let result = build_messages(&messages, &compat);
@@ -807,7 +829,7 @@ mod tests {
     #[test]
     fn test_anthropic_downgrade_text_not_stripped() {
         let mut compat = anthropic_compat();
-        compat.strip_patterns = Some(vec![
+        compat.messages.strip_patterns = Some(vec![
             "REMOVE_ME".into(),
             "[tool call skipped:".into(),
             "arguments={}".into(),
@@ -847,7 +869,7 @@ mod tests {
     #[test]
     fn test_anthropic_sanitize_disabled_keeps_empty_name() {
         let mut compat = anthropic_compat();
-        compat.sanitize_malformed_tool_calls = Some(false);
+        compat.tools.sanitize_malformed_tool_calls = Some(false);
         let messages = vec![Message::new(
             Role::Assistant,
             vec![ContentBlock::ToolUse {
@@ -928,7 +950,7 @@ mod tests {
     #[test]
     fn test_anthropic_empty_id_toolcall_downgraded_when_auto_id_disabled() {
         let mut compat = anthropic_compat();
-        compat.auto_tool_id = Some(false);
+        compat.tools.auto_tool_id = Some(false);
         let messages = vec![Message::new(
             Role::Assistant,
             vec![ContentBlock::ToolUse {
@@ -962,7 +984,7 @@ mod tests {
     #[test]
     fn test_anthropic_empty_id_toolcall_generates_id_when_auto_id_enabled() {
         let mut compat = anthropic_compat();
-        compat.auto_tool_id = Some(true);
+        compat.tools.auto_tool_id = Some(true);
         let messages = vec![
             Message::new(
                 Role::Assistant,
@@ -997,7 +1019,7 @@ mod tests {
     #[test]
     fn test_anthropic_empty_id_rewrites_paired_result_when_auto_id_enabled() {
         let mut compat = anthropic_compat();
-        compat.auto_tool_id = Some(true);
+        compat.tools.auto_tool_id = Some(true);
         let messages = vec![
             Message::new(
                 Role::Assistant,
@@ -1068,7 +1090,7 @@ mod tests {
     #[test]
     fn test_anthropic_dropped_empty_id_does_not_consume_later_generated_empty_id_result() {
         let mut compat = anthropic_compat();
-        compat.auto_tool_id = Some(true);
+        compat.tools.auto_tool_id = Some(true);
         let messages = vec![
             Message::new(
                 Role::Assistant,

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -283,6 +283,7 @@ async fn process_aws_event_stream(
     let mut buffer = Vec::new();
     let mut stream = response.bytes_stream();
     let mut emitted_content = false;
+    let mut emitted_done = false;
 
     while let Some(chunk) = stream.next().await {
         let chunk = match chunk {
@@ -319,6 +320,9 @@ async fn process_aws_event_stream(
                     ) {
                         emitted_content = true;
                     }
+                    if matches!(event, LlmEvent::Done { .. }) {
+                        emitted_done = true;
+                    }
                     if tx.send(event).await.is_err() {
                         return StreamOutcome::Ok;
                     }
@@ -328,7 +332,7 @@ async fn process_aws_event_stream(
     }
 
     // If we haven't sent a Done event, send one now
-    if state.input_tokens > 0 || state.output_tokens > 0 {
+    if !emitted_done && (state.input_tokens > 0 || state.output_tokens > 0) {
         let _ = tx
             .send(LlmEvent::Done {
                 stop_reason: StopReason::EndTurn,
@@ -443,7 +447,10 @@ mod tests {
     use super::*;
     use aion_types::message::{ContentBlock, Message, Role};
     use aion_types::tool::ToolDef;
+    use base64::Engine as _;
     use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // --- Golden body snapshots (baseline for compat-split / seam-extraction refactors) ---
 
@@ -485,6 +492,46 @@ mod tests {
         }]
     }
 
+    fn aws_event_message(payload: &[u8]) -> Vec<u8> {
+        let total_len = 12 + payload.len() + 4;
+        let mut message = Vec::with_capacity(total_len);
+        message.extend_from_slice(&(total_len as u32).to_be_bytes());
+        message.extend_from_slice(&0u32.to_be_bytes());
+        message.extend_from_slice(&0u32.to_be_bytes());
+        message.extend_from_slice(payload);
+        message.extend_from_slice(&0u32.to_be_bytes());
+        message
+    }
+
+    fn bedrock_event_payload(inner: &str) -> Vec<u8> {
+        json!({
+            "bytes": base64::engine::general_purpose::STANDARD.encode(inner)
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    async fn mock_response(body: Vec<u8>) -> reqwest::Response {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stream"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        reqwest::get(format!("{}/stream", server.uri()))
+            .await
+            .expect("mock response should be available")
+    }
+
+    async fn collect_events(mut rx: mpsc::Receiver<LlmEvent>) -> Vec<LlmEvent> {
+        let mut events = Vec::new();
+        while let Some(event) = rx.recv().await {
+            events.push(event);
+        }
+        events
+    }
+
     #[test]
     fn golden_bedrock_basic() {
         let p = bedrock_test_provider();
@@ -513,5 +560,66 @@ mod tests {
             bedrock_tools(),
         );
         insta::assert_json_snapshot!("bedrock_with_tools", p.build_request_body(&r));
+    }
+
+    #[tokio::test]
+    async fn bedrock_event_stream_decodes_payloads_into_llm_events() {
+        let mut body = Vec::new();
+        for inner in [
+            r#"{"type":"message_start","message":{"usage":{"input_tokens":12}}}"#,
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#,
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}"#,
+        ] {
+            body.extend(aws_event_message(&bedrock_event_payload(inner)));
+        }
+
+        let response = mock_response(body).await;
+        let (tx, rx) = mpsc::channel(8);
+
+        let outcome = process_aws_event_stream(response, &tx).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+
+        assert!(matches!(outcome, StreamOutcome::Ok));
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], LlmEvent::TextDelta(text) if text == "Hello"));
+        match &events[1] {
+            LlmEvent::Done { stop_reason, usage } => {
+                assert_eq!(*stop_reason, StopReason::EndTurn);
+                assert_eq!(usage.input_tokens, 12);
+                assert_eq!(usage.output_tokens, 7);
+            }
+            event => panic!("expected Done event, got {event:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bedrock_event_stream_synthesizes_done_when_message_delta_is_missing() {
+        let mut body = Vec::new();
+        for inner in [
+            r#"{"type":"message_start","message":{"usage":{"input_tokens":12}}}"#,
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#,
+        ] {
+            body.extend(aws_event_message(&bedrock_event_payload(inner)));
+        }
+
+        let response = mock_response(body).await;
+        let (tx, rx) = mpsc::channel(8);
+
+        let outcome = process_aws_event_stream(response, &tx).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+
+        assert!(matches!(outcome, StreamOutcome::Ok));
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], LlmEvent::TextDelta(text) if text == "Hello"));
+        match &events[1] {
+            LlmEvent::Done { stop_reason, usage } => {
+                assert_eq!(*stop_reason, StopReason::EndTurn);
+                assert_eq!(usage.input_tokens, 12);
+                assert_eq!(usage.output_tokens, 0);
+            }
+            event => panic!("expected synthesized Done event, got {event:?}"),
+        }
     }
 }

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -477,3 +477,80 @@ pub fn credentials_from_config(bc: &aion_config::config::BedrockConfig) -> AwsCr
         AwsCredentials::Environment
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aion_types::message::{ContentBlock, Message, Role};
+    use aion_types::tool::ToolDef;
+
+    // --- Golden body snapshots (baseline for compat-split / seam-extraction refactors) ---
+
+    fn bedrock_test_provider() -> BedrockProvider {
+        BedrockProvider::new(
+            "us-east-1",
+            AwsCredentials::Explicit {
+                access_key_id: "test-key".to_string(),
+                secret_access_key: "test-secret".to_string(),
+                session_token: None,
+            },
+            false,
+            ProviderCompat::bedrock_defaults(),
+        )
+    }
+
+    fn bedrock_req(messages: Vec<Message>, tools: Vec<ToolDef>) -> LlmRequest {
+        LlmRequest {
+            model: "test-model".to_string(),
+            system: "You are a test assistant.".to_string(),
+            messages,
+            tools,
+            max_tokens: 8192,
+            thinking: None,
+            reasoning_effort: None,
+        }
+    }
+
+    fn bedrock_tools() -> Vec<ToolDef> {
+        vec![ToolDef {
+            name: "read".to_string(),
+            description: "Read".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"path": {"type": ["string", "null"]}},
+                "additionalProperties": false
+            }),
+            deferred: false,
+        }]
+    }
+
+    #[test]
+    fn golden_bedrock_basic() {
+        let p = bedrock_test_provider();
+        let r = bedrock_req(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            )],
+            vec![],
+        );
+        insta::assert_json_snapshot!("bedrock_basic", p.build_request_body(&r));
+    }
+
+    #[test]
+    fn golden_bedrock_with_tools() {
+        let p = bedrock_test_provider();
+        let r = bedrock_req(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "go".to_string(),
+                }],
+            )],
+            bedrock_tools(),
+        );
+        insta::assert_json_snapshot!("bedrock_with_tools", p.build_request_body(&r));
+    }
+}

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -8,18 +8,19 @@ use aws_sigv4::http_request::{
     SigningSettings,
 };
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
-use serde_json::{Value, json};
+use serde_json::Value;
 use std::time::SystemTime;
 use tokio::sync::mpsc;
 
-use base64::Engine as _;
-
-use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
+use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{StopReason, TokenUsage};
 
-use super::anthropic_shared;
+use crate::framing::bedrock_payload_to_frame;
+use crate::parser::ResponseParser;
+use crate::projector::{AnthropicWireProjector, WireParams};
+use crate::stream_runner::StreamOutcome;
 use crate::{LlmProvider, ProviderError};
-use aion_config::compat::{self, ProviderCompat};
+use aion_config::compat::ProviderCompat;
 
 pub struct BedrockProvider {
     client: reqwest::Client,
@@ -57,48 +58,17 @@ impl BedrockProvider {
     }
 
     fn build_request_body(&self, request: &LlmRequest) -> Value {
-        let system = if self.cache_enabled {
-            json!([{
-                "type": "text",
-                "text": &request.system,
-                "cache_control": { "type": "ephemeral" }
-            }])
-        } else {
-            json!(&request.system)
-        };
-
-        let mut body = json!({
-            "anthropic_version": "bedrock-2023-05-31",
-            "max_tokens": request.max_tokens,
-            "system": system,
-            "messages": anthropic_shared::build_messages(&request.messages, &self.compat)
-        });
-
-        if !request.tools.is_empty() {
-            let mut tools = anthropic_shared::build_tools(&request.tools);
-            if self.compat.sanitize_schema() {
-                for tool in &mut tools {
-                    if let Some(schema) = tool.get("input_schema").cloned() {
-                        tool["input_schema"] = compat::sanitize_json_schema(&schema);
-                    }
-                }
-            }
-            if self.cache_enabled
-                && let Some(last) = tools.last_mut()
-            {
-                last["cache_control"] = json!({ "type": "ephemeral" });
-            }
-            body["tools"] = json!(tools);
-        }
-
-        if let Some(ThinkingConfig::Enabled { budget_tokens }) = &request.thinking {
-            body["thinking"] = json!({
-                "type": "enabled",
-                "budget_tokens": budget_tokens
-            });
-        }
-
-        body
+        AnthropicWireProjector::project(
+            request,
+            &self.compat,
+            WireParams {
+                anthropic_version: Some("bedrock-2023-05-31"),
+                include_model_in_body: false,
+                include_stream: false,
+                cache_enabled: self.cache_enabled,
+                sanitize_schema: self.compat.sanitize_schema(),
+            },
+        )
     }
 
     fn build_url(&self, model: &str) -> String {
@@ -289,9 +259,8 @@ impl LlmProvider for BedrockProvider {
         // AWS event stream uses binary framing
         tokio::spawn(async move {
             match process_aws_event_stream(response, &tx).await {
-                anthropic_shared::StreamOutcome::Ok => {}
-                anthropic_shared::StreamOutcome::FailedPartial(e)
-                | anthropic_shared::StreamOutcome::FailedEmpty(e) => {
+                StreamOutcome::Ok => {}
+                StreamOutcome::FailedPartial(e) | StreamOutcome::FailedEmpty(e) => {
                     // Bedrock retry requires re-signing; not implemented yet.
                     let _ = tx.send(LlmEvent::Error(e.to_string())).await;
                 }
@@ -306,10 +275,11 @@ impl LlmProvider for BedrockProvider {
 async fn process_aws_event_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
-) -> anthropic_shared::StreamOutcome {
+) -> StreamOutcome {
     use futures::StreamExt;
 
-    let mut state = anthropic_shared::StreamState::new();
+    let parser = crate::parser::AnthropicParser;
+    let mut state = parser.new_state();
     let mut buffer = Vec::new();
     let mut stream = response.bytes_stream();
     let mut emitted_content = false;
@@ -320,9 +290,9 @@ async fn process_aws_event_stream(
             Err(e) => {
                 let err = ProviderError::Connection(e.to_string());
                 return if emitted_content {
-                    anthropic_shared::StreamOutcome::FailedPartial(err)
+                    StreamOutcome::FailedPartial(err)
                 } else {
-                    anthropic_shared::StreamOutcome::FailedEmpty(err)
+                    StreamOutcome::FailedEmpty(err)
                 };
             }
         };
@@ -332,35 +302,25 @@ async fn process_aws_event_stream(
         while let Some((event_data, consumed)) = parse_aws_event(&buffer) {
             buffer = buffer[consumed..].to_vec();
 
-            if let Some(payload) = event_data {
-                // The payload contains an SSE-like structure with "bytes" field
-                if let Ok(wrapper) = serde_json::from_slice::<Value>(&payload) {
-                    // Bedrock wraps the payload in {"bytes": "base64-encoded-data"}
-                    if let Some(b64) = wrapper["bytes"].as_str()
-                        && let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(b64)
-                        && let Ok(inner) = String::from_utf8(decoded)
-                    {
-                        tracing::debug!(target: "aion_providers", chunk = %inner, "bedrock event chunk");
-                        // Inner payload is JSON with event type hints
-                        if let Ok(json_val) = serde_json::from_str::<Value>(&inner) {
-                            let event_type = json_val["type"].as_str().unwrap_or("");
-                            let events =
-                                anthropic_shared::parse_sse_data(event_type, &inner, &mut state);
-                            for event in events {
-                                if matches!(
-                                    event,
-                                    LlmEvent::TextDelta(_)
-                                        | LlmEvent::ThinkingDelta(_)
-                                        | LlmEvent::ThinkingSignature(_)
-                                        | LlmEvent::ToolUse { .. }
-                                ) {
-                                    emitted_content = true;
-                                }
-                                if tx.send(event).await.is_err() {
-                                    return anthropic_shared::StreamOutcome::Ok;
-                                }
-                            }
-                        }
+            let Some(payload) = event_data else {
+                continue;
+            };
+
+            if let Some(frame) = bedrock_payload_to_frame(&payload) {
+                tracing::debug!(target: "aion_providers", chunk = %frame.data, "bedrock event chunk");
+                let events = parser.parse_frame(&frame, &mut state);
+                for event in events {
+                    if matches!(
+                        event,
+                        LlmEvent::TextDelta(_)
+                            | LlmEvent::ThinkingDelta(_)
+                            | LlmEvent::ThinkingSignature(_)
+                            | LlmEvent::ToolUse { .. }
+                    ) {
+                        emitted_content = true;
+                    }
+                    if tx.send(event).await.is_err() {
+                        return StreamOutcome::Ok;
                     }
                 }
             }
@@ -382,7 +342,7 @@ async fn process_aws_event_stream(
             .await;
     }
 
-    anthropic_shared::StreamOutcome::Ok
+    StreamOutcome::Ok
 }
 
 /// Parse one AWS event stream message from the buffer.
@@ -483,6 +443,7 @@ mod tests {
     use super::*;
     use aion_types::message::{ContentBlock, Message, Role};
     use aion_types::tool::ToolDef;
+    use serde_json::json;
 
     // --- Golden body snapshots (baseline for compat-split / seam-extraction refactors) ---
 

--- a/crates/aion-providers/src/framing.rs
+++ b/crates/aion-providers/src/framing.rs
@@ -1,0 +1,264 @@
+use base64::Engine as _;
+use serde_json::Value;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum FrameKind {
+    Data,
+    Done,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Frame {
+    pub event: Option<String>,
+    pub data: String,
+    pub kind: FrameKind,
+}
+
+#[derive(Default)]
+pub(crate) struct SseLineFramer {
+    buffer: String,
+}
+
+#[derive(Default)]
+pub(crate) struct SseBlockFramer {
+    buffer: String,
+    current_event_type: Option<String>,
+}
+
+pub(crate) fn bedrock_payload_to_frame(payload: &[u8]) -> Option<Frame> {
+    let wrapper = serde_json::from_slice::<Value>(payload).ok()?;
+    let b64 = wrapper.get("bytes")?.as_str()?;
+    let decoded = base64::engine::general_purpose::STANDARD.decode(b64).ok()?;
+    let inner = String::from_utf8(decoded).ok()?;
+    let inner_json = serde_json::from_str::<Value>(&inner).ok()?;
+    let event_type = inner_json
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    Some(Frame {
+        event: Some(event_type),
+        data: inner,
+        kind: FrameKind::Data,
+    })
+}
+
+impl SseLineFramer {
+    pub(crate) fn push_text(&mut self, text: &str, done_sentinel: &str) -> Vec<Frame> {
+        self.buffer.push_str(text);
+
+        let mut frames = Vec::new();
+        while let Some(line_end) = self.buffer.find('\n') {
+            let line = self.buffer.drain(..=line_end).collect::<String>();
+            let line = line.trim();
+
+            if line.is_empty() || line.starts_with(':') {
+                continue;
+            }
+
+            if let Some(data) = line.strip_prefix("data: ") {
+                frames.push(Frame {
+                    event: None,
+                    data: data.to_string(),
+                    kind: if data == done_sentinel {
+                        FrameKind::Done
+                    } else {
+                        FrameKind::Data
+                    },
+                });
+            }
+        }
+
+        frames
+    }
+}
+
+impl SseBlockFramer {
+    pub(crate) fn push_text(&mut self, text: &str) -> Vec<Frame> {
+        self.buffer.push_str(text);
+
+        let mut frames = Vec::new();
+        while let Some(block_end) = self.buffer.find("\n\n") {
+            let block = self.buffer.drain(..block_end + 2).collect::<String>();
+            let block = &block[..block_end];
+
+            for line in block.lines() {
+                let line = line.strip_suffix('\r').unwrap_or(line);
+                if let Some(event_type) = line.strip_prefix("event: ") {
+                    self.current_event_type = Some(event_type.to_string());
+                } else if let Some(data) = line.strip_prefix("data: ") {
+                    frames.push(Frame {
+                        event: self.current_event_type.clone(),
+                        data: data.to_string(),
+                        kind: FrameKind::Data,
+                    });
+                }
+            }
+        }
+
+        frames
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Frame, FrameKind, SseBlockFramer, SseLineFramer, bedrock_payload_to_frame};
+    use base64::Engine as _;
+
+    #[test]
+    fn test_sse_line_framer_extracts_data_and_done() {
+        let mut framer = SseLineFramer::default();
+
+        let frames = framer.push_text(
+            ": keepalive\n\nignored\ndata: {\"type\":\"chunk\"}\ndata: [DONE]\n",
+            "[DONE]",
+        );
+
+        assert_eq!(
+            frames,
+            vec![
+                Frame {
+                    event: None,
+                    data: "{\"type\":\"chunk\"}".to_string(),
+                    kind: FrameKind::Data,
+                },
+                Frame {
+                    event: None,
+                    data: "[DONE]".to_string(),
+                    kind: FrameKind::Done,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_sse_line_framer_keeps_partial_line_buffered() {
+        let mut framer = SseLineFramer::default();
+
+        assert!(framer.push_text("data: partial", "[DONE]").is_empty());
+
+        assert_eq!(
+            framer.push_text(" line\n", "[DONE]"),
+            vec![Frame {
+                event: None,
+                data: "partial line".to_string(),
+                kind: FrameKind::Data,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_sse_block_framer_extracts_event_and_data() {
+        let mut framer = SseBlockFramer::default();
+
+        let frames = framer.push_text("event: content_block_delta\ndata: first\ndata: second\n\n");
+
+        assert_eq!(
+            frames,
+            vec![
+                Frame {
+                    event: Some("content_block_delta".to_string()),
+                    data: "first".to_string(),
+                    kind: FrameKind::Data,
+                },
+                Frame {
+                    event: Some("content_block_delta".to_string()),
+                    data: "second".to_string(),
+                    kind: FrameKind::Data,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_sse_block_framer_keeps_partial_block_buffered() {
+        let mut framer = SseBlockFramer::default();
+
+        assert!(
+            framer
+                .push_text("event: message_delta\ndata: body")
+                .is_empty()
+        );
+
+        assert_eq!(
+            framer.push_text("\n\n"),
+            vec![Frame {
+                event: Some("message_delta".to_string()),
+                data: "body".to_string(),
+                kind: FrameKind::Data,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_sse_block_framer_preserves_payload_whitespace() {
+        let mut framer = SseBlockFramer::default();
+
+        assert_eq!(
+            framer.push_text("event: message_delta\ndata: body \n\n"),
+            vec![Frame {
+                event: Some("message_delta".to_string()),
+                data: "body ".to_string(),
+                kind: FrameKind::Data,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_sse_block_framer_does_not_accept_leading_space_fields() {
+        let mut framer = SseBlockFramer::default();
+
+        assert!(
+            framer
+                .push_text(" event: ignored\n data: ignored\n\n")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_bedrock_payload_frame_decodes_base64_bytes() {
+        let inner = r#"{"type":"content_block_delta","delta":{"text":"hi"}}"#;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(inner);
+        let payload = format!(r#"{{"bytes":"{}"}}"#, encoded);
+
+        assert_eq!(
+            bedrock_payload_to_frame(payload.as_bytes()),
+            Some(Frame {
+                event: Some("content_block_delta".to_string()),
+                data: inner.to_string(),
+                kind: FrameKind::Data,
+            })
+        );
+    }
+
+    #[test]
+    fn test_bedrock_payload_frame_ignores_invalid_payload() {
+        assert_eq!(bedrock_payload_to_frame(b"not json"), None);
+        assert_eq!(bedrock_payload_to_frame(br#"{"bytes":"not base64"}"#), None);
+
+        let invalid_utf8 = base64::engine::general_purpose::STANDARD.encode([0xff]);
+        let payload = format!(r#"{{"bytes":"{}"}}"#, invalid_utf8);
+        assert_eq!(bedrock_payload_to_frame(payload.as_bytes()), None);
+
+        let invalid_inner_json = base64::engine::general_purpose::STANDARD.encode("not json");
+        let payload = format!(r#"{{"bytes":"{}"}}"#, invalid_inner_json);
+        assert_eq!(bedrock_payload_to_frame(payload.as_bytes()), None);
+    }
+
+    #[test]
+    fn test_bedrock_payload_frame_uses_empty_event_for_missing_type() {
+        let inner = r#"{"delta":{"text":"hi"}}"#;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(inner);
+        let payload = format!(r#"{{"bytes":"{}"}}"#, encoded);
+
+        assert_eq!(
+            bedrock_payload_to_frame(payload.as_bytes()),
+            Some(Frame {
+                event: Some(String::new()),
+                data: inner.to_string(),
+                kind: FrameKind::Data,
+            })
+        );
+    }
+}

--- a/crates/aion-providers/src/lib.rs
+++ b/crates/aion-providers/src/lib.rs
@@ -2,9 +2,13 @@ pub mod anthropic;
 pub mod anthropic_shared;
 pub mod bedrock;
 pub mod error;
+pub(crate) mod framing;
 pub mod openai;
+pub(crate) mod parser;
+pub(crate) mod projector;
 pub mod provider;
 pub mod retry;
+pub(crate) mod stream_runner;
 mod tool_call_sanitize;
 pub mod vertex;
 

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -8,7 +8,9 @@ use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
 use aion_types::tool::{ToolDef, truncate_deferred_description};
 
-use crate::anthropic_shared::StreamOutcome;
+use crate::framing::{FrameKind, SseLineFramer};
+use crate::parser::{OpenAiParser, ResponseParser};
+use crate::stream_runner::{RetryPolicy, StreamOutcome, run_stream};
 use crate::tool_call_sanitize::{DroppedToolCallReason, format_dropped_tool_call};
 use crate::{LlmProvider, ProviderError};
 use aion_config::compat::ProviderCompat;
@@ -41,7 +43,11 @@ impl OpenAIProvider {
         Ok(headers)
     }
 
-    fn build_messages(messages: &[Message], system: &str, compat: &ProviderCompat) -> Vec<Value> {
+    pub(crate) fn build_messages(
+        messages: &[Message],
+        system: &str,
+        compat: &ProviderCompat,
+    ) -> Vec<Value> {
         let mut result: Vec<Value> = Vec::new();
         let sanitize = compat.sanitize_malformed_tool_calls();
         let auto_tool_id = compat.auto_tool_id();
@@ -326,7 +332,7 @@ impl OpenAIProvider {
         result
     }
 
-    fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
+    pub(crate) fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
         tools
             .iter()
             .map(|t| {
@@ -360,25 +366,7 @@ impl OpenAIProvider {
     }
 
     fn build_request_body(&self, request: &LlmRequest) -> Value {
-        let max_tokens_field = self.compat.max_tokens_field();
-
-        let mut body = json!({
-            "model": request.model,
-            "messages": Self::build_messages(&request.messages, &request.system, &self.compat),
-            "stream": true,
-            "stream_options": { "include_usage": true }
-        });
-        body[max_tokens_field] = json!(request.max_tokens);
-
-        if !request.tools.is_empty() {
-            body["tools"] = json!(Self::build_tools(&request.tools));
-        }
-
-        if let Some(effort) = &request.reasoning_effort {
-            body["reasoning_effort"] = json!(effort);
-        }
-
-        body
+        crate::projector::OpenAiProjector::project(request, &self.compat)
     }
 }
 
@@ -542,7 +530,7 @@ struct ToolCallAccumulator {
     extra: Option<Value>,
 }
 
-struct StreamState {
+pub(crate) struct StreamState {
     tool_calls: Vec<ToolCallAccumulator>,
     input_tokens: u64,
     output_tokens: u64,
@@ -552,7 +540,7 @@ struct StreamState {
 }
 
 impl StreamState {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             tool_calls: Vec::new(),
             input_tokens: 0,
@@ -566,7 +554,7 @@ impl StreamState {
     /// OpenAI sends usage in a separate trailing chunk (choices:[]) *after* the
     /// chunk that carries `finish_reason`. We defer the Done event until [DONE]
     /// so that token counts are always accurate.
-    fn flush_done(&mut self) -> Option<LlmEvent> {
+    pub(crate) fn flush_done(&mut self) -> Option<LlmEvent> {
         let pending = self.pending_done.take()?;
         Some(match pending {
             LlmEvent::Done { stop_reason, .. } => LlmEvent::Done {
@@ -607,86 +595,53 @@ impl LlmProvider for OpenAIProvider {
 
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
 
-        let response = crate::retry::with_initial_connect_retry(|| async {
-            let response = self
-                .client
-                .post(&url)
-                .headers(headers.clone())
-                .json(&body)
-                .send()
-                .await?;
-
-            let status = response.status();
-            if !status.is_success() {
-                let body_text = response.text().await.unwrap_or_default();
-                if status.as_u16() == 429 {
-                    return Err(ProviderError::RateLimited {
-                        retry_after_ms: 5000,
-                    });
-                }
-                return Err(ProviderError::Api {
-                    status: status.as_u16(),
-                    message: body_text,
-                });
-            }
-
-            Ok(response)
-        })
-        .await?;
-
-        let (tx, rx) = mpsc::channel(64);
         let auto_tool_id = self.compat.auto_tool_id();
         let client = self.client.clone();
-        let url_clone = url.clone();
 
-        tokio::spawn(async move {
-            match process_sse_stream(response, &tx, auto_tool_id).await {
-                StreamOutcome::Ok => {}
-                StreamOutcome::FailedPartial(e) => {
-                    let _ = tx.send(LlmEvent::Error(e.to_string())).await;
-                }
-                StreamOutcome::FailedEmpty(e) => {
-                    if e.is_retryable() {
-                        let mut backoff = std::time::Duration::from_secs(1);
-                        let mut final_err = Some(e);
-                        for attempt in 1..=crate::retry::MAX_STREAM_RETRIES {
-                            backoff = crate::retry::backoff_sleep(attempt, backoff).await;
-                            match crate::retry::send_and_check(&client, &url_clone, &headers, &body)
-                                .await
-                            {
-                                Ok(resp) => {
-                                    let outcome = process_sse_stream(resp, &tx, auto_tool_id).await;
-                                    match crate::retry::evaluate_outcome(outcome, attempt) {
-                                        Ok(None) => {
-                                            final_err = None;
-                                            break;
-                                        }
-                                        Ok(Some(e)) => {
-                                            final_err = Some(e);
-                                            break;
-                                        }
-                                        Err(_) => continue,
-                                    }
-                                }
-                                Err(e) if attempt == crate::retry::MAX_STREAM_RETRIES => {
-                                    final_err = Some(e);
-                                    break;
-                                }
-                                Err(_) => continue,
-                            }
-                        }
-                        if let Some(err) = final_err {
-                            let _ = tx.send(LlmEvent::Error(err.to_string())).await;
-                        }
-                    } else {
-                        let _ = tx.send(LlmEvent::Error(e.to_string())).await;
-                    }
-                }
-            }
-        });
+        let send = move || {
+            send_openai_stream_request(client.clone(), url.clone(), headers.clone(), body.clone())
+        };
+        let process = move |response, tx| async move {
+            process_sse_stream(response, &tx, auto_tool_id).await
+        };
 
-        Ok(rx)
+        run_stream(
+            send,
+            process,
+            RetryPolicy::new(crate::retry::MAX_STREAM_RETRIES, true, true),
+        )
+        .await
     }
+}
+
+async fn send_openai_stream_request(
+    client: reqwest::Client,
+    url: String,
+    headers: HeaderMap,
+    body: Value,
+) -> Result<reqwest::Response, ProviderError> {
+    let response = client
+        .post(&url)
+        .headers(headers)
+        .json(&body)
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body_text = response.text().await.unwrap_or_default();
+        if status.as_u16() == 429 {
+            return Err(ProviderError::RateLimited {
+                retry_after_ms: 5000,
+            });
+        }
+        return Err(ProviderError::Api {
+            status: status.as_u16(),
+            message: body_text,
+        });
+    }
+
+    Ok(response)
 }
 
 async fn process_sse_stream(
@@ -696,8 +651,9 @@ async fn process_sse_stream(
 ) -> StreamOutcome {
     use futures::StreamExt;
 
-    let mut state = StreamState::new();
-    let mut buffer = String::new();
+    let parser = OpenAiParser { auto_tool_id };
+    let mut state = parser.new_state();
+    let mut framer = SseLineFramer::default();
     let mut stream = response.bytes_stream();
     let mut emitted_content = false;
 
@@ -714,50 +670,41 @@ async fn process_sse_stream(
             }
         };
         let text = String::from_utf8_lossy(&chunk);
-        buffer.push_str(&text);
-
-        // Process complete lines
-        while let Some(line_end) = buffer.find('\n') {
-            let line = buffer[..line_end].trim().to_string();
-            buffer = buffer[line_end + 1..].to_string();
-
-            if line.is_empty() || line.starts_with(':') {
-                continue;
-            }
-
-            if let Some(data) = line.strip_prefix("data: ") {
-                tracing::debug!(target: "aion_providers", chunk = %data, "sse chunk received");
-                if data == "[DONE]" {
-                    // Flush the deferred Done event now that the final
-                    // usage-only chunk (choices:[]) has updated token counts.
-                    if let Some(done) = state.flush_done() {
-                        let _ = tx.send(done).await;
-                    }
+        for frame in framer.push_text(&text, "[DONE]") {
+            tracing::debug!(target: "aion_providers", chunk = %frame.data, "sse chunk received");
+            let is_done = frame.kind == FrameKind::Done;
+            let events = parser.parse_frame(&frame, &mut state);
+            for event in events {
+                if matches!(
+                    event,
+                    LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
+                ) {
+                    emitted_content = true;
+                }
+                if tx.send(event).await.is_err() {
                     return StreamOutcome::Ok;
                 }
-
-                let events = parse_sse_chunk(data, &mut state, auto_tool_id);
-                for event in events {
-                    if matches!(
-                        event,
-                        LlmEvent::TextDelta(_)
-                            | LlmEvent::ThinkingDelta(_)
-                            | LlmEvent::ToolUse { .. }
-                    ) {
-                        emitted_content = true;
-                    }
-                    if tx.send(event).await.is_err() {
-                        return StreamOutcome::Ok;
-                    }
-                }
             }
+            if is_done {
+                return StreamOutcome::Ok;
+            }
+        }
+    }
+
+    for event in parser.finish(&mut state) {
+        if tx.send(event).await.is_err() {
+            return StreamOutcome::Ok;
         }
     }
 
     StreamOutcome::Ok
 }
 
-fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id: bool) -> Vec<LlmEvent> {
+pub(crate) fn parse_sse_chunk(
+    data: &str,
+    state: &mut StreamState,
+    auto_tool_id: bool,
+) -> Vec<LlmEvent> {
     let mut events = Vec::new();
 
     let json: Value = match serde_json::from_str(data) {

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -1907,4 +1907,172 @@ mod tests {
             );
         }
     }
+
+    // --- Golden body snapshots (baseline for compat-split / seam-extraction refactors) ---
+
+    fn golden_provider(compat: ProviderCompat) -> OpenAIProvider {
+        OpenAIProvider::new("test-key", "https://example.test/v1", compat)
+    }
+
+    fn golden_req(messages: Vec<Message>, tools: Vec<ToolDef>) -> LlmRequest {
+        LlmRequest {
+            model: "test-model".to_string(),
+            system: "You are a test assistant.".to_string(),
+            messages,
+            tools,
+            max_tokens: 8192,
+            thinking: None,
+            reasoning_effort: None,
+        }
+    }
+
+    #[test]
+    fn golden_openai_basic() {
+        let provider = golden_provider(ProviderCompat::openai_defaults());
+        let request = golden_req(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            )],
+            vec![],
+        );
+        let body = provider.build_request_body(&request);
+        insta::assert_json_snapshot!("openai_basic", body);
+    }
+
+    fn sample_tools() -> Vec<ToolDef> {
+        vec![
+            ToolDef {
+                name: "read".to_string(),
+                description: "Read a file".to_string(),
+                input_schema: json!({"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}),
+                deferred: false,
+            },
+            ToolDef {
+                name: "list".to_string(),
+                description: "List dir".to_string(),
+                input_schema: json!({"type": "object", "properties": {}}),
+                deferred: false,
+            },
+        ]
+    }
+
+    #[test]
+    fn golden_openai_with_tools() {
+        let provider = golden_provider(ProviderCompat::openai_defaults());
+        let request = golden_req(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "go".to_string(),
+                }],
+            )],
+            sample_tools(),
+        );
+        insta::assert_json_snapshot!("openai_with_tools", provider.build_request_body(&request));
+    }
+
+    #[test]
+    fn golden_openai_with_tool_result() {
+        let provider = golden_provider(ProviderCompat::openai_defaults());
+        let messages = vec![
+            Message::new(
+                Role::Assistant,
+                vec![ContentBlock::ToolUse {
+                    id: "call_1".to_string(),
+                    name: "read".to_string(),
+                    input: json!({"path": "a.txt"}),
+                    extra: None,
+                }],
+            ),
+            Message::new(
+                Role::User,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "call_1".to_string(),
+                    content: "file contents".to_string(),
+                    is_error: false,
+                }],
+            ),
+        ];
+        insta::assert_json_snapshot!(
+            "openai_with_tool_result",
+            provider.build_request_body(&golden_req(messages, vec![]))
+        );
+    }
+
+    #[test]
+    fn golden_openai_with_thinking() {
+        let provider = golden_provider(ProviderCompat::openai_defaults());
+        let messages = vec![
+            Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "q1".to_string(),
+                }],
+            ),
+            Message::new(
+                Role::Assistant,
+                vec![
+                    ContentBlock::Thinking {
+                        thinking: "let me think".to_string(),
+                        signature: None,
+                    },
+                    ContentBlock::Text {
+                        text: "answer".to_string(),
+                    },
+                ],
+            ),
+            Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "q2".to_string(),
+                }],
+            ),
+        ];
+        insta::assert_json_snapshot!(
+            "openai_with_thinking",
+            provider.build_request_body(&golden_req(messages, vec![]))
+        );
+    }
+
+    #[test]
+    fn golden_openai_with_reasoning_effort() {
+        let provider = golden_provider(ProviderCompat::openai_defaults());
+        let mut request = golden_req(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+            )],
+            vec![],
+        );
+        request.reasoning_effort = Some("medium".to_string());
+        insta::assert_json_snapshot!(
+            "openai_with_reasoning_effort",
+            provider.build_request_body(&request)
+        );
+    }
+
+    #[test]
+    fn golden_openai_custom_max_tokens_field() {
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.max_tokens_field = Some("max_completion_tokens".to_string());
+        let provider = golden_provider(compat);
+        let request = golden_req(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+            )],
+            vec![],
+        );
+        insta::assert_json_snapshot!(
+            "openai_custom_max_tokens_field",
+            provider.build_request_body(&request)
+        );
+    }
 }

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -360,11 +360,7 @@ impl OpenAIProvider {
     }
 
     fn build_request_body(&self, request: &LlmRequest) -> Value {
-        let max_tokens_field = self
-            .compat
-            .max_tokens_field
-            .as_deref()
-            .unwrap_or("max_tokens");
+        let max_tokens_field = self.compat.max_tokens_field();
 
         let mut body = json!({
             "model": request.model,
@@ -399,7 +395,7 @@ fn generate_call_id() -> String {
 
 /// Strip configured patterns from text content
 fn strip_patterns_from_text(text: &str, compat: &ProviderCompat) -> String {
-    match &compat.strip_patterns {
+    match &compat.messages.strip_patterns {
         Some(patterns) if !patterns.is_empty() => {
             let mut result = text.to_string();
             for pattern in patterns {
@@ -893,6 +889,7 @@ fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id: bool) -> V
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aion_config::compat::TransportCompat;
 
     fn no_compat() -> ProviderCompat {
         ProviderCompat::default()
@@ -924,7 +921,10 @@ mod tests {
     #[test]
     fn test_max_tokens_field_custom() {
         let compat = ProviderCompat {
-            max_tokens_field: Some("max_completion_tokens".into()),
+            transport: TransportCompat {
+                max_tokens_field: Some("max_completion_tokens".into()),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let provider = OpenAIProvider::new("key", "http://localhost", compat);
@@ -1080,7 +1080,7 @@ mod tests {
     #[test]
     fn test_reverse_orphan_tool_result_kept_when_disabled() {
         let mut compat = openai_compat();
-        compat.clean_orphan_tool_results = Some(false);
+        compat.messages.clean_orphan_tool_results = Some(false);
         let messages = vec![Message::new(
             Role::Tool,
             vec![ContentBlock::ToolResult {
@@ -1178,7 +1178,7 @@ mod tests {
     #[test]
     fn test_empty_id_toolcall_downgraded_when_auto_id_disabled() {
         let mut compat = openai_compat();
-        compat.auto_tool_id = Some(false);
+        compat.tools.auto_tool_id = Some(false);
         let messages = vec![
             Message::new(
                 Role::Assistant,
@@ -1212,8 +1212,8 @@ mod tests {
     #[test]
     fn test_empty_id_toolcall_generates_id_when_auto_id_enabled() {
         let mut compat = openai_compat();
-        compat.auto_tool_id = Some(true);
-        compat.clean_orphan_tool_calls = Some(false);
+        compat.tools.auto_tool_id = Some(true);
+        compat.tools.clean_orphan_tool_calls = Some(false);
         let messages = vec![Message::new(
             Role::Assistant,
             vec![ContentBlock::ToolUse {
@@ -1234,7 +1234,7 @@ mod tests {
     #[test]
     fn test_empty_id_toolcall_rewrites_paired_result_when_auto_id_enabled() {
         let mut compat = openai_compat();
-        compat.auto_tool_id = Some(true);
+        compat.tools.auto_tool_id = Some(true);
         let messages = vec![
             Message::new(
                 Role::Assistant,
@@ -1294,7 +1294,7 @@ mod tests {
     #[test]
     fn test_dropped_empty_id_does_not_consume_later_generated_empty_id_result() {
         let mut compat = openai_compat();
-        compat.auto_tool_id = Some(true);
+        compat.tools.auto_tool_id = Some(true);
         let messages = vec![
             Message::new(
                 Role::Assistant,
@@ -1546,7 +1546,7 @@ mod tests {
     #[test]
     fn test_sanitize_disabled_keeps_empty_name() {
         let mut compat = openai_compat();
-        compat.sanitize_malformed_tool_calls = Some(false);
+        compat.tools.sanitize_malformed_tool_calls = Some(false);
         let messages = vec![Message::new(
             Role::Assistant,
             vec![ContentBlock::ToolUse {
@@ -2059,7 +2059,7 @@ mod tests {
     #[test]
     fn golden_openai_custom_max_tokens_field() {
         let mut compat = ProviderCompat::openai_defaults();
-        compat.max_tokens_field = Some("max_completion_tokens".to_string());
+        compat.transport.max_tokens_field = Some("max_completion_tokens".to_string());
         let provider = golden_provider(compat);
         let request = golden_req(
             vec![Message::new(

--- a/crates/aion-providers/src/parser.rs
+++ b/crates/aion-providers/src/parser.rs
@@ -1,0 +1,155 @@
+use aion_types::llm::LlmEvent;
+
+use crate::framing::{Frame, FrameKind};
+
+pub(crate) trait ResponseParser {
+    type State;
+
+    fn new_state(&self) -> Self::State;
+    fn parse_frame(&self, frame: &Frame, state: &mut Self::State) -> Vec<LlmEvent>;
+    fn finish(&self, state: &mut Self::State) -> Vec<LlmEvent>;
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct OpenAiParser {
+    pub auto_tool_id: bool,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct AnthropicParser;
+
+impl ResponseParser for OpenAiParser {
+    type State = crate::openai::StreamState;
+
+    fn new_state(&self) -> Self::State {
+        crate::openai::StreamState::new()
+    }
+
+    fn parse_frame(&self, frame: &Frame, state: &mut Self::State) -> Vec<LlmEvent> {
+        match frame.kind {
+            FrameKind::Done => state.flush_done().into_iter().collect(),
+            FrameKind::Data => {
+                crate::openai::parse_sse_chunk(&frame.data, state, self.auto_tool_id)
+            }
+        }
+    }
+
+    fn finish(&self, _state: &mut Self::State) -> Vec<LlmEvent> {
+        Vec::new()
+    }
+}
+
+impl ResponseParser for AnthropicParser {
+    type State = crate::anthropic_shared::StreamState;
+
+    fn new_state(&self) -> Self::State {
+        crate::anthropic_shared::StreamState::new()
+    }
+
+    fn parse_frame(&self, frame: &Frame, state: &mut Self::State) -> Vec<LlmEvent> {
+        let event_type = frame.event.as_deref().unwrap_or("");
+        crate::anthropic_shared::parse_sse_data(event_type, &frame.data, state)
+    }
+
+    fn finish(&self, _state: &mut Self::State) -> Vec<LlmEvent> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AnthropicParser, OpenAiParser, ResponseParser};
+    use crate::framing::{Frame, FrameKind};
+    use aion_types::llm::LlmEvent;
+    use aion_types::message::StopReason;
+
+    #[test]
+    fn openai_done_frame_flushes_empty_state_to_no_events() {
+        let parser = OpenAiParser {
+            auto_tool_id: false,
+        };
+        let mut state = parser.new_state();
+        let frame = Frame {
+            event: None,
+            data: "[DONE]".to_string(),
+            kind: FrameKind::Done,
+        };
+
+        let events = parser.parse_frame(&frame, &mut state);
+
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn openai_done_frame_flushes_pending_done_with_usage() {
+        let parser = OpenAiParser {
+            auto_tool_id: false,
+        };
+        let mut state = parser.new_state();
+
+        let finish_frame = Frame {
+            event: None,
+            data: r#"{"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}"#.to_string(),
+            kind: FrameKind::Data,
+        };
+        let finish_events = parser.parse_frame(&finish_frame, &mut state);
+        assert_eq!(finish_events.len(), 1);
+        assert!(matches!(&finish_events[0], LlmEvent::TextDelta(text) if text == "hi"));
+
+        let usage_frame = Frame {
+            event: None,
+            data: r#"{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#
+                .to_string(),
+            kind: FrameKind::Data,
+        };
+        assert!(parser.parse_frame(&usage_frame, &mut state).is_empty());
+
+        let done_frame = Frame {
+            event: None,
+            data: "[DONE]".to_string(),
+            kind: FrameKind::Done,
+        };
+        let done_events = parser.parse_frame(&done_frame, &mut state);
+        assert_eq!(done_events.len(), 1);
+        match &done_events[0] {
+            LlmEvent::Done { stop_reason, usage } => {
+                assert_eq!(*stop_reason, StopReason::EndTurn);
+                assert_eq!(usage.input_tokens, 10);
+                assert_eq!(usage.output_tokens, 5);
+            }
+            event => panic!("expected Done, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn anthropic_data_frame_routes_event_type_to_text_delta() {
+        let parser = AnthropicParser;
+        let mut state = parser.new_state();
+        let frame = Frame {
+            event: Some("content_block_delta".to_string()),
+            data: r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#
+                .to_string(),
+            kind: FrameKind::Data,
+        };
+
+        let events = parser.parse_frame(&frame, &mut state);
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], LlmEvent::TextDelta(text) if text == "Hello"));
+    }
+
+    #[test]
+    fn anthropic_invalid_json_frame_returns_no_events() {
+        let parser = AnthropicParser;
+        let mut state = parser.new_state();
+        let frame = Frame {
+            event: Some("content_block_delta".to_string()),
+            data: "not json".to_string(),
+            kind: FrameKind::Data,
+        };
+
+        let events = parser.parse_frame(&frame, &mut state);
+
+        assert!(events.is_empty());
+    }
+}

--- a/crates/aion-providers/src/projector.rs
+++ b/crates/aion-providers/src/projector.rs
@@ -1,0 +1,334 @@
+use aion_config::compat::{self, ProviderCompat};
+use aion_types::llm::{LlmRequest, ThinkingConfig};
+use serde_json::{Value, json};
+
+use crate::anthropic_shared;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WireParams {
+    pub anthropic_version: Option<&'static str>,
+    pub include_model_in_body: bool,
+    pub include_stream: bool,
+    pub cache_enabled: bool,
+    pub sanitize_schema: bool,
+}
+
+pub(crate) struct AnthropicWireProjector;
+
+impl AnthropicWireProjector {
+    pub(crate) fn project(
+        request: &LlmRequest,
+        compat: &ProviderCompat,
+        params: WireParams,
+    ) -> Value {
+        let system = if params.cache_enabled {
+            json!([{
+                "type": "text",
+                "text": &request.system,
+                "cache_control": { "type": "ephemeral" }
+            }])
+        } else {
+            json!(&request.system)
+        };
+
+        let mut body = json!({
+            "max_tokens": request.max_tokens,
+            "system": system,
+            "messages": anthropic_shared::build_messages(&request.messages, compat)
+        });
+
+        if params.include_model_in_body {
+            body["model"] = json!(request.model);
+        }
+
+        if let Some(version) = params.anthropic_version {
+            body["anthropic_version"] = json!(version);
+        }
+
+        if params.include_stream {
+            body["stream"] = json!(true);
+        }
+
+        if !request.tools.is_empty() {
+            let mut tools = anthropic_shared::build_tools(&request.tools);
+            if params.sanitize_schema {
+                for tool in &mut tools {
+                    if let Some(schema) = tool.get("input_schema").cloned() {
+                        tool["input_schema"] = compat::sanitize_json_schema(&schema);
+                    }
+                }
+            }
+            if let Some(last) = tools.last_mut().filter(|_| params.cache_enabled) {
+                last["cache_control"] = json!({ "type": "ephemeral" });
+            }
+            body["tools"] = json!(tools);
+        }
+
+        if let Some(ThinkingConfig::Enabled { budget_tokens }) = &request.thinking {
+            body["thinking"] = json!({
+                "type": "enabled",
+                "budget_tokens": budget_tokens
+            });
+        }
+
+        body
+    }
+}
+
+pub(crate) struct OpenAiProjector;
+
+impl OpenAiProjector {
+    pub(crate) fn project(request: &LlmRequest, compat: &ProviderCompat) -> Value {
+        let max_tokens_field = compat.max_tokens_field();
+
+        let mut body = json!({
+            "model": request.model,
+            "messages": crate::openai::OpenAIProvider::build_messages(
+                &request.messages,
+                &request.system,
+                compat,
+            ),
+            "stream": true,
+            "stream_options": { "include_usage": true }
+        });
+        body[max_tokens_field] = json!(request.max_tokens);
+
+        if !request.tools.is_empty() {
+            body["tools"] = json!(crate::openai::OpenAIProvider::build_tools(&request.tools));
+        }
+
+        if let Some(effort) = &request.reasoning_effort {
+            body["reasoning_effort"] = json!(effort);
+        }
+
+        body
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aion_types::message::{ContentBlock, Message, Role};
+    use aion_types::tool::ToolDef;
+
+    fn test_request(tools: Vec<ToolDef>, thinking: Option<ThinkingConfig>) -> LlmRequest {
+        LlmRequest {
+            model: "test-model".to_string(),
+            system: "You are a test assistant.".to_string(),
+            messages: vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            )],
+            tools,
+            max_tokens: 8192,
+            thinking,
+            reasoning_effort: None,
+        }
+    }
+
+    fn test_tools() -> Vec<ToolDef> {
+        vec![
+            ToolDef {
+                name: "read".to_string(),
+                description: "Read".to_string(),
+                input_schema: json!({"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}),
+                deferred: false,
+            },
+            ToolDef {
+                name: "list".to_string(),
+                description: "List".to_string(),
+                input_schema: json!({"type":"object","properties":{}}),
+                deferred: false,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_anthropic_wire_params_shape_anthropic_body() {
+        let request = test_request(
+            test_tools(),
+            Some(ThinkingConfig::Enabled {
+                budget_tokens: 4096,
+            }),
+        );
+
+        let body = AnthropicWireProjector::project(
+            &request,
+            &ProviderCompat::anthropic_defaults(),
+            WireParams {
+                anthropic_version: None,
+                include_model_in_body: true,
+                include_stream: true,
+                cache_enabled: true,
+                sanitize_schema: false,
+            },
+        );
+
+        assert_eq!(
+            body,
+            json!({
+                "model": "test-model",
+                "max_tokens": 8192,
+                "system": [{
+                    "type": "text",
+                    "text": "You are a test assistant.",
+                    "cache_control": { "type": "ephemeral" }
+                }],
+                "messages": [{
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hello"}]
+                }],
+                "stream": true,
+                "tools": [
+                    {
+                        "name": "read",
+                        "description": "Read",
+                        "input_schema": {"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}
+                    },
+                    {
+                        "name": "list",
+                        "description": "List",
+                        "input_schema": {"type":"object","properties":{}},
+                        "cache_control": { "type": "ephemeral" }
+                    }
+                ],
+                "thinking": {
+                    "type": "enabled",
+                    "budget_tokens": 4096
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_anthropic_wire_params_shape_bedrock_body() {
+        let request = test_request(test_tools(), None);
+
+        let body = AnthropicWireProjector::project(
+            &request,
+            &ProviderCompat::bedrock_defaults(),
+            WireParams {
+                anthropic_version: Some("bedrock-2023-05-31"),
+                include_model_in_body: false,
+                include_stream: false,
+                cache_enabled: false,
+                sanitize_schema: false,
+            },
+        );
+
+        assert_eq!(
+            body,
+            json!({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 8192,
+                "system": "You are a test assistant.",
+                "messages": [{
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hello"}]
+                }],
+                "tools": [
+                    {
+                        "name": "read",
+                        "description": "Read",
+                        "input_schema": {"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}
+                    },
+                    {
+                        "name": "list",
+                        "description": "List",
+                        "input_schema": {"type":"object","properties":{}}
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_anthropic_wire_params_shape_vertex_body() {
+        let request = test_request(vec![], None);
+
+        let body = AnthropicWireProjector::project(
+            &request,
+            &ProviderCompat::anthropic_defaults(),
+            WireParams {
+                anthropic_version: Some("vertex-2023-10-16"),
+                include_model_in_body: false,
+                include_stream: true,
+                cache_enabled: false,
+                sanitize_schema: false,
+            },
+        );
+
+        assert_eq!(
+            body,
+            json!({
+                "anthropic_version": "vertex-2023-10-16",
+                "max_tokens": 8192,
+                "system": "You are a test assistant.",
+                "messages": [{
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hello"}]
+                }],
+                "stream": true
+            })
+        );
+    }
+
+    #[test]
+    fn test_anthropic_wire_projector_sanitizes_schema_only_when_requested() {
+        let request = test_request(
+            vec![ToolDef {
+                name: "read".to_string(),
+                description: "Read".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {"path": {"type": ["string", "null"]}},
+                    "additionalProperties": false
+                }),
+                deferred: false,
+            }],
+            None,
+        );
+        let compat = ProviderCompat::bedrock_defaults();
+        let params = WireParams {
+            anthropic_version: Some("bedrock-2023-05-31"),
+            include_model_in_body: false,
+            include_stream: false,
+            cache_enabled: false,
+            sanitize_schema: false,
+        };
+
+        let unsanitized = AnthropicWireProjector::project(&request, &compat, params);
+        assert_eq!(
+            unsanitized["tools"][0]["input_schema"],
+            request.tools[0].input_schema
+        );
+
+        let sanitized = AnthropicWireProjector::project(
+            &request,
+            &compat,
+            WireParams {
+                sanitize_schema: true,
+                ..params
+            },
+        );
+        assert_eq!(
+            sanitized["tools"][0]["input_schema"],
+            compat::sanitize_json_schema(&request.tools[0].input_schema)
+        );
+        assert!(sanitized["tools"][0]["input_schema"]["additionalProperties"].is_null());
+    }
+
+    #[test]
+    fn test_openai_projector_uses_custom_max_tokens_field() {
+        let request = test_request(vec![], None);
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.transport.max_tokens_field = Some("max_completion_tokens".to_string());
+
+        let body = OpenAiProjector::project(&request, &compat);
+
+        assert_eq!(body["max_completion_tokens"], 8192);
+        assert!(body.get("max_tokens").is_none());
+    }
+}

--- a/crates/aion-providers/src/retry.rs
+++ b/crates/aion-providers/src/retry.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use reqwest::header::HeaderMap;
 use serde_json::Value;
 
-use super::anthropic_shared::StreamOutcome;
 use crate::error::ProviderError;
 
 /// Retry a fallible async operation with exponential backoff
@@ -107,27 +106,6 @@ pub async fn backoff_sleep(attempt: u32, current_backoff: Duration) -> Duration 
     );
     tokio::time::sleep(current_backoff).await;
     (current_backoff * 2).min(MAX_BACKOFF)
-}
-
-/// Evaluate a `StreamOutcome` within a retry loop. Returns:
-/// - `Ok(None)` — stream succeeded, stop retrying
-/// - `Ok(Some(err))` — non-retryable failure, caller should emit error
-/// - `Err(err)` — retryable failure, caller should continue loop
-pub fn evaluate_outcome(
-    outcome: StreamOutcome,
-    attempt: u32,
-) -> Result<Option<ProviderError>, ProviderError> {
-    match outcome {
-        StreamOutcome::Ok => Ok(None),
-        StreamOutcome::FailedPartial(e) => Ok(Some(e)),
-        StreamOutcome::FailedEmpty(e) => {
-            if attempt == MAX_STREAM_RETRIES {
-                Ok(Some(e))
-            } else {
-                Err(e)
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -243,53 +221,6 @@ mod tests {
             }
         ));
         assert_eq!(counter.load(Ordering::SeqCst), 1);
-    }
-
-    // --- evaluate_outcome tests ---
-
-    #[test]
-    fn test_evaluate_outcome_ok_stops_retry() {
-        let result = evaluate_outcome(StreamOutcome::Ok, 1);
-        assert!(matches!(result, Ok(None)));
-    }
-
-    #[test]
-    fn test_evaluate_outcome_failed_partial_always_stops() {
-        let err = ProviderError::Connection("disconnect".into());
-        let result = evaluate_outcome(StreamOutcome::FailedPartial(err), 1);
-        // FailedPartial means content was already emitted — cannot retry regardless of attempt
-        let Ok(Some(e)) = result else {
-            panic!("expected Ok(Some(err))")
-        };
-        assert!(matches!(e, ProviderError::Connection(_)));
-    }
-
-    #[test]
-    fn test_evaluate_outcome_failed_partial_on_last_attempt() {
-        let err = ProviderError::Connection("disconnect".into());
-        let result = evaluate_outcome(StreamOutcome::FailedPartial(err), MAX_STREAM_RETRIES);
-        let Ok(Some(_)) = result else {
-            panic!("expected Ok(Some(err))")
-        };
-    }
-
-    #[test]
-    fn test_evaluate_outcome_failed_empty_retries_when_not_exhausted() {
-        let err = ProviderError::Connection("disconnect".into());
-        // attempt 1 < MAX_STREAM_RETRIES(2), should signal "continue retrying"
-        let result = evaluate_outcome(StreamOutcome::FailedEmpty(err), 1);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_evaluate_outcome_failed_empty_stops_on_last_attempt() {
-        let err = ProviderError::Connection("disconnect".into());
-        // attempt == MAX_STREAM_RETRIES, should stop and return error
-        let result = evaluate_outcome(StreamOutcome::FailedEmpty(err), MAX_STREAM_RETRIES);
-        let Ok(Some(e)) = result else {
-            panic!("expected Ok(Some(err))")
-        };
-        assert!(matches!(e, ProviderError::Connection(_)));
     }
 
     // --- backoff_sleep tests ---

--- a/crates/aion-providers/src/snapshots/README.md
+++ b/crates/aion-providers/src/snapshots/README.md
@@ -1,0 +1,16 @@
+# Golden Body Snapshots
+
+Baseline of outbound HTTP request bodies for the two wire dialects
+(OpenAI-compatible, Anthropic-messages) across all current behavior branches.
+
+**Purpose:** regression safety net for the ProviderCompat sub-struct split and
+the TransportClient/RequestProjector/ResponseParser seam extraction. Any change
+to these `.snap` files during a refactor MUST be intentional and reviewed via
+`cargo insta review` — an unexpected diff means the refactor changed wire output.
+
+**Scenarios:** see `docs/superpowers/plans/2026-06-25-golden-body-snapshot-baseline.md`
+coverage matrix (13 scenarios across openai/anthropic/bedrock/vertex).
+
+**Updating:** when a wire-output change is intended, run `cargo insta review`,
+inspect each diff, accept only the intended ones, and commit the updated `.snap`
+alongside the code change.

--- a/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_basic.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_basic.snap
@@ -1,0 +1,21 @@
+---
+source: crates/aion-providers/src/anthropic.rs
+expression: p.build_request_body(&r)
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "Hello",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "stream": true,
+  "system": "You are a test assistant."
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_cache.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_cache.snap
@@ -1,0 +1,57 @@
+---
+source: crates/aion-providers/src/anthropic.rs
+expression: p.build_request_body(&r)
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "go",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "stream": true,
+  "system": [
+    {
+      "cache_control": {
+        "type": "ephemeral"
+      },
+      "text": "You are a test assistant.",
+      "type": "text"
+    }
+  ],
+  "tools": [
+    {
+      "description": "Read",
+      "input_schema": {
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "read"
+    },
+    {
+      "cache_control": {
+        "type": "ephemeral"
+      },
+      "description": "List",
+      "input_schema": {
+        "properties": {},
+        "type": "object"
+      },
+      "name": "list"
+    }
+  ]
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_thinking.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_thinking.snap
@@ -1,0 +1,25 @@
+---
+source: crates/aion-providers/src/anthropic.rs
+expression: p.build_request_body(&r)
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "q",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "stream": true,
+  "system": "You are a test assistant.",
+  "thinking": {
+    "budget_tokens": 4096,
+    "type": "enabled"
+  }
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_tools_no_cache.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_tools_no_cache.snap
@@ -1,0 +1,46 @@
+---
+source: crates/aion-providers/src/anthropic.rs
+expression: p.build_request_body(&r)
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "go",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "stream": true,
+  "system": "You are a test assistant.",
+  "tools": [
+    {
+      "description": "Read",
+      "input_schema": {
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "read"
+    },
+    {
+      "description": "List",
+      "input_schema": {
+        "properties": {},
+        "type": "object"
+      },
+      "name": "list"
+    }
+  ]
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__bedrock__tests__bedrock_basic.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__bedrock__tests__bedrock_basic.snap
@@ -1,0 +1,20 @@
+---
+source: crates/aion-providers/src/bedrock.rs
+expression: p.build_request_body(&r)
+---
+{
+  "anthropic_version": "bedrock-2023-05-31",
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "Hello",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "system": "You are a test assistant."
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__bedrock__tests__bedrock_with_tools.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__bedrock__tests__bedrock_with_tools.snap
@@ -1,0 +1,34 @@
+---
+source: crates/aion-providers/src/bedrock.rs
+expression: p.build_request_body(&r)
+---
+{
+  "anthropic_version": "bedrock-2023-05-31",
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "go",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "system": "You are a test assistant.",
+  "tools": [
+    {
+      "description": "Read",
+      "input_schema": {
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "name": "read"
+    }
+  ]
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_basic.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_basic.snap
@@ -1,0 +1,22 @@
+---
+source: crates/aion-providers/src/openai.rs
+expression: body
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": "You are a test assistant.",
+      "role": "system"
+    },
+    {
+      "content": "Hello",
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "stream": true,
+  "stream_options": {
+    "include_usage": true
+  }
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_custom_max_tokens_field.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_custom_max_tokens_field.snap
@@ -1,0 +1,22 @@
+---
+source: crates/aion-providers/src/openai.rs
+expression: provider.build_request_body(&request)
+---
+{
+  "max_completion_tokens": 8192,
+  "messages": [
+    {
+      "content": "You are a test assistant.",
+      "role": "system"
+    },
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "stream": true,
+  "stream_options": {
+    "include_usage": true
+  }
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_reasoning_effort.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_reasoning_effort.snap
@@ -1,0 +1,23 @@
+---
+source: crates/aion-providers/src/openai.rs
+expression: provider.build_request_body(&request)
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": "You are a test assistant.",
+      "role": "system"
+    },
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "reasoning_effort": "medium",
+  "stream": true,
+  "stream_options": {
+    "include_usage": true
+  }
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_thinking.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_thinking.snap
@@ -1,0 +1,31 @@
+---
+source: crates/aion-providers/src/openai.rs
+expression: "provider.build_request_body(&golden_req(messages, vec![]))"
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": "You are a test assistant.",
+      "role": "system"
+    },
+    {
+      "content": "q1",
+      "role": "user"
+    },
+    {
+      "content": "answer",
+      "reasoning_content": "let me think",
+      "role": "assistant"
+    },
+    {
+      "content": "q2",
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "stream": true,
+  "stream_options": {
+    "include_usage": true
+  }
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_tool_result.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_tool_result.snap
@@ -1,0 +1,36 @@
+---
+source: crates/aion-providers/src/openai.rs
+expression: "provider.build_request_body(&golden_req(messages, vec![]))"
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": "You are a test assistant.",
+      "role": "system"
+    },
+    {
+      "role": "assistant",
+      "tool_calls": [
+        {
+          "function": {
+            "arguments": "{\"path\":\"a.txt\"}",
+            "name": "read"
+          },
+          "id": "call_1",
+          "type": "function"
+        }
+      ]
+    },
+    {
+      "content": "file contents",
+      "role": "tool",
+      "tool_call_id": "call_1"
+    }
+  ],
+  "model": "test-model",
+  "stream": true,
+  "stream_options": {
+    "include_usage": true
+  }
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_tools.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_tools.snap
@@ -1,0 +1,53 @@
+---
+source: crates/aion-providers/src/openai.rs
+expression: provider.build_request_body(&request)
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": "You are a test assistant.",
+      "role": "system"
+    },
+    {
+      "content": "go",
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "stream": true,
+  "stream_options": {
+    "include_usage": true
+  },
+  "tools": [
+    {
+      "function": {
+        "description": "Read a file",
+        "name": "read",
+        "parameters": {
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "function"
+    },
+    {
+      "function": {
+        "description": "List dir",
+        "name": "list",
+        "parameters": {
+          "properties": {},
+          "type": "object"
+        }
+      },
+      "type": "function"
+    }
+  ]
+}

--- a/crates/aion-providers/src/snapshots/aion_providers__vertex__tests__vertex_basic.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__vertex__tests__vertex_basic.snap
@@ -1,0 +1,21 @@
+---
+source: crates/aion-providers/src/vertex.rs
+expression: p.build_request_body(&r)
+---
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "Hello",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "stream": true,
+  "system": "You are a test assistant."
+}

--- a/crates/aion-providers/src/stream_runner.rs
+++ b/crates/aion-providers/src/stream_runner.rs
@@ -1,0 +1,419 @@
+use std::future::Future;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use aion_types::llm::LlmEvent;
+
+use crate::ProviderError;
+
+#[derive(Debug)]
+pub(crate) enum StreamOutcome {
+    Ok,
+    FailedEmpty(ProviderError),
+    FailedPartial(ProviderError),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RetryPolicy {
+    pub max_stream_retries: u32,
+    pub initial_connect: bool,
+    pub can_resign: bool,
+}
+
+impl RetryPolicy {
+    pub(crate) const fn new(
+        max_stream_retries: u32,
+        initial_connect: bool,
+        can_resign: bool,
+    ) -> Self {
+        Self {
+            max_stream_retries,
+            initial_connect,
+            can_resign,
+        }
+    }
+}
+
+pub(crate) async fn run_stream<Resp, SendFn, SendFut, ProcessFn, ProcessFut>(
+    send: SendFn,
+    process: ProcessFn,
+    policy: RetryPolicy,
+) -> Result<mpsc::Receiver<LlmEvent>, ProviderError>
+where
+    Resp: Send + 'static,
+    SendFn: Fn() -> SendFut + Clone + Send + Sync + 'static,
+    SendFut: Future<Output = Result<Resp, ProviderError>> + Send + 'static,
+    ProcessFn: Fn(Resp, mpsc::Sender<LlmEvent>) -> ProcessFut + Clone + Send + Sync + 'static,
+    ProcessFut: Future<Output = StreamOutcome> + Send + 'static,
+{
+    let response = if policy.initial_connect {
+        crate::retry::with_initial_connect_retry(send.clone()).await?
+    } else {
+        send().await?
+    };
+
+    let (tx, rx) = mpsc::channel(64);
+
+    tokio::spawn(async move {
+        let mut response = response;
+
+        match process.clone()(response, tx.clone()).await {
+            StreamOutcome::Ok => {}
+            StreamOutcome::FailedPartial(err) => {
+                let _ = tx.send(LlmEvent::Error(err.to_string())).await;
+            }
+            StreamOutcome::FailedEmpty(err) => {
+                if !err.is_retryable() || !policy.can_resign || policy.max_stream_retries == 0 {
+                    let _ = tx.send(LlmEvent::Error(err.to_string())).await;
+                    return;
+                }
+
+                let mut backoff = Duration::from_secs(1);
+                let mut final_err = err;
+
+                for attempt in 1..=policy.max_stream_retries {
+                    tracing::warn!(
+                        attempt,
+                        max_stream_retries = policy.max_stream_retries,
+                        error = %final_err,
+                        "retrying stream after empty stream failure"
+                    );
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(15));
+
+                    match send.clone()().await {
+                        Ok(next_response) => {
+                            response = next_response;
+                            match process.clone()(response, tx.clone()).await {
+                                StreamOutcome::Ok => return,
+                                StreamOutcome::FailedPartial(err) => {
+                                    let _ = tx.send(LlmEvent::Error(err.to_string())).await;
+                                    return;
+                                }
+                                StreamOutcome::FailedEmpty(err) => {
+                                    final_err = err;
+                                    if !final_err.is_retryable()
+                                        || !policy.can_resign
+                                        || attempt == policy.max_stream_retries
+                                    {
+                                        let _ =
+                                            tx.send(LlmEvent::Error(final_err.to_string())).await;
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            final_err = err;
+                            if !is_retryable_resend_error(&final_err)
+                                || attempt == policy.max_stream_retries
+                            {
+                                let _ = tx.send(LlmEvent::Error(final_err.to_string())).await;
+                                return;
+                            }
+                        }
+                    }
+                }
+
+                let _ = tx.send(LlmEvent::Error(final_err.to_string())).await;
+            }
+        }
+    });
+
+    Ok(rx)
+}
+
+fn is_retryable_resend_error(error: &ProviderError) -> bool {
+    matches!(error, ProviderError::Http(_)) || error.is_retryable()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use super::*;
+
+    async fn reqwest_builder_error() -> reqwest::Error {
+        reqwest::Client::new()
+            .get("http://")
+            .send()
+            .await
+            .expect_err("invalid URL should fail before request")
+    }
+
+    #[tokio::test]
+    async fn test_run_stream_retries_failed_empty_then_emits_success() {
+        tokio::time::pause();
+
+        let send_count = Arc::new(AtomicU32::new(0));
+        let process_count = Arc::new(AtomicU32::new(0));
+
+        let mut rx = run_stream(
+            {
+                let send_count = Arc::clone(&send_count);
+                move || {
+                    let send_count = Arc::clone(&send_count);
+                    async move {
+                        let attempt = send_count.fetch_add(1, Ordering::SeqCst);
+                        Ok::<_, ProviderError>(attempt)
+                    }
+                }
+            },
+            {
+                let process_count = Arc::clone(&process_count);
+                move |attempt, tx| {
+                    let process_count = Arc::clone(&process_count);
+                    async move {
+                        process_count.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 0 {
+                            StreamOutcome::FailedEmpty(ProviderError::Connection(
+                                "disconnect".into(),
+                            ))
+                        } else {
+                            tx.send(LlmEvent::TextDelta("ok".into())).await.unwrap();
+                            StreamOutcome::Ok
+                        }
+                    }
+                }
+            },
+            RetryPolicy::new(2, false, true),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            rx.recv().await,
+            Some(LlmEvent::TextDelta(text)) if text == "ok"
+        ));
+        assert!(rx.recv().await.is_none());
+        assert_eq!(send_count.load(Ordering::SeqCst), 2);
+        assert_eq!(process_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_run_stream_retries_http_error_during_resend() {
+        tokio::time::pause();
+
+        let send_count = Arc::new(AtomicU32::new(0));
+        let process_count = Arc::new(AtomicU32::new(0));
+
+        let mut rx = run_stream(
+            {
+                let send_count = Arc::clone(&send_count);
+                move || {
+                    let send_count = Arc::clone(&send_count);
+                    async move {
+                        let attempt = send_count.fetch_add(1, Ordering::SeqCst);
+                        match attempt {
+                            0 => Ok(0),
+                            1 => Err(ProviderError::Http(reqwest_builder_error().await)),
+                            _ => Ok(2),
+                        }
+                    }
+                }
+            },
+            {
+                let process_count = Arc::clone(&process_count);
+                move |response, tx| {
+                    let process_count = Arc::clone(&process_count);
+                    async move {
+                        process_count.fetch_add(1, Ordering::SeqCst);
+                        if response == 0 {
+                            StreamOutcome::FailedEmpty(ProviderError::Connection(
+                                "disconnect".into(),
+                            ))
+                        } else {
+                            tx.send(LlmEvent::TextDelta("ok".into())).await.unwrap();
+                            StreamOutcome::Ok
+                        }
+                    }
+                }
+            },
+            RetryPolicy::new(2, false, true),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            rx.recv().await,
+            Some(LlmEvent::TextDelta(text)) if text == "ok"
+        ));
+        assert!(rx.recv().await.is_none());
+        assert_eq!(send_count.load(Ordering::SeqCst), 3);
+        assert_eq!(process_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_run_stream_stops_on_non_retryable_resend_error() {
+        tokio::time::pause();
+
+        let send_count = Arc::new(AtomicU32::new(0));
+        let process_count = Arc::new(AtomicU32::new(0));
+
+        let mut rx = run_stream(
+            {
+                let send_count = Arc::clone(&send_count);
+                move || {
+                    let send_count = Arc::clone(&send_count);
+                    async move {
+                        let attempt = send_count.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 0 {
+                            Ok(())
+                        } else {
+                            Err(ProviderError::Api {
+                                status: 401,
+                                message: "unauthorized".into(),
+                            })
+                        }
+                    }
+                }
+            },
+            {
+                let process_count = Arc::clone(&process_count);
+                move |(), _tx| {
+                    let process_count = Arc::clone(&process_count);
+                    async move {
+                        process_count.fetch_add(1, Ordering::SeqCst);
+                        StreamOutcome::FailedEmpty(ProviderError::Connection("disconnect".into()))
+                    }
+                }
+            },
+            RetryPolicy::new(2, false, true),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(rx.recv().await, Some(LlmEvent::Error(_))));
+        assert!(rx.recv().await.is_none());
+        assert_eq!(send_count.load(Ordering::SeqCst), 2);
+        assert_eq!(process_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_run_stream_does_not_retry_failed_partial() {
+        tokio::time::pause();
+
+        let send_count = Arc::new(AtomicU32::new(0));
+
+        let mut rx = run_stream(
+            {
+                let send_count = Arc::clone(&send_count);
+                move || {
+                    let send_count = Arc::clone(&send_count);
+                    async move {
+                        send_count.fetch_add(1, Ordering::SeqCst);
+                        Ok::<_, ProviderError>(())
+                    }
+                }
+            },
+            move |(), _tx| async move {
+                StreamOutcome::FailedPartial(ProviderError::Connection("disconnect".into()))
+            },
+            RetryPolicy::new(2, false, true),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(rx.recv().await, Some(LlmEvent::Error(_))));
+        assert!(rx.recv().await.is_none());
+        assert_eq!(send_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_run_stream_retries_initial_connect_when_enabled() {
+        tokio::time::pause();
+
+        let send_count = Arc::new(AtomicU32::new(0));
+
+        let mut rx = run_stream(
+            {
+                let send_count = Arc::clone(&send_count);
+                move || {
+                    let send_count = Arc::clone(&send_count);
+                    async move {
+                        let attempt = send_count.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 0 {
+                            Err(ProviderError::Connection("connection refused".into()))
+                        } else {
+                            Ok(())
+                        }
+                    }
+                }
+            },
+            move |(), tx| async move {
+                tx.send(LlmEvent::TextDelta("connected".into()))
+                    .await
+                    .unwrap();
+                StreamOutcome::Ok
+            },
+            RetryPolicy::new(2, true, true),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            rx.recv().await,
+            Some(LlmEvent::TextDelta(text)) if text == "connected"
+        ));
+        assert!(rx.recv().await.is_none());
+        assert_eq!(send_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_run_stream_does_not_retry_initial_connect_when_disabled() {
+        tokio::time::pause();
+
+        let send_count = Arc::new(AtomicU32::new(0));
+
+        let result = run_stream(
+            {
+                let send_count = Arc::clone(&send_count);
+                move || {
+                    let send_count = Arc::clone(&send_count);
+                    async move {
+                        send_count.fetch_add(1, Ordering::SeqCst);
+                        Err::<(), _>(ProviderError::Connection("connection refused".into()))
+                    }
+                }
+            },
+            move |(), _tx| async move { StreamOutcome::Ok },
+            RetryPolicy::new(2, false, true),
+        )
+        .await;
+
+        assert!(matches!(result, Err(ProviderError::Connection(_))));
+        assert_eq!(send_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_run_stream_respects_can_resign_false() {
+        tokio::time::pause();
+
+        let send_count = Arc::new(AtomicU32::new(0));
+
+        let mut rx = run_stream(
+            {
+                let send_count = Arc::clone(&send_count);
+                move || {
+                    let send_count = Arc::clone(&send_count);
+                    async move {
+                        send_count.fetch_add(1, Ordering::SeqCst);
+                        Ok::<_, ProviderError>(())
+                    }
+                }
+            },
+            move |(), _tx| async move {
+                StreamOutcome::FailedEmpty(ProviderError::Connection("disconnect".into()))
+            },
+            RetryPolicy::new(2, false, false),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(rx.recv().await, Some(LlmEvent::Error(_))));
+        assert!(rx.recv().await.is_none());
+        assert_eq!(send_count.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/aion-providers/src/vertex.rs
+++ b/crates/aion-providers/src/vertex.rs
@@ -410,3 +410,50 @@ pub fn auth_from_config(vc: &aion_config::config::VertexConfig) -> GcpAuth {
         GcpAuth::ApplicationDefault
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aion_config::compat::ProviderCompat;
+    use aion_types::message::{ContentBlock, Message, Role};
+    use aion_types::tool::ToolDef;
+
+    // --- Golden body snapshots (baseline for compat-split / seam-extraction refactors) ---
+
+    fn vertex_test_provider() -> VertexProvider {
+        VertexProvider::new(
+            "test-project",
+            "us-central1",
+            GcpAuth::ApplicationDefault,
+            false,
+            ProviderCompat::anthropic_defaults(),
+        )
+    }
+
+    fn vertex_req(messages: Vec<Message>, tools: Vec<ToolDef>) -> LlmRequest {
+        LlmRequest {
+            model: "test-model".to_string(),
+            system: "You are a test assistant.".to_string(),
+            messages,
+            tools,
+            max_tokens: 8192,
+            thinking: None,
+            reasoning_effort: None,
+        }
+    }
+
+    #[test]
+    fn golden_vertex_basic() {
+        let p = vertex_test_provider();
+        let r = vertex_req(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            )],
+            vec![],
+        );
+        insta::assert_json_snapshot!("vertex_basic", p.build_request_body(&r));
+    }
+}

--- a/crates/aion-providers/src/vertex.rs
+++ b/crates/aion-providers/src/vertex.rs
@@ -5,17 +5,20 @@ use async_trait::async_trait;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
-use std::sync::Mutex;
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 
-use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
+use aion_types::llm::{LlmEvent, LlmRequest};
 
 use super::anthropic_shared;
+use crate::projector::{AnthropicWireProjector, WireParams};
+use crate::stream_runner::{RetryPolicy, run_stream};
 use crate::{LlmProvider, ProviderError};
 use aion_config::compat::ProviderCompat;
 
+#[derive(Clone)]
 pub struct VertexProvider {
     client: reqwest::Client,
     project_id: String,
@@ -24,7 +27,7 @@ pub struct VertexProvider {
     cache_enabled: bool,
     compat: ProviderCompat,
     /// Cached access token
-    cached_token: Mutex<Option<CachedToken>>,
+    cached_token: Arc<Mutex<Option<CachedToken>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -54,7 +57,7 @@ impl VertexProvider {
             auth,
             cache_enabled,
             compat,
-            cached_token: Mutex::new(None),
+            cached_token: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -66,40 +69,17 @@ impl VertexProvider {
     }
 
     fn build_request_body(&self, request: &LlmRequest) -> Value {
-        let system = if self.cache_enabled {
-            json!([{
-                "type": "text",
-                "text": &request.system,
-                "cache_control": { "type": "ephemeral" }
-            }])
-        } else {
-            json!(&request.system)
-        };
-
-        let mut body = json!({
-            "anthropic_version": "vertex-2023-10-16",
-            "max_tokens": request.max_tokens,
-            "system": system,
-            "messages": anthropic_shared::build_messages(&request.messages, &self.compat),
-            "stream": true
-        });
-
-        if !request.tools.is_empty() {
-            let mut tools = anthropic_shared::build_tools(&request.tools);
-            if let Some(last) = tools.last_mut().filter(|_| self.cache_enabled) {
-                last["cache_control"] = json!({ "type": "ephemeral" });
-            }
-            body["tools"] = json!(tools);
-        }
-
-        if let Some(ThinkingConfig::Enabled { budget_tokens }) = &request.thinking {
-            body["thinking"] = json!({
-                "type": "enabled",
-                "budget_tokens": budget_tokens
-            });
-        }
-
-        body
+        AnthropicWireProjector::project(
+            request,
+            &self.compat,
+            WireParams {
+                anthropic_version: Some("vertex-2023-10-16"),
+                include_model_in_body: false,
+                include_stream: true,
+                cache_enabled: self.cache_enabled,
+                sanitize_schema: false,
+            },
+        )
     }
 
     async fn get_access_token(&self) -> Result<String, ProviderError> {
@@ -248,19 +228,12 @@ impl VertexProvider {
 
         Ok((token_resp.access_token, token_resp.expires_in))
     }
-}
 
-#[async_trait]
-impl LlmProvider for VertexProvider {
-    async fn stream(
+    async fn send_stream_request(
         &self,
-        request: &LlmRequest,
-    ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
-        let url = self.build_url(&request.model);
-        let body = self.build_request_body(request);
-
-        tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
-
+        url: &str,
+        body: &Value,
+    ) -> Result<reqwest::Response, ProviderError> {
         let access_token = self.get_access_token().await?;
 
         let mut headers = HeaderMap::new();
@@ -273,9 +246,9 @@ impl LlmProvider for VertexProvider {
 
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .headers(headers)
-            .json(&body)
+            .json(body)
             .send()
             .await?;
 
@@ -293,74 +266,43 @@ impl LlmProvider for VertexProvider {
             });
         }
 
-        let (tx, rx) = mpsc::channel(64);
-        let client = self.client.clone();
-        let url_clone = url.clone();
-        let headers_clone = {
-            let mut h = HeaderMap::new();
-            h.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-            h.insert(
-                AUTHORIZATION,
-                HeaderValue::from_str(&format!("Bearer {}", access_token))
-                    .map_err(|e| ProviderError::Connection(format!("Header error: {}", e)))?,
-            );
-            h
+        Ok(response)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for VertexProvider {
+    async fn stream(
+        &self,
+        request: &LlmRequest,
+    ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+        let url = self.build_url(&request.model);
+        let body = self.build_request_body(request);
+
+        tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
+
+        let provider = self.clone();
+        let send = {
+            let provider = provider.clone();
+            let url = url.clone();
+            let body = body.clone();
+            move || {
+                let provider = provider.clone();
+                let url = url.clone();
+                let body = body.clone();
+                async move { provider.send_stream_request(&url, &body).await }
+            }
+        };
+        let process = move |response, tx| async move {
+            anthropic_shared::process_sse_stream(response, &tx).await
         };
 
-        // Vertex uses standard SSE (same as Anthropic)
-        tokio::spawn(async move {
-            match anthropic_shared::process_sse_stream(response, &tx).await {
-                anthropic_shared::StreamOutcome::Ok => {}
-                anthropic_shared::StreamOutcome::FailedPartial(e) => {
-                    let _ = tx.send(LlmEvent::Error(e.to_string())).await;
-                }
-                anthropic_shared::StreamOutcome::FailedEmpty(e) => {
-                    if e.is_retryable() {
-                        let mut backoff = std::time::Duration::from_secs(1);
-                        let mut final_err = Some(e);
-                        for attempt in 1..=crate::retry::MAX_STREAM_RETRIES {
-                            backoff = crate::retry::backoff_sleep(attempt, backoff).await;
-                            match crate::retry::send_and_check(
-                                &client,
-                                &url_clone,
-                                &headers_clone,
-                                &body,
-                            )
-                            .await
-                            {
-                                Ok(resp) => {
-                                    let outcome =
-                                        anthropic_shared::process_sse_stream(resp, &tx).await;
-                                    match crate::retry::evaluate_outcome(outcome, attempt) {
-                                        Ok(None) => {
-                                            final_err = None;
-                                            break;
-                                        }
-                                        Ok(Some(e)) => {
-                                            final_err = Some(e);
-                                            break;
-                                        }
-                                        Err(_) => continue,
-                                    }
-                                }
-                                Err(e) if attempt == crate::retry::MAX_STREAM_RETRIES => {
-                                    final_err = Some(e);
-                                    break;
-                                }
-                                Err(_) => continue,
-                            }
-                        }
-                        if let Some(err) = final_err {
-                            let _ = tx.send(LlmEvent::Error(err.to_string())).await;
-                        }
-                    } else {
-                        let _ = tx.send(LlmEvent::Error(e.to_string())).await;
-                    }
-                }
-            }
-        });
-
-        Ok(rx)
+        run_stream(
+            send,
+            process,
+            RetryPolicy::new(crate::retry::MAX_STREAM_RETRIES, false, true),
+        )
+        .await
     }
 }
 

--- a/crates/aion-providers/tests/malformed_tool_call.rs
+++ b/crates/aion-providers/tests/malformed_tool_call.rs
@@ -198,7 +198,7 @@ async fn test_public_projection_downgrades_empty_id_when_auto_id_disabled() {
         .await;
 
     let mut compat = ProviderCompat::openai_defaults();
-    compat.auto_tool_id = Some(false);
+    compat.tools.auto_tool_id = Some(false);
     let provider = OpenAIProvider::new("test-key", &server.uri(), compat);
     let rx = provider.stream(&request).await.unwrap();
     let _ = collect_events(rx).await;


### PR DESCRIPTION
## Summary

This PR establishes the provider-contract baseline that later AIO issue fixes can stack on.

It includes:

- golden request-body snapshots for OpenAI, Anthropic, Bedrock, and Vertex wire dialects;
- a `ProviderCompat` domain split for transport, messages, tools, schema, and reasoning behavior while preserving legacy flattened TOML keys;
- shared provider seams for request projection, SSE/event framing, response parsing, and stream retry execution;
- a Bedrock regression fix that prevents duplicate final `Done` events.

## Why this is separate

This branch is intentionally a foundation PR, not the full provider-contract redesign. It locks down observable provider wire bodies and extracts low-risk seams before the user-facing AIO fixes land.

Follow-up PRs are expected to target this baseline first, then retarget or rebase to `main` after this PR merges.

## Explicit non-goals

This PR does not close these follow-up tasks by itself:

- AIO-68 tool-count/body-size preflight and projection error boundary;
- AIO-77 OpenAI-compatible field controls;
- AIO-140 tools wire-shape override and readable mismatch errors;
- AIO-8 universal schema legalization;
- AIO-129 OpenAI reasoning replay behavior;
- the full transport/provider composition refactor.

Those are split into follow-up worktrees/branches so each behavior change can carry focused regression tests and review.

## Verification

Targeted checks:

- [x] `cargo test -p aion-providers golden_`
  - 13 passed
- [x] `cargo test -p aion-providers projector`
  - 5 passed
- [x] `cargo test -p aion-config compat`
  - 27 passed
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p aion-providers --all-targets -- -D warnings`

Push gate:

- [x] `just push origin HEAD:refs/heads/boii/fix/golden-snapshot-baseline-pr`
  - ran `cargo fix --allow-dirty --allow-staged`
  - ran `cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged -- -D warnings`
  - ran `cargo fmt --all`
  - ran `cargo nextest run --workspace --profile default`
  - 2012 passed, 2 skipped