### PR TITLE
fix(providers): add projection preflight limits

### DIFF
--- a/crates/aion-config/src/compat.rs
+++ b/crates/aion-config/src/compat.rs
@@ -29,6 +29,10 @@ pub struct TransportCompat {
     /// Custom API path appended to base_url for chat completions.
     /// Default: "/v1/chat/completions" for OpenAI provider.
     pub api_path: Option<String>,
+
+    /// Maximum serialized provider request body size in bytes.
+    /// Default: None (no local preflight limit).
+    pub max_request_body_bytes: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -71,6 +75,10 @@ pub struct ToolCompat {
     /// Auto-generate tool IDs when missing.
     /// Default: true for anthropic/bedrock/vertex.
     pub auto_tool_id: Option<bool>,
+
+    /// Maximum number of tools allowed in the projected provider request.
+    /// Default: None (no local preflight limit).
+    pub max_tool_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -100,6 +108,9 @@ impl TransportCompat {
         Self {
             max_tokens_field: user.max_tokens_field.or(defaults.max_tokens_field),
             api_path: user.api_path.or(defaults.api_path),
+            max_request_body_bytes: user
+                .max_request_body_bytes
+                .or(defaults.max_request_body_bytes),
         }
     }
 }
@@ -131,6 +142,7 @@ impl ToolCompat {
                 .sanitize_malformed_tool_calls
                 .or(defaults.sanitize_malformed_tool_calls),
             auto_tool_id: user.auto_tool_id.or(defaults.auto_tool_id),
+            max_tool_count: user.max_tool_count.or(defaults.max_tool_count),
         }
     }
 }
