### PR TITLE
fix(providers): add tool wire shape controls

### DIFF
--- a/crates/aion-config/src/compat.rs
+++ b/crates/aion-config/src/compat.rs
@@ -87,6 +87,20 @@ pub struct ToolCompat {
     /// Whether OpenAI-compatible requests include outgoing tools.
     /// Default: true for OpenAI-compatible providers.
     pub emit_tools: Option<bool>,
+
+    /// Explicit tools declaration wire shape.
+    /// Default: native provider path shape.
+    pub tool_wire_shape: Option<ToolWireShape>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq)]
+pub enum ToolWireShape {
+    #[serde(rename = "native")]
+    Native,
+    #[serde(rename = "openai_function")]
+    OpenAiFunction,
+    #[serde(rename = "anthropic_input_schema")]
+    AnthropicInputSchema,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -155,6 +169,7 @@ impl ToolCompat {
             auto_tool_id: user.auto_tool_id.or(defaults.auto_tool_id),
             max_tool_count: user.max_tool_count.or(defaults.max_tool_count),
             emit_tools: user.emit_tools.or(defaults.emit_tools),
+            tool_wire_shape: user.tool_wire_shape.or(defaults.tool_wire_shape),
         }
     }
 }
@@ -293,6 +308,10 @@ impl ProviderCompat {
         self.tools.emit_tools.unwrap_or(true)
     }
 
+    pub fn tool_wire_shape(&self) -> ToolWireShape {
+        self.tools.tool_wire_shape.unwrap_or(ToolWireShape::Native)
+    }
+
     pub fn merge_assistant_messages(&self) -> bool {
         self.messages.merge_assistant_messages.unwrap_or(false)
     }
@@ -423,6 +442,7 @@ clean_orphan_tool_calls = true
 sanitize_malformed_tool_calls = false
 max_tool_count = 512
 emit_tools = false
+tool_wire_shape = "openai_function"
 ensure_alternation = true
 merge_same_role = true
 sanitize_schema = true
@@ -461,6 +481,7 @@ effort_levels = ["low", "medium"]
         assert_eq!(compat.max_tool_count(), Some(512));
         assert_eq!(compat.tools.emit_tools, Some(false));
         assert!(!compat.emit_tools());
+        assert_eq!(compat.tool_wire_shape(), ToolWireShape::OpenAiFunction);
         assert_eq!(compat.schema.sanitize_schema, Some(true));
         assert_eq!(compat.reasoning.supports_thinking, Some(true));
         assert_eq!(compat.reasoning.supports_effort, Some(false));
@@ -493,6 +514,7 @@ effort_levels = ["low", "medium"]
                 auto_tool_id: Some(true),
                 max_tool_count: Some(512),
                 emit_tools: Some(false),
