### PR TITLE
fix(providers): add OpenAI field policy controls

### DIFF
--- a/crates/aion-config/src/compat.rs
+++ b/crates/aion-config/src/compat.rs
@@ -33,6 +33,10 @@ pub struct TransportCompat {
     /// Maximum serialized provider request body size in bytes.
     /// Default: None (no local preflight limit).
     pub max_request_body_bytes: Option<usize>,
+
+    /// Whether OpenAI-compatible requests include stream_options.
+    /// Default: true for OpenAI-compatible providers.
+    pub include_stream_options: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -79,6 +83,10 @@ pub struct ToolCompat {
     /// Maximum number of tools allowed in the projected provider request.
     /// Default: None (no local preflight limit).
     pub max_tool_count: Option<usize>,
+
+    /// Whether OpenAI-compatible requests include outgoing tools.
+    /// Default: true for OpenAI-compatible providers.
+    pub emit_tools: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -111,6 +119,9 @@ impl TransportCompat {
             max_request_body_bytes: user
                 .max_request_body_bytes
                 .or(defaults.max_request_body_bytes),
+            include_stream_options: user
+                .include_stream_options
+                .or(defaults.include_stream_options),
         }
     }
 }
@@ -143,6 +154,7 @@ impl ToolCompat {
                 .or(defaults.sanitize_malformed_tool_calls),
             auto_tool_id: user.auto_tool_id.or(defaults.auto_tool_id),
             max_tool_count: user.max_tool_count.or(defaults.max_tool_count),
+            emit_tools: user.emit_tools.or(defaults.emit_tools),
         }
     }
 }