@@ -220,6 +232,7 @@ impl ProviderCompat {
                 clean_orphan_tool_calls: Some(true),
                 sanitize_malformed_tool_calls: Some(true),
                 auto_tool_id: Some(true),
+                ..Default::default()
             },
             reasoning: ReasoningCompat {
                 supports_thinking: Some(false),
@@ -248,6 +261,14 @@ impl ProviderCompat {
             .max_tokens_field
             .as_deref()
             .unwrap_or("max_tokens")
+    }
+
+    pub fn max_request_body_bytes(&self) -> Option<usize> {
+        self.transport.max_request_body_bytes
+    }
+
+    pub fn max_tool_count(&self) -> Option<usize> {
+        self.tools.max_tool_count
     }
 
     pub fn merge_assistant_messages(&self) -> bool {
@@ -371,11 +392,13 @@ mod tests {
         let toml_str = r#"
 max_tokens_field = "max_completion_tokens"
 api_path = "/chat/completions"
+max_request_body_bytes = 1048576
 merge_assistant_messages = true
 clean_orphan_tool_results = false
 dedup_tool_results = true
 clean_orphan_tool_calls = true
 sanitize_malformed_tool_calls = false
+max_tool_count = 512
 ensure_alternation = true
 merge_same_role = true
 sanitize_schema = true
@@ -396,6 +419,7 @@ effort_levels = ["low", "medium"]
             compat.transport.api_path.as_deref(),
             Some("/chat/completions")
         );
+        assert_eq!(compat.max_request_body_bytes(), Some(1_048_576));
         assert_eq!(compat.messages.merge_assistant_messages, Some(true));
         assert_eq!(compat.messages.clean_orphan_tool_results, Some(false));
         assert_eq!(compat.messages.dedup_tool_results, Some(true));
@@ -408,6 +432,7 @@ effort_levels = ["low", "medium"]
         assert_eq!(compat.tools.clean_orphan_tool_calls, Some(true));
         assert_eq!(compat.tools.sanitize_malformed_tool_calls, Some(false));
         assert_eq!(compat.tools.auto_tool_id, Some(true));
+        assert_eq!(compat.max_tool_count(), Some(512));
         assert_eq!(compat.schema.sanitize_schema, Some(true));
         assert_eq!(compat.reasoning.supports_thinking, Some(true));
         assert_eq!(compat.reasoning.supports_effort, Some(false));
@@ -423,6 +448,7 @@ effort_levels = ["low", "medium"]
             transport: TransportCompat {
                 max_tokens_field: Some("max_completion_tokens".to_string()),
                 api_path: Some("/chat/completions".to_string()),
+                max_request_body_bytes: Some(1_048_576),
             },
             messages: MessageCompat {
                 merge_assistant_messages: Some(true),
@@ -436,6 +462,7 @@ effort_levels = ["low", "medium"]
                 clean_orphan_tool_calls: Some(true),
                 sanitize_malformed_tool_calls: Some(false),
                 auto_tool_id: Some(true),
+                max_tool_count: Some(512),
             },
             schema: SchemaCompat {
                 sanitize_schema: Some(true),
@@ -451,11 +478,13 @@ effort_levels = ["low", "medium"]
 
         assert!(toml.contains("max_tokens_field = \"max_completion_tokens\""));
         assert!(toml.contains("api_path = \"/chat/completions\""));
+        assert!(toml.contains("max_request_body_bytes = 1048576"));
         assert!(toml.contains("merge_assistant_messages = true"));
         assert!(toml.contains("clean_orphan_tool_results = false"));
         assert!(toml.contains("dedup_tool_results = true"));
         assert!(toml.contains("clean_orphan_tool_calls = true"));
         assert!(toml.contains("sanitize_malformed_tool_calls = false"));
+        assert!(toml.contains("max_tool_count = 512"));
         assert!(toml.contains("ensure_alternation = true"));
         assert!(toml.contains("merge_same_role = true"));
         assert!(toml.contains("sanitize_schema = true"));
@@ -478,6 +507,7 @@ effort_levels = ["low", "medium"]
             transport: TransportCompat {
                 max_tokens_field: Some("max_completion_tokens".to_string()),
                 api_path: Some("/chat/completions".to_string()),
+                max_request_body_bytes: Some(2_048),
             },
             messages: MessageCompat {
                 merge_assistant_messages: Some(false),
@@ -491,6 +521,7 @@ effort_levels = ["low", "medium"]
                 clean_orphan_tool_calls: Some(false),
                 sanitize_malformed_tool_calls: Some(false),
                 auto_tool_id: Some(false),
+                max_tool_count: Some(42),
             },
             schema: SchemaCompat {
                 sanitize_schema: Some(true),
@@ -512,11 +543,13 @@ effort_levels = ["low", "medium"]
             merged.transport.api_path.as_deref(),
             Some("/chat/completions")
         );
+        assert_eq!(merged.max_request_body_bytes(), Some(2_048));
         assert!(!merged.merge_assistant_messages());
         assert!(!merged.clean_orphan_tool_calls());
         assert!(!merged.clean_orphan_tool_results());
         assert!(merged.dedup_tool_results());
         assert!(!merged.sanitize_malformed_tool_calls());
+        assert_eq!(merged.max_tool_count(), Some(42));
         assert!(merged.sanitize_schema());
         assert!(!merged.auto_tool_id());
         assert!(merged.supports_thinking());

--- a/crates/aion-config/src/config.rs
+++ b/crates/aion-config/src/config.rs
@@ -2283,6 +2283,49 @@ effort_levels = ["low", "medium"]
     }
 
     #[test]
+    fn test_config_resolve_loads_flat_provider_max_tool_count_limits() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".aionrs.toml"),
+            r#"
+[default]
+provider = "gemini"
+model = "test-model"
+
+[providers.gemini]
+provider = "openai"
+api_key = "test-key"
+base_url = "https://example.test/v1"
+
+[providers.gemini.compat]
+max_tool_count = 512
+max_request_body_bytes = 1048576
+"#,
+        )
+        .unwrap();
+
+        let cli = CliArgs {
+            provider: None,
+            api_key: None,
+            base_url: None,
+            model: None,
+            max_tokens: None,
+            max_turns: None,
+            max_tool_call_malformed_turns: None,
+            max_tool_call_failure_turns: None,
+            system_prompt: None,
+            profile: None,
+            auto_approve: false,
+            project_dir: Some(tmp.path().to_path_buf()),
+        };
+
+        let config = Config::resolve(&cli).unwrap();
+
+        assert_eq!(config.compat.max_tool_count(), Some(512));
+        assert_eq!(config.compat.max_request_body_bytes(), Some(1_048_576));
+    }
+
+    #[test]
     fn test_resolve_zero_max_turns_disables_turn_limit() {
         let tmp = tempfile::tempdir().unwrap();
         let cli_args = CliArgs {

--- a/crates/aion-providers/src/anthropic.rs
+++ b/crates/aion-providers/src/anthropic.rs
@@ -6,7 +6,9 @@ use tokio::sync::mpsc;
 use aion_types::llm::{LlmEvent, LlmRequest};
 
 use super::anthropic_shared;
-use crate::projector::{AnthropicWireProjector, WireParams};
+use crate::projector::{
+    AnthropicWireProjector, WireParams, WireProvider, projection_to_provider_error,
+};
 use crate::stream_runner::{RetryPolicy, run_stream};
 use crate::{LlmProvider, ProviderError};
 use aion_config::compat::ProviderCompat;
@@ -51,11 +53,12 @@ impl AnthropicProvider {
         Ok(headers)
     }
 
-    fn build_request_body(&self, request: &LlmRequest) -> Value {
+    fn build_request_body(&self, request: &LlmRequest) -> Result<Value, ProviderError> {
         AnthropicWireProjector::project(
             request,
             &self.compat,
             WireParams {
+                provider: WireProvider::Anthropic,
                 anthropic_version: None,
                 include_model_in_body: true,
                 include_stream: true,
@@ -63,6 +66,7 @@ impl AnthropicProvider {
                 sanitize_schema: false,
             },
         )
+        .map_err(projection_to_provider_error)
     }
 }
 
@@ -103,7 +107,7 @@ impl LlmProvider for AnthropicProvider {
         request: &LlmRequest,
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = format!("{}/v1/messages", self.base_url);
-        let body = self.build_request_body(request);
+        let body = self.build_request_body(request)?;
 
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
 
@@ -196,7 +200,11 @@ mod tests {
             vec![],
             None,
         );
-        insta::assert_json_snapshot!("anthropic_basic", p.build_request_body(&r));
+        insta::assert_json_snapshot!(
+            "anthropic_basic",
+            p.build_request_body(&r)
+                .expect("request body projection should succeed")
+        );
     }
 
     #[test]
@@ -212,7 +220,11 @@ mod tests {
             atools(),
             None,
         );
-        insta::assert_json_snapshot!("anthropic_with_tools_no_cache", p.build_request_body(&r));
+        insta::assert_json_snapshot!(
+            "anthropic_with_tools_no_cache",
+            p.build_request_body(&r)
+                .expect("request body projection should succeed")
+        );
     }
 
     #[test]
@@ -228,7 +240,11 @@ mod tests {
             atools(),
             None,
         );
-        insta::assert_json_snapshot!("anthropic_with_cache", p.build_request_body(&r));
+        insta::assert_json_snapshot!(
+            "anthropic_with_cache",
+            p.build_request_body(&r)
+                .expect("request body projection should succeed")
+        );
     }
 
     #[test]
@@ -246,6 +262,10 @@ mod tests {
                 budget_tokens: 4096,
             }),
         );