+                tool_wire_shape: Some(ToolWireShape::OpenAiFunction),
             },
             schema: SchemaCompat {
                 sanitize_schema: Some(true),
@@ -517,6 +539,7 @@ effort_levels = ["low", "medium"]
         assert!(toml.contains("sanitize_malformed_tool_calls = false"));
         assert!(toml.contains("max_tool_count = 512"));
         assert!(toml.contains("emit_tools = false"));
+        assert!(toml.contains("tool_wire_shape = \"openai_function\""));
         assert!(toml.contains("ensure_alternation = true"));
         assert!(toml.contains("merge_same_role = true"));
         assert!(toml.contains("sanitize_schema = true"));
@@ -556,6 +579,7 @@ effort_levels = ["low", "medium"]
                 auto_tool_id: Some(false),
                 max_tool_count: Some(42),
                 emit_tools: None,
+                tool_wire_shape: None,
             },
             schema: SchemaCompat {
                 sanitize_schema: Some(true),
@@ -586,6 +610,7 @@ effort_levels = ["low", "medium"]
         assert!(!merged.sanitize_malformed_tool_calls());
         assert_eq!(merged.max_tool_count(), Some(42));
         assert!(merged.emit_tools());
+        assert_eq!(merged.tool_wire_shape(), ToolWireShape::Native);
         assert!(merged.sanitize_schema());
         assert!(!merged.auto_tool_id());
         assert!(merged.supports_thinking());
@@ -703,6 +728,29 @@ supports_effort = false
         assert!(!merged.include_stream_options());
         assert!(!merged.emit_tools());
         assert!(!merged.supports_effort());
+    }
+
+    #[test]
+    fn test_tool_wire_shape_toml_round_trips_supported_values() {
+        for value in ["native", "openai_function", "anthropic_input_schema"] {
+            let compat: ProviderCompat =
+                toml::from_str(&format!("tool_wire_shape = \"{value}\"")).unwrap();
+
+            let toml = toml::to_string(&compat).unwrap();
+
+            assert!(toml.contains(&format!("tool_wire_shape = \"{value}\"")));
+        }
+    }
+
+    #[test]
+    fn test_tool_wire_shape_toml_rejects_unknown_value() {
+        let result = toml::from_str::<ProviderCompat>(
+            r#"
+tool_wire_shape = "provider_guess"
+"#,
+        );
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/aion-config/src/config.rs
+++ b/crates/aion-config/src/config.rs
@@ -1051,7 +1051,7 @@ max_sessions = 20                # auto-cleanup oldest
 mod tests {
     use super::*;
     use crate::compat::{
-        MessageCompat, ReasoningCompat, SchemaCompat, ToolCompat, TransportCompat,
+        MessageCompat, ReasoningCompat, SchemaCompat, ToolCompat, ToolWireShape, TransportCompat,
     };
 
     // -------------------------------------------------------------------------
@@ -2397,6 +2397,49 @@ supports_effort = true
         assert!(profile_config.compat.include_stream_options());
         assert!(profile_config.compat.emit_tools());
         assert!(profile_config.compat.supports_effort());
+    }
+
+    #[test]
+    fn test_config_resolve_tool_wire_shape_override_from_provider_compat() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".aionrs.toml"),
+            r#"
+[default]
+provider = "openai"
+model = "test-model"
+
+[providers.openai]
+api_key = "test-key"
+base_url = "https://example.test/v1"
+
+[providers.openai.compat]
+tool_wire_shape = "anthropic_input_schema"
+"#,
+        )
+        .unwrap();
+
+        let cli = CliArgs {
+            provider: None,
+            api_key: None,
+            base_url: None,
+            model: None,
+            max_tokens: None,
+            max_turns: None,
+            max_tool_call_malformed_turns: None,
+            max_tool_call_failure_turns: None,
+            system_prompt: None,
+            profile: None,
+            auto_approve: false,
+            project_dir: Some(tmp.path().to_path_buf()),
+        };
+
+        let config = Config::resolve(&cli).unwrap();
+
+        assert_eq!(
+            config.compat.tool_wire_shape(),
+            ToolWireShape::AnthropicInputSchema
+        );
     }
 
     #[test]

--- a/crates/aion-providers/src/anthropic.rs
+++ b/crates/aion-providers/src/anthropic.rs
@@ -7,7 +7,8 @@ use aion_types::llm::{LlmEvent, LlmRequest};
 
 use super::anthropic_shared;
 use crate::projector::{
-    AnthropicWireProjector, WireParams, WireProvider, projection_to_provider_error,
+    AnthropicWireProjector, ResolvedToolWireShape, WireParams, WireProvider,
+    classify_tools_wire_shape_mismatch, projection_to_provider_error,
 };
 use crate::stream_runner::{RetryPolicy, run_stream};
 use crate::{LlmProvider, ProviderError};
