### PR TITLE
fix(shell): preserve Windows command stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "regex",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aion-config",
  "chrono",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "libc",
  "tokio",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aion-types",
  "rstest",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/aion-compact/src/sanitize.rs
+++ b/crates/aion-compact/src/sanitize.rs
@@ -14,6 +14,7 @@ pub fn collapse_cr_lines(text: &str) -> String {
         if !result.is_empty() {
             result.push('\n');
         }
+        let line = line.strip_suffix('\r').unwrap_or(line);
         if let Some(last) = line.rsplit('\r').next() {
             result.push_str(last);
         }
@@ -105,6 +106,21 @@ mod tests {
     }
 
     #[test]
+    fn collapse_cr_preserves_crlf_line_content() {
+        let input = "Exit code: 0\nSTDOUT:\nmessage\r\nSTDERR:";
+        assert_eq!(
+            collapse_cr_lines(input),
+            "Exit code: 0\nSTDOUT:\nmessage\nSTDERR:"
+        );
+    }
+
+    #[test]
+    fn collapse_cr_preserves_overwrite_semantics_with_crlf() {
+        let input = "Downloading... 10%\rDownloading... 100%\r\nDone\r\nLast";
+        assert_eq!(collapse_cr_lines(input), "Downloading... 100%\nDone\nLast");
+    }
+
+    #[test]
     fn collapse_cr_no_cr_unchanged() {
         let input = "line1\nline2\nline3";
         assert_eq!(collapse_cr_lines(input), input);
@@ -154,5 +170,19 @@ mod tests {
         assert!(!result.contains("\n\n\n"));
         assert!(!result.contains("   \n"));
         assert!(result.contains("bar done"));
+    }
+
+    #[test]
+    fn sanitize_preserves_windows_command_stdout() {
+        let input = "Exit code: 0\nSTDOUT:\nmessage\r\nSTDERR:";
+        let result = sanitize(input);
+        assert_eq!(result, "Exit code: 0\nSTDOUT:\nmessage\nSTDERR:");
+    }
+
+    #[test]
+    fn sanitize_preserves_unix_command_stdout() {
+        let input = "Exit code: 0\nSTDOUT:\nmessage\nSTDERR:";
+        let result = sanitize(input);
+        assert_eq!(result, input);
     }
 }

--- a/crates/aion-tools/src/exec_command.rs
+++ b/crates/aion-tools/src/exec_command.rs
@@ -320,6 +320,25 @@ mod tests {
 
     #[cfg(windows)]
     #[tokio::test]
+    async fn execute_powershell_echo_quoted_message_returns_stdout() {
+        let tool = ExecCommandTool::new(std::env::temp_dir());
+        let input = json!({
+            "cmd": "echo \"message\"",
+            "shell": "powershell"
+        });
+
+        let result = tool.execute(input).await;
+
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert!(
+            result.content.contains("STDOUT:\n") && result.content.contains("message"),
+            "PowerShell quoted echo stdout should be preserved, got: {}",
+            result.content
+        );
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
     async fn execute_cmd_echo_returns_stdout() {
         let tool = ExecCommandTool::new(std::env::temp_dir());
         let input = json!({

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@
 
 # Cross-platform shell defaults for linewise recipes.
 set shell := ["sh", "-cu"]
-set windows-shell := ["pwsh", "-NoLogo", "-NoProfile", "-Command"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command"]
 
 # `which()` is used below to probe for `vx`; it is a just unstable feature.
 set unstable
@@ -141,13 +141,17 @@ clean:
 push *ARGS: lint-fix fmt _auto-commit-fixes test
     git push {{ ARGS }}
 
-# Auto-commit any fmt/clippy fixes. Pure git + the `||` chain operator, which
-# both `sh` and `pwsh` (7+) understand — so no bash shebang / `[ ]` test, and
-# it runs the same on every OS. `git diff --cached --quiet` exits non-zero only
-# when there is something staged, gating the commit.
+# Auto-commit any fmt/clippy fixes. Split by shell so the Windows path works
+# with the built-in Windows PowerShell as well as PowerShell 7.
+[unix]
 _auto-commit-fixes:
     @git add -A
     @git diff --cached --quiet || git commit -m "chore: auto-commit lint/fmt fixes in just push recipe"
+
+[windows]
+_auto-commit-fixes:
+    @git add -A
+    @git diff --cached --quiet; if ($LASTEXITCODE -eq 1) { git commit -m "chore: auto-commit lint/fmt fixes in just push recipe" } elseif ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # ── All checks (mirrors CI exactly) ───────────────────────────────────────
 check-all: fmt-check lint test-ci hakari-verify audit


### PR DESCRIPTION
## Summary
- Preserve CRLF line content when sanitizing command output with carriage returns
- Add regression coverage for PowerShell stdout from quoted echo commands
- Make the Windows just shell work without requiring PowerShell 7

## Verification
- cargo test -p aion-compact -- --nocapture
- cargo test -p aion-tools execute_powershell_echo_quoted_message_returns_stdout -- --nocapture
- cargo fmt --all -- --check
- RUSTUP_TOOLCHAIN=stable-x86_64-pc-windows-msvc just push -u origin fix/windows-process-stdout