-        insta::assert_json_snapshot!("anthropic_with_thinking", p.build_request_body(&r));
+        insta::assert_json_snapshot!(
+            "anthropic_with_thinking",
+            p.build_request_body(&r)
+                .expect("request body projection should succeed")
+        );
     }
 }

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -17,7 +17,9 @@ use aion_types::message::{StopReason, TokenUsage};
 
 use crate::framing::bedrock_payload_to_frame;
 use crate::parser::ResponseParser;
-use crate::projector::{AnthropicWireProjector, WireParams};
+use crate::projector::{
+    AnthropicWireProjector, WireParams, WireProvider, projection_to_provider_error,
+};
 use crate::stream_runner::StreamOutcome;
 use crate::{LlmProvider, ProviderError};
 use aion_config::compat::ProviderCompat;
@@ -57,11 +59,12 @@ impl BedrockProvider {
         }
     }
 
-    fn build_request_body(&self, request: &LlmRequest) -> Value {
+    fn build_request_body(&self, request: &LlmRequest) -> Result<Value, ProviderError> {
         AnthropicWireProjector::project(
             request,
             &self.compat,
             WireParams {
+                provider: WireProvider::Bedrock,
                 anthropic_version: Some("bedrock-2023-05-31"),
                 include_model_in_body: false,
                 include_stream: false,
@@ -69,6 +72,7 @@ impl BedrockProvider {
                 sanitize_schema: self.compat.sanitize_schema(),
             },
         )
+        .map_err(projection_to_provider_error)
     }
 
     fn build_url(&self, model: &str) -> String {
@@ -216,7 +220,7 @@ impl LlmProvider for BedrockProvider {
         request: &LlmRequest,
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = self.build_url(&request.model);
-        let body = self.build_request_body(request);
+        let body = self.build_request_body(request)?;
 
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
 
@@ -544,7 +548,11 @@ mod tests {
             )],
             vec![],
         );
-        insta::assert_json_snapshot!("bedrock_basic", p.build_request_body(&r));
+        insta::assert_json_snapshot!(
+            "bedrock_basic",
+            p.build_request_body(&r)
+                .expect("request body projection should succeed")
+        );
     }
 
     #[test]
@@ -559,7 +567,11 @@ mod tests {
             )],
             bedrock_tools(),
         );
