### PR TITLE
fix(providers): legalize tool schemas

### DIFF
--- a/crates/aion-config/src/lib.rs
+++ b/crates/aion-config/src/lib.rs
@@ -8,4 +8,5 @@ pub mod file_cache;
 pub mod hooks;
 pub mod logging;
 pub mod plan;
+pub mod schema;
 pub mod shell;

--- a/crates/aion-config/src/schema.rs
+++ b/crates/aion-config/src/schema.rs
@@ -1,0 +1,160 @@
+use serde_json::{Map, Value};
+
+pub const JSON_SCHEMA_DRAFT_2020_12: &str = "https://json-schema.org/draft/2020-12/schema";
+
+/// Apply provider-neutral JSON Schema fixes required for tool declarations.
+pub fn legalize_json_schema(schema: &Value) -> Value {
+    match schema {
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Array(_) => {
+            empty_object_schema()
+        }
+        Value::Object(object) if object.is_empty() => empty_object_schema(),
+        Value::Object(_) => {
+            if has_non_object_root_type(schema) {
+                return empty_object_schema();
+            }
+
+            let mut legalized = schema.clone();
+            if let Some(object) = legalized.as_object_mut() {
+                if !object.contains_key("type") {
+                    object.insert("type".to_string(), Value::String("object".to_string()));
+                }
+
+                if object.get("type").and_then(Value::as_str) == Some("object")
+                    && !object.contains_key("properties")
+                {
+                    object.insert("properties".to_string(), Value::Object(Map::new()));
+                }
+
+                object.insert(
+                    "$schema".to_string(),
+                    Value::String(JSON_SCHEMA_DRAFT_2020_12.to_string()),
+                );
+            }
+
+            legalized
+        }
+    }
+}
+
+fn has_non_object_root_type(schema: &Value) -> bool {
+    match schema.get("type") {
+        Some(Value::String(root_type)) => root_type != "object",
+        Some(_) => true,
+        None => false,
+    }
+}
+
+fn empty_object_schema() -> Value {
+    let mut object = Map::new();
+    object.insert(
+        "$schema".to_string(),
+        Value::String(JSON_SCHEMA_DRAFT_2020_12.to_string()),
+    );
+    object.insert("type".to_string(), Value::String("object".to_string()));
+    object.insert("properties".to_string(), Value::Object(Map::new()));
+    Value::Object(object)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn legalize_json_schema_null_becomes_empty_object_schema() {
+        assert_eq!(
+            legalize_json_schema(&Value::Null),
+            json!({
+                "$schema": JSON_SCHEMA_DRAFT_2020_12,
+                "type": "object",
+                "properties": {}
+            })
+        );
+    }
+
+    #[test]
+    fn legalize_json_schema_empty_object_becomes_empty_object_schema() {
+        assert_eq!(
+            legalize_json_schema(&json!({})),
+            json!({
+                "$schema": JSON_SCHEMA_DRAFT_2020_12,
+                "type": "object",
+                "properties": {}
+            })
+        );
+    }
+
+    #[test]
+    fn legalize_json_schema_boolean_roots_become_empty_object_schema() {
+        for schema in [json!(true), json!(false)] {
+            assert_eq!(
+                legalize_json_schema(&schema),
+                json!({
+                    "$schema": JSON_SCHEMA_DRAFT_2020_12,
+                    "type": "object",
+                    "properties": {}
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn legalize_json_schema_string_array_and_number_roots_become_empty_object_schema() {
+        for schema in [json!("raw"), json!(["not", "object"]), json!(42)] {
+            assert_eq!(
+                legalize_json_schema(&schema),
+                json!({
+                    "$schema": JSON_SCHEMA_DRAFT_2020_12,
+                    "type": "object",
+                    "properties": {}
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn legalize_json_schema_non_object_root_type_becomes_empty_object_schema() {
+        assert_eq!(
+            legalize_json_schema(&json!({
+                "type": "string"
+            })),
+            json!({
+                "$schema": JSON_SCHEMA_DRAFT_2020_12,
+                "type": "object",
+                "properties": {}
+            })
+        );
+    }
+
+    #[test]
+    fn legalize_json_schema_missing_root_type_defaults_to_object() {
+        let legalized = legalize_json_schema(&json!({
+            "properties": {
+                "path": { "type": "string" }
+            }
+        }));
+
+        assert_eq!(legalized["type"], "object");
+        assert_eq!(legalized["properties"]["path"]["type"], "string");
+    }
+
+    #[test]
+    fn legalize_json_schema_missing_root_properties_defaults_to_empty_object() {
+        let legalized = legalize_json_schema(&json!({
+            "type": "object"
+        }));
+
+        assert_eq!(legalized["properties"], json!({}));
+    }
+
+    #[test]
+    fn legalize_json_schema_sets_root_draft_2020_12_schema() {
+        let legalized = legalize_json_schema(&json!({
+            "type": "object",
+            "properties": {}
+        }));
+
+        assert_eq!(legalized["$schema"], JSON_SCHEMA_DRAFT_2020_12);
+    }
+}

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -475,6 +475,7 @@ mod tests {
     use super::*;
 
     use aion_config::compat::{MessageCompat, ToolCompat};
+    use aion_config::schema::legalize_json_schema;
     use aion_types::tool::ToolDef;
     use serde_json::json;
 
@@ -1199,7 +1200,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0]["name"], "bash");
         assert_eq!(result[0]["description"], "Run a shell command");
-        assert_eq!(result[0]["input_schema"], schema);
+        assert_eq!(result[0]["input_schema"], legalize_json_schema(&schema));
     }
 
     #[test]
@@ -1246,6 +1247,66 @@ mod tests {
         );
         let desc = result[1]["description"].as_str().unwrap();
         assert!(desc.contains("ToolSearch"));
+    }
+
+    #[test]
+    fn test_build_tools_legalizes_null_and_missing_type_schema() {
+        let tools = vec![
+            ToolDef {
+                name: "NullSchema".into(),
+                description: "Null schema".into(),
+                input_schema: Value::Null,
+                deferred: false,
+            },
+            ToolDef {
+                name: "MissingType".into(),
+                description: "Missing root type".into(),
+                input_schema: json!({
+                    "properties": {
+                        "path": { "type": "string" }
+                    }
+                }),
+                deferred: false,
+            },
+            ToolDef {
+                name: "ArraySchema".into(),
+                description: "Array schema".into(),
+                input_schema: json!(["not", "object"]),
+                deferred: false,
+            },
+            ToolDef {
+                name: "StringRootType".into(),
+                description: "String root type".into(),
+                input_schema: json!({"type": "string"}),
+                deferred: false,
+            },
+        ];
+        let result = build_tools(&tools);
+
+        assert_eq!(
+            result[0]["input_schema"],
+            json!({
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {}
+            })
+        );
+        assert_eq!(result[1]["input_schema"]["type"], "object");
+        assert_eq!(
+            result[1]["input_schema"]["$schema"],
+            "https://json-schema.org/draft/2020-12/schema"
+        );
+        assert!(result[1]["input_schema"]["properties"]["path"].is_object());
+        for tool in result.iter().skip(2) {
+            assert_eq!(
+                tool["input_schema"],
+                json!({
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {}
+                })
+            );
+        }
     }
 
     // --- parse_sse_data tests ---

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -1694,6 +1694,48 @@ mod tests {
     }
 
     #[test]
+    fn test_build_tools_legalizes_null_and_empty_parameters() {
+        let tools = vec![
+            ToolDef {
+                name: "NullSchema".into(),
+                description: "Null schema".into(),
+                input_schema: Value::Null,
+                deferred: false,
+            },
+            ToolDef {
+                name: "EmptySchema".into(),
+                description: "Empty schema".into(),
+                input_schema: json!({}),
+                deferred: false,
+            },
+            ToolDef {
+                name: "StringSchema".into(),
+                description: "String schema".into(),
+                input_schema: json!("raw"),
+                deferred: false,
+            },
+            ToolDef {
+                name: "StringRootType".into(),
+                description: "String root type".into(),
+                input_schema: json!({"type": "string"}),
+                deferred: false,
+            },
+        ];
+        let result = project_tools(&tools, ResolvedToolWireShape::OpenAiFunction);
+
+        for tool in result {
+            assert_eq!(
+                tool["function"]["parameters"],
+                json!({
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {}
+                })
+            );
+        }
+    }
+
+    #[test]
     fn usage_includes_prompt_cache_hit_tokens() {
         // DeepSeek reports prompt_cache_hit_tokens separately;
         // input_tokens should be the sum of prompt_tokens + prompt_cache_hit_tokens

--- a/crates/aion-providers/src/projector.rs
+++ b/crates/aion-providers/src/projector.rs
@@ -1,4 +1,5 @@
 use aion_config::compat::{self, ProviderCompat, ToolWireShape};
+use aion_config::schema::legalize_json_schema;
 use aion_types::llm::{LlmRequest, ThinkingConfig};
 use aion_types::tool::{ToolDef, truncate_deferred_description};
 use serde_json::{Value, json};
@@ -265,13 +266,16 @@ fn tool_description_and_schema(tool: &ToolDef) -> (String, Value) {
         let short_desc = truncate_deferred_description(&tool.description);
         (
             format!("(Deferred) {short_desc} — Use ToolSearch to load full schema before calling."),
-            json!({
+            legalize_json_schema(&json!({
                 "type": "object",
                 "properties": {}
-            }),
+            })),
         )
     } else {
-        (tool.description.clone(), tool.input_schema.clone())
+        (
+            tool.description.clone(),
+            legalize_json_schema(&tool.input_schema),
+        )
     }
 }
 
@@ -351,6 +355,7 @@ fn preflight_projected_body(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aion_config::schema::legalize_json_schema;
     use aion_types::message::{ContentBlock, Message, Role};
     use aion_types::tool::ToolDef;
 
@@ -441,12 +446,21 @@ mod tests {
                     {
                         "name": "read",
                         "description": "Read",
-                        "input_schema": {"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}
+                        "input_schema": {
+                            "$schema": "https://json-schema.org/draft/2020-12/schema",
+                            "type":"object",
+                            "properties":{"path":{"type":"string"}},
+                            "required":["path"]
+                        }
                     },
                     {
                         "name": "list",
                         "description": "List",
-                        "input_schema": {"type":"object","properties":{}},
+                        "input_schema": {
+                            "$schema": "https://json-schema.org/draft/2020-12/schema",
+                            "type":"object",
+                            "properties":{}
+                        },
                         "cache_control": { "type": "ephemeral" }
                     }
                 ],
@@ -490,12 +504,21 @@ mod tests {
                     {
                         "name": "read",
                         "description": "Read",
-                        "input_schema": {"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}
+                        "input_schema": {
+                            "$schema": "https://json-schema.org/draft/2020-12/schema",
+                            "type":"object",
+                            "properties":{"path":{"type":"string"}},
+                            "required":["path"]
+                        }
                     },
                     {
                         "name": "list",
                         "description": "List",
-                        "input_schema": {"type":"object","properties":{}}
+                        "input_schema": {
+                            "$schema": "https://json-schema.org/draft/2020-12/schema",
+                            "type":"object",
+                            "properties":{}
+                        }
                     }
                 ]
             })
@@ -564,7 +587,11 @@ mod tests {
             .expect("request body projection should succeed");
         assert_eq!(
             unsanitized["tools"][0]["input_schema"],
-            request.tools[0].input_schema
+            legalize_json_schema(&request.tools[0].input_schema)
+        );
+        assert_eq!(
+            unsanitized["tools"][0]["input_schema"]["additionalProperties"],
+            false
         );
 
         let sanitized = AnthropicWireProjector::project(
@@ -578,9 +605,47 @@ mod tests {
         .expect("request body projection should succeed");
         assert_eq!(
             sanitized["tools"][0]["input_schema"],
-            compat::sanitize_json_schema(&request.tools[0].input_schema)
+            compat::sanitize_json_schema(&legalize_json_schema(&request.tools[0].input_schema))
         );
         assert!(sanitized["tools"][0]["input_schema"]["additionalProperties"].is_null());
+    }
+
+    #[test]
+    fn test_bedrock_strict_sanitize_runs_after_universal_legalize() {
+        let request = test_request(
+            vec![ToolDef {
+                name: "empty".to_string(),
+                description: "Empty".to_string(),
+                input_schema: json!({
+                    "additionalProperties": false
+                }),
+                deferred: false,
+            }],
+            None,
+        );
+
+        let body = AnthropicWireProjector::project(
+            &request,
+            &ProviderCompat::bedrock_defaults(),
+            WireParams {
+                provider: WireProvider::Bedrock,
+                anthropic_version: Some("bedrock-2023-05-31"),
+                include_model_in_body: false,
+                include_stream: false,
+                cache_enabled: false,
+                sanitize_schema: true,
+            },
+        )
+        .expect("request body projection should succeed");
+
+        let schema = &body["tools"][0]["input_schema"];
+        assert_eq!(schema["type"], "object");
+        assert_eq!(
+            schema["$schema"],
+            "https://json-schema.org/draft/2020-12/schema"
+        );
+        assert!(schema["properties"].as_object().unwrap().is_empty());
+        assert!(schema.get("additionalProperties").is_none());
     }
 
     #[test]

--- a/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_cache.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_cache.snap
@@ -30,6 +30,7 @@ expression: p.build_request_body(&r)
     {
       "description": "Read",
       "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "path": {
             "type": "string"
@@ -48,6 +49,7 @@ expression: p.build_request_body(&r)
       },
       "description": "List",
       "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {},
         "type": "object"
       },

--- a/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_tools_no_cache.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__anthropic__tests__anthropic_with_tools_no_cache.snap
@@ -22,6 +22,7 @@ expression: p.build_request_body(&r)
     {
       "description": "Read",
       "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "path": {
             "type": "string"
@@ -37,6 +38,7 @@ expression: p.build_request_body(&r)
     {
       "description": "List",
       "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {},
         "type": "object"
       },

--- a/crates/aion-providers/src/snapshots/aion_providers__bedrock__tests__bedrock_with_tools.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__bedrock__tests__bedrock_with_tools.snap
@@ -21,6 +21,7 @@ expression: p.build_request_body(&r)
     {
       "description": "Read",
       "input_schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "path": {
             "type": "string"

--- a/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_tools.snap
+++ b/crates/aion-providers/src/snapshots/aion_providers__openai__tests__openai_with_tools.snap
@@ -25,6 +25,7 @@ expression: provider.build_request_body(&request)
         "description": "Read a file",
         "name": "read",
         "parameters": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "properties": {
             "path": {
               "type": "string"
@@ -43,6 +44,7 @@ expression: provider.build_request_body(&request)
         "description": "List dir",
         "name": "list",
         "parameters": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "properties": {},
           "type": "object"
         }


### PR DESCRIPTION
## Summary
- add provider-neutral JSON Schema legalization for tool declarations
- route OpenAI and Anthropic-compatible tool projections through the shared legalizer
- preserve strict Bedrock sanitization after legalization and update provider golden snapshots

## Issue
- [AIO-8](https://multica.ai/aionui-dev/issues/AIO-8)

## Verification
- cargo test -p aion-config legalize_json_schema
- cargo test -p aion-providers legalizes
- cargo test -p aion-providers projector
- cargo test -p aion-providers golden_
- cargo fmt --all --check
- cargo clippy -p aion-providers --all-targets -- -D warnings
- git diff --check
- GIT_SSH_COMMAND='ssh -i ~/.ssh/github_boiilab -o IdentitiesOnly=yes' just push -u origin boii/fix/aio-8-schema-legalize
  - nextest summary: 2046 tests run: 2046 passed, 2 skipped