### PR TITLE
ci(release): sync lockfile in release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,8 @@
 # Job 2 "update-pr" — runs on EVERY OTHER commit:
 #   Creates/updates the release PR. Skipped on release commits to avoid
 #   the duplicate PR problem (googleapis/release-please#713).
+#   After release-please updates Cargo.toml, refreshes Cargo.lock on the
+#   release PR branch because this workspace uses version.workspace = true.
 
 name: Release Please
 
@@ -59,7 +61,46 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'chore: release') && !startsWith(github.event.head_commit.message, 'chore(main): release')"
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Resolve release PR branch
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        id: release-pr
+        env:
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
+        run: |
+          branch="$(jq -r '.headBranchName' <<<"${RELEASE_PR}")"
+          if [[ -z "${branch}" || "${branch}" == "null" ]]; then
+            echo "release-please did not expose a PR branch" >&2
+            exit 1
+          fi
+          echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout release PR branch
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.release-pr.outputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync Cargo.lock versions
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        run: cargo update --workspace
+
+      - name: Commit Cargo.lock if changed
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        run: |
+          if git diff --quiet -- Cargo.lock; then
+            echo "Cargo.lock already matches Cargo.toml"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore: sync Cargo.lock for release"
+          git push origin HEAD:${{ steps.release-pr.outputs.branch }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "aion-cli"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aion-agent",
  "aion-compact",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "regex",
  "serde",
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aion-config",
  "chrono",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "libc",
  "tokio",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aion-types",
  "rstest",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "async-trait",
  "chrono",


### PR DESCRIPTION
## Summary
- Refresh Cargo.lock on release-please PR branches after Cargo.toml version bumps
- Keep the existing simple release-please setup for the version.workspace workspace layout
- Sync the current Cargo.lock workspace crate versions to 0.1.37

## Test plan
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "yaml ok"'
- cargo metadata --locked --format-version 1 --no-deps
- git diff --check
- cargo check --workspace --locked
- just push -u origin boii/fix/release-lock-sync