-        insta::assert_json_snapshot!("bedrock_with_tools", p.build_request_body(&r));
+        insta::assert_json_snapshot!(
+            "bedrock_with_tools",
+            p.build_request_body(&r)
+                .expect("request body projection should succeed")
+        );
     }
 
     #[tokio::test]

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -10,6 +10,7 @@ use aion_types::tool::{ToolDef, truncate_deferred_description};
 
 use crate::framing::{FrameKind, SseLineFramer};
 use crate::parser::{OpenAiParser, ResponseParser};
+use crate::projector::{OpenAiProjector, projection_to_provider_error};
 use crate::stream_runner::{RetryPolicy, StreamOutcome, run_stream};
 use crate::tool_call_sanitize::{DroppedToolCallReason, format_dropped_tool_call};
 use crate::{LlmProvider, ProviderError};
@@ -365,8 +366,8 @@ impl OpenAIProvider {
             .collect()
     }
 
-    fn build_request_body(&self, request: &LlmRequest) -> Value {
-        crate::projector::OpenAiProjector::project(request, &self.compat)
+    fn build_request_body(&self, request: &LlmRequest) -> Result<Value, ProviderError> {
+        OpenAiProjector::project(request, &self.compat).map_err(projection_to_provider_error)
     }
 }
 
@@ -590,7 +591,7 @@ impl LlmProvider for OpenAIProvider {
         request: &LlmRequest,
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = format!("{}{}", self.base_url, self.compat.api_path());
-        let body = self.build_request_body(request);
+        let body = self.build_request_body(request)?;
         let headers = self.build_headers()?;
 
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
@@ -860,7 +861,9 @@ mod tests {
             thinking: None,
             reasoning_effort: None,
         };
-        let body = provider.build_request_body(&req);
+        let body = provider
+            .build_request_body(&req)
+            .expect("request body projection should succeed");
         assert_eq!(body["max_tokens"], 1024);
         assert!(body.get("max_completion_tokens").is_none());
     }
@@ -884,9 +887,44 @@ mod tests {
             thinking: None,
             reasoning_effort: None,
         };
-        let body = provider.build_request_body(&req);
+        let body = provider
+            .build_request_body(&req)
+            .expect("request body projection should succeed");
         assert_eq!(body["max_completion_tokens"], 2048);
         assert!(body.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn test_projection_limit_maps_to_non_retryable_prompt_too_long() {
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.tools.max_tool_count = Some(0);
+        let provider = OpenAIProvider::new("key", "http://localhost", compat);
+        let req = LlmRequest {
+            model: "gpt-4o".into(),
+            system: String::new(),
+            messages: vec![],
+            tools: vec![ToolDef {
+                name: "read".into(),
+                description: "Read".into(),
+                input_schema: json!({"type":"object","properties":{}}),
+                deferred: false,
+            }],
+            max_tokens: 1024,
+            thinking: None,
+            reasoning_effort: None,
+        };
+
+        let error = provider
+            .build_request_body(&req)
+            .expect_err("projection limit should map to provider error");
+
+        match &error {
+            ProviderError::PromptTooLong(message) => {
+                assert!(message.contains("openai tools count 1 exceeds configured limit 0"));
+            }
+            other => panic!("unexpected provider error: {other}"),
+        }
+        assert!(!error.is_retryable());
     }
 
     // --- merge_assistant_messages ---
@@ -1885,7 +1923,9 @@ mod tests {
             )],
             vec![],
         );
