### PR TITLE
fix(config): leave max turns unlimited by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "regex",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aion-config",
  "chrono",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "libc",
  "tokio",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aion-types",
  "rstest",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "async-trait",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -46,19 +46,21 @@ aionrs --help
 
 ## Runtime Limits
 
-`max_turns` is the broad model-turn limit per run; it defaults to `20`.
-Set it to `0` to disable the broad limit. `max_tool_call_malformed_turns`
+`max_turns` is the broad model-turn limit per run. It is unset by default,
+so runs have no broad model-turn limit unless you configure one. Set it to
+`0` to explicitly disable the broad limit. `max_tool_call_malformed_turns`
 stops repeated same tool-call-malformed rounds earlier; it defaults to `3`.
 `max_tool_call_failure_turns` stops zero-text turns where every executable
 tool result failed; it also defaults to `3`. Set either guard to `0` to
-disable that breaker and rely on `max_turns`.
+disable that breaker and rely on `max_turns` if a broad turn limit is
+configured.
 
 See [Core Concepts](docs/core-concepts.md) for the distinction between runs,
 turns, tool rounds, and tool calls.
 
 ```toml
 [default]
-max_turns = 20
+max_turns = 20  # optional broad model-turn limit
 max_tool_call_malformed_turns = 3
 max_tool_call_failure_turns = 3
 

--- a/crates/aion-config/src/config.rs
+++ b/crates/aion-config/src/config.rs
@@ -13,8 +13,6 @@ use crate::plan::PlanConfig;
 use crate::shell::ShellConfig;
 use aion_types::llm::ThinkingConfig;
 
-pub const DEFAULT_MAX_TURNS: usize = 20;
-
 // ---------------------------------------------------------------------------
 // Provider-specific sub-configurations (defined here to avoid circular deps)
 // ---------------------------------------------------------------------------
@@ -262,7 +260,7 @@ fn resolve_max_turns(configured: Option<usize>) -> Option<usize> {
     match configured {
         Some(0) => None,
         Some(limit) => Some(limit),
-        None => Some(DEFAULT_MAX_TURNS),
+        None => None,
     }
 }
 
@@ -894,7 +892,7 @@ const DEFAULT_CONFIG_TEMPLATE: &str = r#"# aionrs configuration
 provider = "anthropic"            # built-in provider or custom alias from [providers.<name>]
 # model = "claude-sonnet-4-20250514"
 max_tokens = 8192
-# max_turns = 20                  # max model turns per run; set 0 to disable
+# max_turns = 20                  # optional max model turns per run; omit or set 0 to disable
 # max_tool_call_malformed_turns = 3  # 0 disables the tool-call-malformed round breaker
 # max_tool_call_failure_turns = 3    # 0 disables the tool-call-failure round breaker
 # system_prompt = "..."          # optional custom system prompt
@@ -1580,8 +1578,8 @@ allow = ["commit", "review-pr", "db:*"]
     }
 
     #[test]
-    fn resolve_max_turns_defaults_and_allows_explicit_disable() {
-        assert_eq!(resolve_max_turns(None), Some(DEFAULT_MAX_TURNS));
+    fn resolve_max_turns_defaults_to_unlimited_and_preserves_explicit_limits() {
+        assert_eq!(resolve_max_turns(None), None);
         assert_eq!(resolve_max_turns(Some(0)), None);
         assert_eq!(resolve_max_turns(Some(7)), Some(7));
     }

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -106,7 +106,8 @@ tool call/result pairs: 3
 
 ## Runtime Limit Semantics
 
-`max_turns` is the broad non-convergence limit for one run:
+`max_turns` is the broad non-convergence limit for one run. It is unset by
+default, so runs have no broad model-turn limit unless you configure one:
 
 ```toml
 max_turns = 20