@@ -220,6 +232,7 @@ impl ProviderCompat {
         Self {
             transport: TransportCompat {
                 max_tokens_field: Some("max_tokens".into()),
+                include_stream_options: Some(true),
                 ..Default::default()
             },
             messages: MessageCompat {
@@ -232,6 +245,7 @@ impl ProviderCompat {
                 clean_orphan_tool_calls: Some(true),
                 sanitize_malformed_tool_calls: Some(true),
                 auto_tool_id: Some(true),
+                emit_tools: Some(true),
                 ..Default::default()
             },
             reasoning: ReasoningCompat {
@@ -269,6 +283,14 @@ impl ProviderCompat {
 
     pub fn max_tool_count(&self) -> Option<usize> {
         self.tools.max_tool_count
+    }
+
+    pub fn include_stream_options(&self) -> bool {
+        self.transport.include_stream_options.unwrap_or(true)
+    }
+
+    pub fn emit_tools(&self) -> bool {
+        self.tools.emit_tools.unwrap_or(true)
     }
 
     pub fn merge_assistant_messages(&self) -> bool {
@@ -393,12 +415,14 @@ mod tests {
 max_tokens_field = "max_completion_tokens"
 api_path = "/chat/completions"
 max_request_body_bytes = 1048576
+include_stream_options = false
 merge_assistant_messages = true
 clean_orphan_tool_results = false
 dedup_tool_results = true
 clean_orphan_tool_calls = true
 sanitize_malformed_tool_calls = false
 max_tool_count = 512
+emit_tools = false
 ensure_alternation = true
 merge_same_role = true
 sanitize_schema = true
@@ -420,6 +444,8 @@ effort_levels = ["low", "medium"]
             Some("/chat/completions")
         );
         assert_eq!(compat.max_request_body_bytes(), Some(1_048_576));
+        assert_eq!(compat.transport.include_stream_options, Some(false));
+        assert!(!compat.include_stream_options());
         assert_eq!(compat.messages.merge_assistant_messages, Some(true));
         assert_eq!(compat.messages.clean_orphan_tool_results, Some(false));
         assert_eq!(compat.messages.dedup_tool_results, Some(true));
@@ -433,6 +459,8 @@ effort_levels = ["low", "medium"]
         assert_eq!(compat.tools.sanitize_malformed_tool_calls, Some(false));
         assert_eq!(compat.tools.auto_tool_id, Some(true));
         assert_eq!(compat.max_tool_count(), Some(512));
+        assert_eq!(compat.tools.emit_tools, Some(false));
+        assert!(!compat.emit_tools());
         assert_eq!(compat.schema.sanitize_schema, Some(true));
         assert_eq!(compat.reasoning.supports_thinking, Some(true));
         assert_eq!(compat.reasoning.supports_effort, Some(false));
@@ -449,6 +477,7 @@ effort_levels = ["low", "medium"]
                 max_tokens_field: Some("max_completion_tokens".to_string()),
                 api_path: Some("/chat/completions".to_string()),
                 max_request_body_bytes: Some(1_048_576),
+                include_stream_options: Some(false),
             },
             messages: MessageCompat {
                 merge_assistant_messages: Some(true),
@@ -463,6 +492,7 @@ effort_levels = ["low", "medium"]
                 sanitize_malformed_tool_calls: Some(false),
                 auto_tool_id: Some(true),
                 max_tool_count: Some(512),
+                emit_tools: Some(false),
             },
             schema: SchemaCompat {
                 sanitize_schema: Some(true),
@@ -479,12 +509,14 @@ effort_levels = ["low", "medium"]
         assert!(toml.contains("max_tokens_field = \"max_completion_tokens\""));
         assert!(toml.contains("api_path = \"/chat/completions\""));
         assert!(toml.contains("max_request_body_bytes = 1048576"));
+        assert!(toml.contains("include_stream_options = false"));
         assert!(toml.contains("merge_assistant_messages = true"));
         assert!(toml.contains("clean_orphan_tool_results = false"));
         assert!(toml.contains("dedup_tool_results = true"));
         assert!(toml.contains("clean_orphan_tool_calls = true"));
         assert!(toml.contains("sanitize_malformed_tool_calls = false"));
         assert!(toml.contains("max_tool_count = 512"));
+        assert!(toml.contains("emit_tools = false"));
         assert!(toml.contains("ensure_alternation = true"));
         assert!(toml.contains("merge_same_role = true"));
         assert!(toml.contains("sanitize_schema = true"));
@@ -508,6 +540,7 @@ effort_levels = ["low", "medium"]
                 max_tokens_field: Some("max_completion_tokens".to_string()),
                 api_path: Some("/chat/completions".to_string()),
                 max_request_body_bytes: Some(2_048),
+                include_stream_options: None,
             },
             messages: MessageCompat {
                 merge_assistant_messages: Some(false),
@@ -522,6 +555,7 @@ effort_levels = ["low", "medium"]
                 sanitize_malformed_tool_calls: Some(false),
                 auto_tool_id: Some(false),
                 max_tool_count: Some(42),
+                emit_tools: None,
             },
             schema: SchemaCompat {
                 sanitize_schema: Some(true),
@@ -544,12 +578,14 @@ effort_levels = ["low", "medium"]
             Some("/chat/completions")
         );
         assert_eq!(merged.max_request_body_bytes(), Some(2_048));
+        assert!(merged.include_stream_options());
         assert!(!merged.merge_assistant_messages());
         assert!(!merged.clean_orphan_tool_calls());
         assert!(!merged.clean_orphan_tool_results());
         assert!(merged.dedup_tool_results());
         assert!(!merged.sanitize_malformed_tool_calls());
         assert_eq!(merged.max_tool_count(), Some(42));
+        assert!(merged.emit_tools());
         assert!(merged.sanitize_schema());
         assert!(!merged.auto_tool_id());
         assert!(merged.supports_thinking());
@@ -616,6 +652,57 @@ effort_levels = ["low", "medium"]
             Some("max_tokens")
         );
         assert!(!compat.ensure_alternation());
+        assert_eq!(compat.transport.include_stream_options, Some(true));
+        assert_eq!(compat.tools.emit_tools, Some(true));
+        assert!(compat.include_stream_options());
+        assert!(compat.emit_tools());
+    }
+
+    #[test]
+    fn test_openai_field_controls_parse_flattened_compat() {
+        let toml_str = r#"
+include_stream_options = false
+emit_tools = false
+supports_effort = false
+"#;
+
+        let compat: ProviderCompat = toml::from_str(toml_str).unwrap();
+
+        assert_eq!(compat.transport.include_stream_options, Some(false));
+        assert_eq!(compat.tools.emit_tools, Some(false));
+        assert_eq!(compat.reasoning.supports_effort, Some(false));
+        assert!(!compat.include_stream_options());
+        assert!(!compat.emit_tools());
+        assert!(!compat.supports_effort());
+    }
+
+    #[test]
+    fn test_openai_field_controls_merge_user_overrides_defaults() {
+        let defaults = ProviderCompat::openai_defaults();
+        let user = ProviderCompat {
+            transport: TransportCompat {
+                include_stream_options: Some(false),
+                ..Default::default()
+            },
+            tools: ToolCompat {
+                emit_tools: Some(false),
+                ..Default::default()
+            },
+            reasoning: ReasoningCompat {
+                supports_effort: Some(false),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let merged = ProviderCompat::merge(defaults, user);
+
+        assert_eq!(merged.transport.include_stream_options, Some(false));
+        assert_eq!(merged.tools.emit_tools, Some(false));
+        assert_eq!(merged.reasoning.supports_effort, Some(false));
+        assert!(!merged.include_stream_options());
+        assert!(!merged.emit_tools());
+        assert!(!merged.supports_effort());
     }
 
     #[test]

--- a/crates/aion-config/src/config.rs
+++ b/crates/aion-config/src/config.rs
@@ -2326,6 +2326,80 @@ max_request_body_bytes = 1048576
     }
 
     #[test]
+    fn test_openai_field_controls_alias_and_profile_override_flattened_compat() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".aionrs.toml"),
+            r#"
+[default]
+provider = "nim"
+model = "alias-model"
+
+[providers.openai]
+api_key = "builtin-key"
+base_url = "https://api.openai.test/v1"
+
+[providers.openai.compat]
+include_stream_options = true
+emit_tools = true
+supports_effort = true
+
+[providers.nim]
+provider = "openai"
+api_key = "alias-key"
+base_url = "https://nim.example.test/v1"
+
+[providers.nim.compat]
+include_stream_options = false
+emit_tools = false
+supports_effort = false
+
+[profiles.restore-openai-fields]
+provider = "nim"
+
+[profiles.restore-openai-fields.compat]
+include_stream_options = true
+emit_tools = true
+supports_effort = true
+"#,
+        )
+        .unwrap();
+
+        let base_cli = CliArgs {
+            provider: None,
+            api_key: None,
+            base_url: None,
+            model: None,
+            max_tokens: None,
+            max_turns: None,
+            max_tool_call_malformed_turns: None,
+            max_tool_call_failure_turns: None,
+            system_prompt: None,
+            profile: None,
+            auto_approve: false,
+            project_dir: Some(tmp.path().to_path_buf()),
+        };
+
+        let alias_config = Config::resolve(&base_cli).unwrap();
+        assert_eq!(alias_config.provider, ProviderType::OpenAI);
+        assert_eq!(alias_config.provider_label, "nim");
+        assert!(!alias_config.compat.include_stream_options());
+        assert!(!alias_config.compat.emit_tools());
+        assert!(!alias_config.compat.supports_effort());
+
+        let profile_config = Config::resolve(&CliArgs {
+            profile: Some("restore-openai-fields".to_string()),
+            ..base_cli
+        })
+        .unwrap();
+        assert_eq!(profile_config.provider, ProviderType::OpenAI);
+        assert_eq!(profile_config.provider_label, "nim");
+        assert!(profile_config.compat.include_stream_options());
+        assert!(profile_config.compat.emit_tools());
+        assert!(profile_config.compat.supports_effort());
+    }
+
+    #[test]
     fn test_resolve_zero_max_turns_disables_turn_limit() {
         let tmp = tempfile::tempdir().unwrap();
         let cli_args = CliArgs {

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -2075,4 +2075,30 @@ mod tests {
                 .expect("request body projection should succeed")
         );
     }
+
+    #[test]
+    fn golden_openai_field_controls_disabled() {
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.transport.include_stream_options = Some(false);
+        compat.tools.emit_tools = Some(false);
+        compat.reasoning.supports_effort = Some(false);
+        let provider = golden_provider(compat);
+        let mut request = golden_req(
+            vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: "hi".to_string(),
+                }],
+            )],
+            sample_tools(),
+        );
+        request.reasoning_effort = Some("medium".to_string());
+
+        insta::assert_json_snapshot!(
+            "openai_field_controls_disabled",
+            provider
+                .build_request_body(&request)
+                .expect("request body projection should succeed")
+        );
+    }
 }