-        let body = provider.build_request_body(&request);
+        let body = provider
+            .build_request_body(&request)
+            .expect("request body projection should succeed");
         insta::assert_json_snapshot!("openai_basic", body);
     }
 
@@ -1918,7 +1958,12 @@ mod tests {
             )],
             sample_tools(),
         );
-        insta::assert_json_snapshot!("openai_with_tools", provider.build_request_body(&request));
+        insta::assert_json_snapshot!(
+            "openai_with_tools",
+            provider
+                .build_request_body(&request)
+                .expect("request body projection should succeed")
+        );
     }
 
     #[test]
@@ -1945,7 +1990,9 @@ mod tests {
         ];
         insta::assert_json_snapshot!(
             "openai_with_tool_result",
-            provider.build_request_body(&golden_req(messages, vec![]))
+            provider
+                .build_request_body(&golden_req(messages, vec![]))
+                .expect("request body projection should succeed")
         );
     }
 
@@ -1980,7 +2027,9 @@ mod tests {
         ];
         insta::assert_json_snapshot!(
             "openai_with_thinking",
-            provider.build_request_body(&golden_req(messages, vec![]))
+            provider
+                .build_request_body(&golden_req(messages, vec![]))
+                .expect("request body projection should succeed")
         );
     }
 
@@ -1999,7 +2048,9 @@ mod tests {
         request.reasoning_effort = Some("medium".to_string());
         insta::assert_json_snapshot!(
             "openai_with_reasoning_effort",
-            provider.build_request_body(&request)
+            provider
+                .build_request_body(&request)
+                .expect("request body projection should succeed")
         );
     }
 
@@ -2019,7 +2070,9 @@ mod tests {
         );
         insta::assert_json_snapshot!(
             "openai_custom_max_tokens_field",
-            provider.build_request_body(&request)
+            provider
+                .build_request_body(&request)
+                .expect("request body projection should succeed")
         );
     }
 }

--- a/crates/aion-providers/src/projector.rs
+++ b/crates/aion-providers/src/projector.rs
@@ -1,11 +1,68 @@
 use aion_config::compat::{self, ProviderCompat};
 use aion_types::llm::{LlmRequest, ThinkingConfig};
 use serde_json::{Value, json};
+use std::fmt;
 
+use crate::ProviderError;
 use crate::anthropic_shared;