@@ -118,7 +119,7 @@ means:
 max model turns per run = 20
 ```
 
-Setting `max_turns = 0` disables this broad turn limit.
+Omitting `max_turns` or setting `max_turns = 0` disables this broad turn limit.
 
 The limit applies to turns, not individual tool calls. If one turn requests
 three tools, that consumes:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,7 @@ aionrs [OPTIONS] [PROMPT]...
 | `--profile <name>` | Named profile from config file |
 | `--compaction <level>` | Output compaction: `off`, `safe` (default), `full` |
 | `--toon` | Enable TOON tabular encoding (with `full` compaction) |
-| `--max-turns <n>` | Broad model-turn limit per run; defaults to `20`, `0` disables |
+| `--max-turns <n>` | Broad model-turn limit per run; unset by default, `0` disables |
 | `--max-tool-call-malformed-turns <n>` | Stop after repeated same tool-call-malformed rounds; `0` disables |
 | `--max-tool-call-failure-turns <n>` | Stop after repeated tool-call-failure rounds; `0` disables |
 | `--auto-approve` | Skip all tool confirmations |
@@ -69,7 +69,7 @@ aionrs --init-config
 provider = "anthropic"
 # model = "claude-sonnet-4-20250514"
 max_tokens = 8192
-max_turns = 20  # max model turns per run; set 0 to disable
+# max_turns = 20  # optional max model turns per run; omit or set 0 to disable
 max_tool_call_malformed_turns = 3  # default; set 0 to disable this breaker
 max_tool_call_failure_turns = 3  # default; set 0 to disable this breaker
 
@@ -140,17 +140,18 @@ plan_directory = ".aionrs/plans"
 
 ### Runtime Limits
 
-`max_turns` is the broad model-turn limit per run. It defaults to `20`; set it
-to `0` to disable the broad limit. See [Core Concepts](core-concepts.md) for
+`max_turns` is the broad model-turn limit per run. It is unset by default, so
+runs have no broad model-turn limit unless you configure one. Set it to `0` to
+explicitly disable the broad limit. See [Core Concepts](core-concepts.md) for
 the distinction between runs, turns, tool rounds, and tool calls.
 
 `max_tool_call_malformed_turns` limits consecutive same tool-call-malformed
 rounds from a provider. The default is `3`; `0` disables this breaker
-and leaves stopping to `max_turns`.
+and leaves stopping to `max_turns` if a broad turn limit is configured.
 
 `max_tool_call_failure_turns` limits consecutive zero-text turns where every
 executable tool result failed. The default is `3`; `0` disables this breaker
-and leaves stopping to `max_turns`.
+and leaves stopping to `max_turns` if a broad turn limit is configured.
 
 Precedence is `CLI > profile > project config > global config > built-in default 3`. Use `--max-tool-call-malformed-turns <n>` or `--max-tool-call-failure-turns <n>` for a one-off CLI override.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -84,8 +84,8 @@ aionrs --profile dev "Create a GitHub issue"
 - Supports multi-level inheritance chains
 - Auto-detects circular inheritance
 - Child profile settings override parent
-- `max_tool_call_malformed_turns` can be set per profile. It defaults to `3`; `0` disables this tool-call-malformed round breaker and leaves stopping to `max_turns`.
-- `max_tool_call_failure_turns` can be set per profile. It defaults to `3`; `0` disables this tool-call-failure round breaker and leaves stopping to `max_turns`.
+- `max_tool_call_malformed_turns` can be set per profile. It defaults to `3`; `0` disables this tool-call-malformed round breaker and leaves stopping to `max_turns` if a broad turn limit is configured.
+- `max_tool_call_failure_turns` can be set per profile. It defaults to `3`; `0` disables this tool-call-failure round breaker and leaves stopping to `max_turns` if a broad turn limit is configured.
 - Override them for one run with `--max-tool-call-malformed-turns <n>` or `--max-tool-call-failure-turns <n>`.
 
 ---


### PR DESCRIPTION
## Summary
- Preserve legacy behavior by resolving missing `max_turns` to no broad turn limit.
- Keep explicit positive `max_turns` values as turn limits and `0` as disabled.
- Update runtime-limit docs and refresh the lockfile package versions after the `v0.1.35` release.

## Verification
- `just push` was run before PR creation per maintainer note.