--- a/crates/aion-providers/src/projector.rs
+++ b/crates/aion-providers/src/projector.rs
@@ -152,20 +152,35 @@ impl OpenAiProjector {
                 &request.system,
                 compat,
             ),
-            "stream": true,
-            "stream_options": { "include_usage": true }
+            "stream": true
         });
         body[max_tokens_field] = json!(request.max_tokens);
 
+        if compat.include_stream_options() {
+            body["stream_options"] = json!({ "include_usage": true });
+        }
+
         let mut tool_count = 0;
-        if !request.tools.is_empty() {
+        if !request.tools.is_empty() && compat.emit_tools() {
             let tools = OpenAIProvider::build_tools(&request.tools);
             tool_count = tools.len();
             body["tools"] = json!(tools);
+        } else if !request.tools.is_empty() {
+            tracing::warn!(
+                target: "aion_providers",
+                "OpenAI-compatible outgoing tools omitted because compat.emit_tools is disabled"
+            );
         }
 
         if let Some(effort) = &request.reasoning_effort {
-            body["reasoning_effort"] = json!(effort);
+            if compat.supports_effort() {
+                body["reasoning_effort"] = json!(effort);
+            } else {
+                tracing::warn!(
+                    target: "aion_providers",
+                    "OpenAI-compatible reasoning_effort omitted because compat.supports_effort is disabled"
+                );
+            }
         }
 
         preflight_projected_body(WireProvider::OpenAi, &body, tool_count, compat)?;
@@ -465,6 +480,55 @@ mod tests {
             .expect("request body projection should succeed");
 
         assert_eq!(body["model"], "test-model");
+    }
+
+    #[test]
+    fn test_openai_projector_default_includes_stream_options() {
+        let request = test_request(vec![], None);
+        let body = OpenAiProjector::project(&request, &ProviderCompat::openai_defaults())
+            .expect("request body projection should succeed");
+
+        assert_eq!(body["stream_options"], json!({ "include_usage": true }));
+    }
+
+    #[test]
+    fn test_openai_projector_omits_stream_options_when_disabled() {
+        let request = test_request(vec![], None);
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.transport.include_stream_options = Some(false);
+
+        let body = OpenAiProjector::project(&request, &compat)
+            .expect("request body projection should succeed");
+
+        assert!(body.get("stream_options").is_none());
+    }
+
+    #[test]
+    fn test_openai_projector_omits_tools_when_disabled_without_mutating_request() {
+        let request = test_request(test_tools(), None);
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.tools.emit_tools = Some(false);
+
+        let body = OpenAiProjector::project(&request, &compat)
+            .expect("request body projection should succeed");
+
+        assert!(body.get("tools").is_none());
+        assert_eq!(request.tools.len(), 2);
+        assert_eq!(request.tools[0].name, "read");
+        assert_eq!(request.tools[1].name, "list");
+    }
+
+    #[test]
+    fn test_openai_projector_omits_reasoning_effort_when_effort_disabled() {
+        let mut request = test_request(vec![], None);
+        request.reasoning_effort = Some("medium".to_string());
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.reasoning.supports_effort = Some(false);
+
+        let body = OpenAiProjector::project(&request, &compat)
+            .expect("request body projection should succeed");
+
+        assert!(body.get("reasoning_effort").is_none());
     }
 
     #[test]

--- a/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_field_controls_disabled.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_field_controls_disabled.snap
@@ -1,0 +1,19 @@
+---
+source: crates/aion-providers/src/openai.rs
+expression: provider.build_request_body(&request)
+---
+{
+  "max_tokens": 8192,
+  "messages": [
+    {
+      "content": "You are a test assistant.",
+      "role": "system"
+    },
+    {
+      "content": "hi",
+      "role": "user"
+    }
+  ],
+  "model": "test-model",
+  "stream": true
+}


### PR DESCRIPTION
## Summary

Implements OpenAI-compatible field policy controls for [AIO-77](https://multica.ai/aionui-dev/issues/AIO-77).

- Adds compat switches for `include_stream_options`, `emit_tools`, and `supports_effort`.
- Applies the switches in OpenAI request projection without mutating the source request.
- Keeps OpenAI defaults preserving the existing request body shape unless a provider alias/profile opts out.

## Scope

This PR covers the OpenAI-compatible field-control track only. It builds on the provider projection preflight baseline already merged into `main`.

## Verification

Targeted checks after rebasing onto `origin/main`:

- [x] `cargo test -p aion-config openai_field_controls`
  - 3 passed
- [x] `cargo test -p aion-config max_tool_count`
  - 1 passed
- [x] `cargo test -p aion-providers projector`
  - 13 passed
- [x] `cargo test -p aion-providers golden_`
  - 14 passed
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p aion-providers --all-targets -- -D warnings`
- [x] `git diff --check`

Push gate:

- [x] `just push -u origin boii/fix/aio-77-openai-field-policy`
  - `cargo nextest run --workspace --profile default`
  - 2026 passed, 2 skipped