+use crate::openai::OpenAIProvider;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WireProvider {
+    OpenAi,
+    Anthropic,
+    Bedrock,
+    Vertex,
+}
+
+impl WireProvider {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::OpenAi => "openai",
+            Self::Anthropic => "anthropic",
+            Self::Bedrock => "bedrock",
+            Self::Vertex => "vertex",
+        }
+    }
+}
+
+impl fmt::Display for WireProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ProjectionError {
+    #[error("{provider} tools count {count} exceeds configured limit {max}")]
+    ToolLimitExceeded {
+        provider: WireProvider,
+        count: usize,
+        max: usize,
+    },
+    #[error(
+        "{provider} request body is {bytes} bytes, exceeding configured limit {max_bytes} bytes"
+    )]
+    BodyLimitExceeded {
+        provider: WireProvider,
+        bytes: usize,
+        max_bytes: usize,
+    },
+    #[error("{provider} tool schema for {tool_name} is invalid: {reason}")]
+    SchemaInvalid {
+        provider: WireProvider,
+        tool_name: String,
+        reason: String,
+    },
+}
+
+pub(crate) fn projection_to_provider_error(error: ProjectionError) -> ProviderError {
+    ProviderError::PromptTooLong(error.to_string())
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct WireParams {
+    pub provider: WireProvider,
     pub anthropic_version: Option<&'static str>,
     pub include_model_in_body: bool,
     pub include_stream: bool,
@@ -20,7 +77,7 @@ impl AnthropicWireProjector {
         request: &LlmRequest,
         compat: &ProviderCompat,
         params: WireParams,
-    ) -> Value {
+    ) -> Result<Value, ProjectionError> {
         let system = if params.cache_enabled {
             json!([{
                 "type": "text",
@@ -49,8 +106,10 @@ impl AnthropicWireProjector {
             body["stream"] = json!(true);
         }
 
+        let mut tool_count = 0;
         if !request.tools.is_empty() {
             let mut tools = anthropic_shared::build_tools(&request.tools);
+            tool_count = tools.len();
             if params.sanitize_schema {
                 for tool in &mut tools {
                     if let Some(schema) = tool.get("input_schema").cloned() {
@@ -71,19 +130,24 @@ impl AnthropicWireProjector {
             });
         }
 
-        body
+        preflight_projected_body(params.provider, &body, tool_count, compat)?;
+
+        Ok(body)
     }
 }
 
 pub(crate) struct OpenAiProjector;
 
 impl OpenAiProjector {
-    pub(crate) fn project(request: &LlmRequest, compat: &ProviderCompat) -> Value {
+    pub(crate) fn project(
+        request: &LlmRequest,
+        compat: &ProviderCompat,
+    ) -> Result<Value, ProjectionError> {
         let max_tokens_field = compat.max_tokens_field();
 
         let mut body = json!({
             "model": request.model,
-            "messages": crate::openai::OpenAIProvider::build_messages(
+            "messages": OpenAIProvider::build_messages(
                 &request.messages,
                 &request.system,
                 compat,
@@ -93,16 +157,57 @@ impl OpenAiProjector {
         });
         body[max_tokens_field] = json!(request.max_tokens);
 
+        let mut tool_count = 0;
         if !request.tools.is_empty() {
-            body["tools"] = json!(crate::openai::OpenAIProvider::build_tools(&request.tools));
+            let tools = OpenAIProvider::build_tools(&request.tools);
+            tool_count = tools.len();
+            body["tools"] = json!(tools);
         }
 
         if let Some(effort) = &request.reasoning_effort {
             body["reasoning_effort"] = json!(effort);
         }
 
-        body
+        preflight_projected_body(WireProvider::OpenAi, &body, tool_count, compat)?;
+
+        Ok(body)
     }
+}
+
+fn preflight_projected_body(
+    provider: WireProvider,
+    body: &Value,
+    tool_count: usize,
+    compat: &ProviderCompat,
+) -> Result<(), ProjectionError> {
+    if let Some(max) = compat.max_tool_count()
+        && tool_count > max
+    {
+        return Err(ProjectionError::ToolLimitExceeded {
+            provider,
+            count: tool_count,
+            max,
+        });
+    }
+
+    if let Some(max_bytes) = compat.max_request_body_bytes() {
+        let bytes = serde_json::to_vec(body)
+            .map_err(|error| ProjectionError::SchemaInvalid {
+                provider,
+                tool_name: "<request-body>".to_string(),
+                reason: error.to_string(),
+            })?
+            .len();
+        if bytes > max_bytes {
+            return Err(ProjectionError::BodyLimitExceeded {
+                provider,
+                bytes,
+                max_bytes,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -145,6 +250,17 @@ mod tests {
         ]
     }
 
+    fn numbered_tools(count: usize) -> Vec<ToolDef> {
+        (0..count)
+            .map(|index| ToolDef {
+                name: format!("tool_{index}"),
+                description: format!("Tool {index}"),
+                input_schema: json!({"type":"object","properties":{}}),
+                deferred: false,
+            })
+            .collect()
+    }
+
     #[test]
     fn test_anthropic_wire_params_shape_anthropic_body() {
         let request = test_request(
@@ -158,13 +274,15 @@ mod tests {
             &request,
             &ProviderCompat::anthropic_defaults(),
             WireParams {
+                provider: WireProvider::Anthropic,
                 anthropic_version: None,
                 include_model_in_body: true,
                 include_stream: true,
                 cache_enabled: true,
                 sanitize_schema: false,
             },
-        );
+        )
+        .expect("request body projection should succeed");
 
         assert_eq!(
             body,
@@ -210,13 +328,15 @@ mod tests {
             &request,
             &ProviderCompat::bedrock_defaults(),
             WireParams {
+                provider: WireProvider::Bedrock,
                 anthropic_version: Some("bedrock-2023-05-31"),
                 include_model_in_body: false,
                 include_stream: false,
                 cache_enabled: false,
                 sanitize_schema: false,
             },
-        );
+        )
+        .expect("request body projection should succeed");
 
         assert_eq!(
             body,
@@ -252,13 +372,15 @@ mod tests {
             &request,
             &ProviderCompat::anthropic_defaults(),
             WireParams {
+                provider: WireProvider::Vertex,
                 anthropic_version: Some("vertex-2023-10-16"),
                 include_model_in_body: false,
                 include_stream: true,
                 cache_enabled: false,
                 sanitize_schema: false,
             },
-        );
+        )
+        .expect("request body projection should succeed");
 
         assert_eq!(
             body,
@@ -293,13 +415,15 @@ mod tests {
         let compat = ProviderCompat::bedrock_defaults();
         let params = WireParams {
             anthropic_version: Some("bedrock-2023-05-31"),
+            provider: WireProvider::Bedrock,
             include_model_in_body: false,
             include_stream: false,
             cache_enabled: false,
             sanitize_schema: false,
         };
 
-        let unsanitized = AnthropicWireProjector::project(&request, &compat, params);
+        let unsanitized = AnthropicWireProjector::project(&request, &compat, params)
+            .expect("request body projection should succeed");
         assert_eq!(
             unsanitized["tools"][0]["input_schema"],
             request.tools[0].input_schema
@@ -312,7 +436,8 @@ mod tests {
                 sanitize_schema: true,
                 ..params
             },
-        );
+        )
+        .expect("request body projection should succeed");
         assert_eq!(
             sanitized["tools"][0]["input_schema"],
             compat::sanitize_json_schema(&request.tools[0].input_schema)
@@ -326,9 +451,85 @@ mod tests {
         let mut compat = ProviderCompat::openai_defaults();
         compat.transport.max_tokens_field = Some("max_completion_tokens".to_string());
 
-        let body = OpenAiProjector::project(&request, &compat);
+        let body = OpenAiProjector::project(&request, &compat)
+            .expect("request body projection should succeed");
 
         assert_eq!(body["max_completion_tokens"], 8192);
         assert!(body.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn test_openai_projector_returns_success_result() {
+        let request = test_request(vec![], None);
+        let body = OpenAiProjector::project(&request, &ProviderCompat::openai_defaults())
+            .expect("request body projection should succeed");
+
+        assert_eq!(body["model"], "test-model");
+    }
+
+    #[test]
+    fn test_anthropic_projector_returns_success_result() {
+        let request = test_request(vec![], None);
+        let body = AnthropicWireProjector::project(
+            &request,
+            &ProviderCompat::anthropic_defaults(),
+            WireParams {
+                provider: WireProvider::Anthropic,
+                anthropic_version: None,
+                include_model_in_body: true,
+                include_stream: true,
+                cache_enabled: false,
+                sanitize_schema: false,
+            },
+        )
+        .expect("request body projection should succeed");
+
+        assert_eq!(body["model"], "test-model");
+    }
+
+    #[test]
+    fn test_preflight_tool_count_limit_rejects_openai_tools() {
+        let request = test_request(numbered_tools(513), None);
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.tools.max_tool_count = Some(512);
+
+        let error = OpenAiProjector::project(&request, &compat)
+            .expect_err("tool count over the configured limit should fail");
+
+        match error {
+            ProjectionError::ToolLimitExceeded {
+                provider,
+                count,
+                max,
+            } => {
+                assert_eq!(provider, WireProvider::OpenAi);
+                assert_eq!(count, 513);
+                assert_eq!(max, 512);
+            }
+            other => panic!("unexpected projection error: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_preflight_request_body_size_limit_rejects_openai_body() {
+        let request = test_request(vec![], None);
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.transport.max_request_body_bytes = Some(1);
+
+        let error = OpenAiProjector::project(&request, &compat)
+            .expect_err("request body over the configured byte limit should fail");
+
+        match error {
+            ProjectionError::BodyLimitExceeded {
+                provider,
+                bytes,
+                max_bytes,
+            } => {
+                assert_eq!(provider, WireProvider::OpenAi);
+                assert!(bytes > 1);
+                assert_eq!(max_bytes, 1);
+            }
+            other => panic!("unexpected projection error: {other}"),
+        }
     }
 }

--- a/crates/aion-providers/src/vertex.rs
+++ b/crates/aion-providers/src/vertex.rs
@@ -13,7 +13,9 @@ use tokio::sync::mpsc;
 use aion_types::llm::{LlmEvent, LlmRequest};
 
 use super::anthropic_shared;
-use crate::projector::{AnthropicWireProjector, WireParams};
+use crate::projector::{
+    AnthropicWireProjector, WireParams, WireProvider, projection_to_provider_error,
+};
 use crate::stream_runner::{RetryPolicy, run_stream};
 use crate::{LlmProvider, ProviderError};
 use aion_config::compat::ProviderCompat;
@@ -68,11 +70,12 @@ impl VertexProvider {
         )
     }
 
-    fn build_request_body(&self, request: &LlmRequest) -> Value {
+    fn build_request_body(&self, request: &LlmRequest) -> Result<Value, ProviderError> {
         AnthropicWireProjector::project(
             request,
             &self.compat,
             WireParams {
+                provider: WireProvider::Vertex,
                 anthropic_version: Some("vertex-2023-10-16"),
                 include_model_in_body: false,
                 include_stream: true,
@@ -80,6 +83,7 @@ impl VertexProvider {
                 sanitize_schema: false,
             },
         )
+        .map_err(projection_to_provider_error)
     }
 
     async fn get_access_token(&self) -> Result<String, ProviderError> {
@@ -277,7 +281,7 @@ impl LlmProvider for VertexProvider {
         request: &LlmRequest,
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = self.build_url(&request.model);
-        let body = self.build_request_body(request);
+        let body = self.build_request_body(request)?;
 
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
 
@@ -396,6 +400,10 @@ mod tests {
             )],
             vec![],
         );
-        insta::assert_json_snapshot!("vertex_basic", p.build_request_body(&r));
+        insta::assert_json_snapshot!(
+            "vertex_basic",
+            p.build_request_body(&r)
+                .expect("request body projection should succeed")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements the preflight track for [AIO-68](https://multica.ai/aionui-dev/issues/AIO-68) on top of the provider-contract baseline.

- Adds structured projection errors for outbound provider request construction.
- Adds explicit compat controls for `max_tool_count` and `max_request_body_bytes`.
- Fails before sending provider requests when projected body/tool limits are exceeded.
- Keeps the approved behavior: no silent trimming, dropping, reordering, or downgrading tools.

## Scope

This PR covers T4/T5 only:

- T4 projection error boundary
- T5 provider tool-count and request-body-size preflight

It does not include the other follow-up provider-contract tracks for field controls, tool wire-shape overrides, schema legalization, or reasoning replay changes.

## Verification

Targeted checks after rebasing onto `origin/main`:

- [x] `cargo test -p aion-config max_tool_count`
  - 1 passed
- [x] `cargo test -p aion-providers projector`
  - 9 passed
- [x] `cargo test -p aion-providers openai::tests::test_projection_limit_maps_to_non_retryable_prompt_too_long`
  - 1 passed
- [x] `cargo test -p aion-providers golden_`
  - 13 passed
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p aion-providers --all-targets -- -D warnings`
- [x] `git diff --check`

Push gate:

- [x] `just push -u origin boii/fix/aio-68-preflight`
  - `cargo nextest run --workspace --profile default`
  - 2018 passed, 2 skipped