@@ -75,6 +76,7 @@ async fn send_anthropic_stream_request(
     url: String,
     headers: HeaderMap,
     body: Value,
+    tool_wire_shape: ResolvedToolWireShape,
 ) -> Result<reqwest::Response, ProviderError> {
     let response = client
         .post(&url)
@@ -89,6 +91,14 @@ async fn send_anthropic_stream_request(
         if status.as_u16() == 429 {
             return Err(ProviderError::RateLimited {
                 retry_after_ms: 5000,
+            });
+        }
+        if let Some(message) =
+            classify_tools_wire_shape_mismatch(status.as_u16(), &body_text, tool_wire_shape)
+        {
+            return Err(ProviderError::Api {
+                status: status.as_u16(),
+                message,
             });
         }
         return Err(ProviderError::Api {
@@ -113,6 +123,7 @@ impl LlmProvider for AnthropicProvider {
 
         let client = self.client.clone();
         let headers = self.build_headers()?;
+        let tool_wire_shape = AnthropicWireProjector::resolved_tool_wire_shape(&self.compat);
         let send = {
             let url = url.clone();
             let body = body.clone();
@@ -121,7 +132,9 @@ impl LlmProvider for AnthropicProvider {
                 let url = url.clone();
                 let headers = headers.clone();
                 let body = body.clone();
-                async move { send_anthropic_stream_request(client, url, headers, body).await }
+                async move {
+                    send_anthropic_stream_request(client, url, headers, body, tool_wire_shape).await
+                }
             }
         };
         let process = move |response, tx| async move {

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -7,11 +7,12 @@ use tokio::sync::mpsc;
 
 use aion_types::llm::LlmEvent;
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
-use aion_types::tool::{ToolDef, truncate_deferred_description};
+use aion_types::tool::ToolDef;
 
 use crate::error::ProviderError;
 use crate::framing::SseBlockFramer;
 use crate::parser::{AnthropicParser, ResponseParser};
+use crate::projector::{ResolvedToolWireShape, project_tools};
 pub(crate) use crate::stream_runner::StreamOutcome;
 use crate::tool_call_sanitize::{DroppedToolCallReason, format_dropped_tool_call};
 use aion_config::compat::ProviderCompat;
@@ -247,30 +248,7 @@ fn generate_tool_id() -> String {
 /// Deferred tools emit a minimal schema to reduce input token usage;
 /// the caller must invoke ToolSearch to retrieve the full schema.
 pub fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
-    tools
-        .iter()
-        .map(|t| {
-            if t.deferred {
-                let short_desc = truncate_deferred_description(&t.description);
-                json!({
-                    "name": t.name,
-                    "description": format!(
-                        "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
-                    ),
-                    "input_schema": {
-                        "type": "object",
-                        "properties": {}
-                    }
-                })
-            } else {
-                json!({
-                    "name": t.name,
-                    "description": t.description,
-                    "input_schema": t.input_schema
-                })
-            }
-        })
-        .collect()
+    project_tools(tools, ResolvedToolWireShape::AnthropicInputSchema)
 }
 
 /// State machine for accumulating SSE content blocks

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -18,7 +18,8 @@ use aion_types::message::{StopReason, TokenUsage};
 use crate::framing::bedrock_payload_to_frame;
 use crate::parser::ResponseParser;
 use crate::projector::{
-    AnthropicWireProjector, WireParams, WireProvider, projection_to_provider_error,
+    AnthropicWireProjector, WireParams, WireProvider, classify_tools_wire_shape_mismatch,
+    projection_to_provider_error,
 };
 use crate::stream_runner::StreamOutcome;
 use crate::{LlmProvider, ProviderError};
@@ -221,6 +222,7 @@ impl LlmProvider for BedrockProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = self.build_url(&request.model);
         let body = self.build_request_body(request)?;
+        let tool_wire_shape = AnthropicWireProjector::resolved_tool_wire_shape(&self.compat);
 
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
 
@@ -249,6 +251,14 @@ impl LlmProvider for BedrockProvider {
             if status.as_u16() == 429 {
                 return Err(ProviderError::RateLimited {
                     retry_after_ms: 5000,
+                });
+            }
+            if let Some(message) =
+                classify_tools_wire_shape_mismatch(status.as_u16(), &body_text, tool_wire_shape)
+            {
+                return Err(ProviderError::Api {
+                    status: status.as_u16(),
+                    message,
                 });
             }
             let message = format_bedrock_error(status.as_u16(), &body_text);

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -6,11 +6,13 @@ use tokio::sync::mpsc;
 
 use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
-use aion_types::tool::{ToolDef, truncate_deferred_description};
 
 use crate::framing::{FrameKind, SseLineFramer};
 use crate::parser::{OpenAiParser, ResponseParser};
-use crate::projector::{OpenAiProjector, projection_to_provider_error};
+use crate::projector::{
+    OpenAiProjector, ResolvedToolWireShape, classify_tools_wire_shape_mismatch,
+    projection_to_provider_error,
+};
 use crate::stream_runner::{RetryPolicy, StreamOutcome, run_stream};
 use crate::tool_call_sanitize::{DroppedToolCallReason, format_dropped_tool_call};
 use crate::{LlmProvider, ProviderError};
@@ -333,39 +335,6 @@ impl OpenAIProvider {
         result
     }
 
-    pub(crate) fn build_tools(tools: &[ToolDef]) -> Vec<Value> {
-        tools
-            .iter()
-            .map(|t| {
-                if t.deferred {
-                    let short_desc = truncate_deferred_description(&t.description);
-                    json!({
-                        "type": "function",
-                        "function": {
-                            "name": t.name,
-                            "description": format!(
-                                "(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."
-                            ),
-                            "parameters": {
-                                "type": "object",
-                                "properties": {}
-                            }
-                        }
-                    })
-                } else {
-                    json!({
-                        "type": "function",
-                        "function": {
-                            "name": t.name,
-                            "description": t.description,
-                            "parameters": t.input_schema
-                        }
-                    })
-                }
-            })
-            .collect()
-    }
-
     fn build_request_body(&self, request: &LlmRequest) -> Result<Value, ProviderError> {
         OpenAiProjector::project(request, &self.compat).map_err(projection_to_provider_error)
     }
@@ -597,10 +566,17 @@ impl LlmProvider for OpenAIProvider {
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
 
         let auto_tool_id = self.compat.auto_tool_id();
+        let tool_wire_shape = OpenAiProjector::resolved_tool_wire_shape(&self.compat);
         let client = self.client.clone();
 
         let send = move || {
-            send_openai_stream_request(client.clone(), url.clone(), headers.clone(), body.clone())
+            send_openai_stream_request(
+                client.clone(),
+                url.clone(),
+                headers.clone(),
+                body.clone(),
+                tool_wire_shape,
+            )
         };
         let process = move |response, tx| async move {
             process_sse_stream(response, &tx, auto_tool_id).await
@@ -620,6 +596,7 @@ async fn send_openai_stream_request(
     url: String,
     headers: HeaderMap,
     body: Value,
+    tool_wire_shape: ResolvedToolWireShape,
 ) -> Result<reqwest::Response, ProviderError> {
     let response = client
         .post(&url)
@@ -634,6 +611,14 @@ async fn send_openai_stream_request(
         if status.as_u16() == 429 {
             return Err(ProviderError::RateLimited {
                 retry_after_ms: 5000,
+            });
+        }
+        if let Some(message) =
+            classify_tools_wire_shape_mismatch(status.as_u16(), &body_text, tool_wire_shape)
+        {
+            return Err(ProviderError::Api {
+                status: status.as_u16(),
+                message,
             });
         }
         return Err(ProviderError::Api {
@@ -838,6 +823,9 @@ pub(crate) fn parse_sse_chunk(
 mod tests {
     use super::*;
     use aion_config::compat::TransportCompat;
+    use aion_types::tool::ToolDef;
+
+    use crate::projector::project_tools;
 
     fn no_compat() -> ProviderCompat {
         ProviderCompat::default()
@@ -1692,7 +1680,7 @@ mod tests {
                 deferred: true,
             },
         ];
-        let result = OpenAIProvider::build_tools(&tools);
+        let result = project_tools(&tools, ResolvedToolWireShape::OpenAiFunction);
 
         // Core tool has full parameters
         let read_params = &result[0]["function"]["parameters"];

--- a/crates/aion-providers/src/projector.rs
+++ b/crates/aion-providers/src/projector.rs
@@ -1,5 +1,6 @@
-use aion_config::compat::{self, ProviderCompat};
+use aion_config::compat::{self, ProviderCompat, ToolWireShape};
 use aion_types::llm::{LlmRequest, ThinkingConfig};
+use aion_types::tool::{ToolDef, truncate_deferred_description};
 use serde_json::{Value, json};
 use std::fmt;
 
@@ -73,6 +74,10 @@ pub(crate) struct WireParams {
 pub(crate) struct AnthropicWireProjector;
 
 impl AnthropicWireProjector {
+    pub(crate) fn resolved_tool_wire_shape(compat: &ProviderCompat) -> ResolvedToolWireShape {
+        resolve_tool_wire_shape(compat, ResolvedToolWireShape::AnthropicInputSchema)
+    }
+
     pub(crate) fn project(
         request: &LlmRequest,
         compat: &ProviderCompat,
@@ -108,16 +113,20 @@ impl AnthropicWireProjector {
 
         let mut tool_count = 0;
         if !request.tools.is_empty() {
-            let mut tools = anthropic_shared::build_tools(&request.tools);
+            let tool_wire_shape = Self::resolved_tool_wire_shape(compat);
+            let mut tools = project_tools(&request.tools, tool_wire_shape);
             tool_count = tools.len();
             if params.sanitize_schema {
                 for tool in &mut tools {
-                    if let Some(schema) = tool.get("input_schema").cloned() {
-                        tool["input_schema"] = compat::sanitize_json_schema(&schema);
+                    if let Some(schema) = projected_tool_schema_mut(tool, tool_wire_shape) {
+                        *schema = compat::sanitize_json_schema(schema);
                     }
                 }
             }
-            if let Some(last) = tools.last_mut().filter(|_| params.cache_enabled) {
+            if let Some(last) = tools.last_mut().filter(|_| {
+                params.cache_enabled
+                    && tool_wire_shape == ResolvedToolWireShape::AnthropicInputSchema
+            }) {
                 last["cache_control"] = json!({ "type": "ephemeral" });
             }
             body["tools"] = json!(tools);
@@ -139,6 +148,10 @@ impl AnthropicWireProjector {
 pub(crate) struct OpenAiProjector;
 
 impl OpenAiProjector {
+    pub(crate) fn resolved_tool_wire_shape(compat: &ProviderCompat) -> ResolvedToolWireShape {
+        resolve_tool_wire_shape(compat, ResolvedToolWireShape::OpenAiFunction)
+    }
+
     pub(crate) fn project(
         request: &LlmRequest,
         compat: &ProviderCompat,
@@ -162,7 +175,7 @@ impl OpenAiProjector {
 
         let mut tool_count = 0;
         if !request.tools.is_empty() && compat.emit_tools() {
-            let tools = OpenAIProvider::build_tools(&request.tools);
+            let tools = project_tools(&request.tools, Self::resolved_tool_wire_shape(compat));
             tool_count = tools.len();
             body["tools"] = json!(tools);
         } else if !request.tools.is_empty() {
@@ -187,6 +200,116 @@ impl OpenAiProjector {
 
         Ok(body)
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResolvedToolWireShape {
+    OpenAiFunction,
+    AnthropicInputSchema,
+}
+
+impl ResolvedToolWireShape {
+    pub(crate) const fn as_config_value(self) -> &'static str {
+        match self {
+            Self::OpenAiFunction => "openai_function",
+            Self::AnthropicInputSchema => "anthropic_input_schema",
+        }
+    }
+}
+
+fn resolve_tool_wire_shape(
+    compat: &ProviderCompat,
+    native: ResolvedToolWireShape,
+) -> ResolvedToolWireShape {
+    match compat.tool_wire_shape() {
+        ToolWireShape::Native => native,
+        ToolWireShape::OpenAiFunction => ResolvedToolWireShape::OpenAiFunction,
+        ToolWireShape::AnthropicInputSchema => ResolvedToolWireShape::AnthropicInputSchema,
+    }
+}
+
+pub(crate) fn project_tools(tools: &[ToolDef], shape: ResolvedToolWireShape) -> Vec<Value> {
+    tools.iter().map(|tool| project_tool(tool, shape)).collect()
+}
+
+fn project_tool(tool: &ToolDef, shape: ResolvedToolWireShape) -> Value {
+    match shape {
+        ResolvedToolWireShape::OpenAiFunction => project_openai_function_tool(tool),
+        ResolvedToolWireShape::AnthropicInputSchema => project_anthropic_input_schema_tool(tool),
+    }
+}
+
+fn project_openai_function_tool(tool: &ToolDef) -> Value {
+    let (description, parameters) = tool_description_and_schema(tool);
+    json!({
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": description,
+            "parameters": parameters
+        }
+    })
+}
+
+fn project_anthropic_input_schema_tool(tool: &ToolDef) -> Value {
+    let (description, input_schema) = tool_description_and_schema(tool);
+    json!({
+        "name": tool.name,
+        "description": description,
+        "input_schema": input_schema
+    })
+}
+
+fn tool_description_and_schema(tool: &ToolDef) -> (String, Value) {
+    if tool.deferred {
+        let short_desc = truncate_deferred_description(&tool.description);
+        (
+            format!("(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."),
+            json!({
+                "type": "object",
+                "properties": {}
+            }),
+        )
+    } else {
+        (tool.description.clone(), tool.input_schema.clone())
+    }
+}
+
+fn projected_tool_schema_mut(tool: &mut Value, shape: ResolvedToolWireShape) -> Option<&mut Value> {
+    match shape {
+        ResolvedToolWireShape::OpenAiFunction => tool
+            .get_mut("function")
+            .and_then(|function| function.get_mut("parameters")),
+        ResolvedToolWireShape::AnthropicInputSchema => tool.get_mut("input_schema"),
+    }
+}
+
+pub(crate) fn classify_tools_wire_shape_mismatch(
+    status: u16,
+    body_text: &str,
+    configured_shape: ResolvedToolWireShape,
+) -> Option<String> {
+    if status != 400 {
+        return None;
+    }
+
+    let lower = body_text.to_ascii_lowercase();
+    let expected_shape = if lower.contains("body.tools[0].function")
+        && (lower.contains("missing") || lower.contains("required"))
+    {
+        Some(ResolvedToolWireShape::OpenAiFunction)
+    } else if lower.contains("input tag function does not match expected custom") {
+        Some(ResolvedToolWireShape::AnthropicInputSchema)
+    } else {
+        None
+    }?;
+
+    Some(format!(
+        "tools wire shape mismatch: configured tool_wire_shape resolved to {}; upstream appears to expect {}; upstream error: {}",
+        configured_shape.as_config_value(),
+        expected_shape.as_config_value(),
+        body_text
+    ))
 }
 
 fn preflight_projected_body(
@@ -529,6 +652,82 @@ mod tests {
             .expect("request body projection should succeed");
 
         assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_tool_wire_shape_anthropic_default_emits_input_schema() {
+        let request = test_request(test_tools(), None);
+        let body = AnthropicWireProjector::project(
+            &request,
+            &ProviderCompat::anthropic_defaults(),
+            WireParams {
+                provider: WireProvider::Anthropic,
+                anthropic_version: None,
+                include_model_in_body: true,
+                include_stream: true,
+                cache_enabled: false,
+                sanitize_schema: false,
+            },
+        )
+        .expect("request body projection should succeed");
+
+        assert_eq!(body["tools"][0]["name"], "read");
+        assert!(body["tools"][0].get("input_schema").is_some());
+        assert!(body["tools"][0].get("function").is_none());
+    }
+
+    #[test]
+    fn test_tool_wire_shape_anthropic_override_openai_function() {
+        let request = test_request(test_tools(), None);
+        let user_compat: ProviderCompat =
+            serde_json::from_value(json!({"tool_wire_shape": "openai_function"})).unwrap();
+        let compat = ProviderCompat::merge(ProviderCompat::anthropic_defaults(), user_compat);
+
+        let body = AnthropicWireProjector::project(
+            &request,
+            &compat,
+            WireParams {
+                provider: WireProvider::Anthropic,
+                anthropic_version: None,
+                include_model_in_body: true,
+                include_stream: true,
+                cache_enabled: false,
+                sanitize_schema: false,
+            },
+        )
+        .expect("request body projection should succeed");
+
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["function"]["name"], "read");
+        assert!(body["tools"][0]["function"].get("parameters").is_some());
+        assert!(body["tools"][0].get("input_schema").is_none());
+    }
+
+    #[test]
+    fn test_tool_wire_shape_openai_default_emits_function() {
+        let request = test_request(test_tools(), None);
+        let body = OpenAiProjector::project(&request, &ProviderCompat::openai_defaults())
+            .expect("request body projection should succeed");
+
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["function"]["name"], "read");
+        assert!(body["tools"][0]["function"].get("parameters").is_some());
+        assert!(body["tools"][0].get("input_schema").is_none());
+    }
+
+    #[test]
+    fn test_tool_wire_shape_openai_override_anthropic_input_schema() {
+        let request = test_request(test_tools(), None);
+        let user_compat: ProviderCompat =
+            serde_json::from_value(json!({"tool_wire_shape": "anthropic_input_schema"})).unwrap();
+        let compat = ProviderCompat::merge(ProviderCompat::openai_defaults(), user_compat);
+
+        let body = OpenAiProjector::project(&request, &compat)
+            .expect("request body projection should succeed");
+
+        assert_eq!(body["tools"][0]["name"], "read");
+        assert!(body["tools"][0].get("input_schema").is_some());
+        assert!(body["tools"][0].get("function").is_none());
     }
 
     #[test]

--- a/crates/aion-providers/src/vertex.rs
+++ b/crates/aion-providers/src/vertex.rs
@@ -14,7 +14,8 @@ use aion_types::llm::{LlmEvent, LlmRequest};
 
 use super::anthropic_shared;
 use crate::projector::{
-    AnthropicWireProjector, WireParams, WireProvider, projection_to_provider_error,
+    AnthropicWireProjector, ResolvedToolWireShape, WireParams, WireProvider,
+    classify_tools_wire_shape_mismatch, projection_to_provider_error,
 };
 use crate::stream_runner::{RetryPolicy, run_stream};
 use crate::{LlmProvider, ProviderError};
@@ -237,6 +238,7 @@ impl VertexProvider {
         &self,
         url: &str,
         body: &Value,
+        tool_wire_shape: ResolvedToolWireShape,
     ) -> Result<reqwest::Response, ProviderError> {
         let access_token = self.get_access_token().await?;
 
@@ -264,6 +266,14 @@ impl VertexProvider {
                     retry_after_ms: 5000,
                 });
             }
+            if let Some(message) =
+                classify_tools_wire_shape_mismatch(status.as_u16(), &body_text, tool_wire_shape)
+            {
+                return Err(ProviderError::Api {
+                    status: status.as_u16(),
+                    message,
+                });
+            }
             return Err(ProviderError::Api {
                 status: status.as_u16(),
                 message: body_text,
@@ -282,6 +292,7 @@ impl LlmProvider for VertexProvider {
     ) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let url = self.build_url(&request.model);
         let body = self.build_request_body(request)?;
+        let tool_wire_shape = AnthropicWireProjector::resolved_tool_wire_shape(&self.compat);
 
         tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
 
@@ -294,7 +305,11 @@ impl LlmProvider for VertexProvider {
                 let provider = provider.clone();
                 let url = url.clone();
                 let body = body.clone();
-                async move { provider.send_stream_request(&url, &body).await }
+                async move {
+                    provider
+                        .send_stream_request(&url, &body, tool_wire_shape)
+                        .await
+                }
             }
         };
         let process = move |response, tx| async move {

--- a/crates/aion-providers/tests/provider_anthropic_test.rs
+++ b/crates/aion-providers/tests/provider_anthropic_test.rs
@@ -8,6 +8,8 @@ use aion_providers::anthropic::AnthropicProvider;
 use aion_providers::{LlmProvider, ProviderError};
 use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 use aion_types::message::{ContentBlock, Message, Role, StopReason};
+use aion_types::tool::ToolDef;
+use serde_json::{Value, json};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -28,6 +30,23 @@ fn minimal_request() -> LlmRequest {
         thinking: None,
         reasoning_effort: None,
     }
+}
+
+fn minimal_request_with_tool() -> LlmRequest {
+    let mut request = minimal_request();
+    request.tools = vec![ToolDef {
+        name: "read".to_string(),
+        description: "Read a file".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" }
+            },
+            "required": ["path"]
+        }),
+        deferred: false,
+    }];
+    request
 }
 
 /// Build a complete SSE body for a simple text response.
@@ -319,6 +338,46 @@ async fn test_anthropic_auth_error() {
         }
         Err(other) => panic!("expected Api error, got: {other:?}"),
         Ok(_) => panic!("expected an error but stream succeeded"),
+    }
+}
+
+#[tokio::test]
+async fn test_aio_140_anthropic_tools_wire_shape_mismatch_error_is_readable_and_not_retried() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(
+            r#"{"error":{"message":"Missing required parameter: body.tools[0].function"}}"#,
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider = AnthropicProvider::new(
+        "test-api-key",
+        &server.uri(),
+        ProviderCompat::anthropic_defaults(),
+    )
+    .with_cache(false);
+    let result = provider.stream(&minimal_request_with_tool()).await;
+
+    server.verify().await;
+    let received = server.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1, "mismatch errors must not be retried");
+    let body: Value = received[0].body_json().unwrap();
+    assert!(
+        body["tools"][0].get("input_schema").is_some(),
+        "Anthropic native request should keep input_schema tools"
+    );
+
+    match result.unwrap_err() {
+        ProviderError::Api { status, message } => {
+            assert_eq!(status, 400);
+            assert!(message.contains("tools wire shape mismatch"));
+            assert!(message.contains("anthropic_input_schema"));
+        }
+        other => panic!("expected Api error, got: {other:?}"),
     }
 }
 

--- a/crates/aion-providers/tests/provider_openai_test.rs
+++ b/crates/aion-providers/tests/provider_openai_test.rs
@@ -5,7 +5,8 @@ use aion_providers::LlmProvider;
 use aion_providers::openai::OpenAIProvider;
 use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, StopReason};
-use serde_json::json;
+use aion_types::tool::ToolDef;
+use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use wiremock::matchers::{header, method, path};
@@ -31,6 +32,23 @@ fn make_request() -> LlmRequest {
         thinking: None,
         reasoning_effort: None,
     }
+}
+
+fn make_request_with_tool() -> LlmRequest {
+    let mut request = make_request();
+    request.tools = vec![ToolDef {
+        name: "read".to_string(),
+        description: "Read a file".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" }
+            },
+            "required": ["path"]
+        }),
+        deferred: false,
+    }];
+    request
 }
 
 /// Collect all events from the receiver until the channel closes.
@@ -546,6 +564,42 @@ async fn test_openai_api_error_non_success_status() {
     match result.unwrap_err() {
         aion_providers::ProviderError::Api { status, .. } => {
             assert_eq!(status, 401);
+        }
+        e => panic!("expected Api error, got: {:?}", e),
+    }
+}
+
+#[tokio::test]
+async fn test_aio_140_openai_tools_wire_shape_mismatch_error_is_readable_and_not_retried() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(
+            r#"{"error":{"message":"Input tag function does not match expected custom"}}"#,
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let provider =
+        OpenAIProvider::new("test-key", &server.uri(), ProviderCompat::openai_defaults());
+    let result = provider.stream(&make_request_with_tool()).await;
+
+    server.verify().await;
+    let received = server.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1, "mismatch errors must not be retried");
+    let body: Value = received[0].body_json().unwrap();
+    assert!(
+        body["tools"][0].get("function").is_some(),
+        "OpenAI native request should keep function tools"
+    );
+
+    match result.unwrap_err() {
+        aion_providers::ProviderError::Api { status, message } => {
+            assert_eq!(status, 400);
+            assert!(message.contains("tools wire shape mismatch"));
+            assert!(message.contains("openai_function"));
         }
         e => panic!("expected Api error, got: {:?}", e),
     }


### PR DESCRIPTION
## Summary
- add provider compat control for explicit tool declaration wire shape
- share tool projection across OpenAI and Anthropic-compatible providers
- classify upstream tool wire-shape 400 responses as readable provider API errors without retrying

## Issue
- [AIO-140](https://multica.ai/aionui-dev/issues/AIO-140)

## Verification
- cargo test -p aion-config tool_wire_shape
- cargo test -p aion-providers projector
- cargo test -p aion-providers aio_140
- cargo test -p aion-providers golden_
- cargo fmt --all --check
- cargo clippy -p aion-providers --all-targets -- -D warnings
- git diff --check
- GIT_SSH_COMMAND='ssh -i ~/.ssh/github_boiilab -o IdentitiesOnly=yes' just push -u origin boii/fix/aio-140-tool-wire-shape
  - nextest summary: 2035 tests run: 2035 passed, 2 skipped