### PR TITLE
fix(process): capture delayed command output

### DIFF
--- a/crates/aion-config/src/shell.rs
+++ b/crates/aion-config/src/shell.rs
@@ -4,6 +4,8 @@ use std::process::Output;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 
+const POWERSHELL_UTF8_PREFIX: &str = "try { [Console]::InputEncoding=[System.Text.Encoding]::UTF8; [Console]::OutputEncoding=[System.Text.Encoding]::UTF8; $OutputEncoding=[System.Text.Encoding]::UTF8; $PSDefaultParameterValues['Out-File:Encoding']='utf8' } catch {}";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ShellKind {
     Bash,
@@ -275,7 +277,7 @@ fn user_shell_path() -> Option<PathBuf> {
 }
 
 fn prefix_powershell_script_with_utf8(command: &str) -> String {
-    format!("try {{ [Console]::OutputEncoding=[System.Text.Encoding]::UTF8 }} catch {{}}\n{command}")
+    format!("{POWERSHELL_UTF8_PREFIX}\n{command}")
 }
 
 #[cfg(test)]

--- a/crates/aion-config/src/shell_test.rs
+++ b/crates/aion-config/src/shell_test.rs
@@ -37,9 +37,9 @@ mod tests {
         assert_eq!(
             powershell.derive_exec_args("Write-Output ok", false),
             vec![
-                "-NoProfile",
-                "-Command",
-                "try { [Console]::OutputEncoding=[System.Text.Encoding]::UTF8 } catch {}\nWrite-Output ok"
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                format!("{POWERSHELL_UTF8_PREFIX}\nWrite-Output ok")
             ]
         );
 

--- a/crates/aion-process/src/runner.rs
+++ b/crates/aion-process/src/runner.rs
@@ -6,11 +6,12 @@ use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
 use tokio::task::JoinHandle;
+use tokio::time::Instant;
 
 use crate::containment::ChildContainment;
 
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
-pub const DEFAULT_POST_PROCESS_DRAIN: Duration = Duration::from_millis(250);
+pub const DEFAULT_POST_PROCESS_DRAIN: Duration = Duration::from_secs(2);
 
 /// Runs one process and buffers its stdout/stderr while it is running.
 pub struct CommandRunner {
@@ -64,8 +65,8 @@ impl CommandRunner {
             Ok(status) => {
                 let status = status?;
                 let (stdout_result, stderr_result) = tokio::join!(
-                    drain_reader_with_result(stdout_reader, self.post_process_drain),
-                    drain_reader_with_result(stderr_reader, self.post_process_drain)
+                    drain_reader_with_result(stdout_reader, &stdout, self.post_process_drain),
+                    drain_reader_with_result(stderr_reader, &stderr, self.post_process_drain)
                 );
                 stdout_result?;
                 stderr_result?;
@@ -83,8 +84,8 @@ impl CommandRunner {
                     status?;
                 }
                 tokio::join!(
-                    drain_reader(stdout_reader, self.post_process_drain),
-                    drain_reader(stderr_reader, self.post_process_drain)
+                    drain_reader(stdout_reader, &stdout, self.post_process_drain),
+                    drain_reader(stderr_reader, &stderr, self.post_process_drain)
                 );
 
                 Ok(CommandResult {
@@ -127,26 +128,61 @@ where
     })
 }
 
-async fn drain_reader(reader: Option<JoinHandle<Result<()>>>, drain: Duration) {
-    let _reader_result = drain_reader_with_result(reader, drain).await;
+async fn drain_reader(reader: Option<JoinHandle<Result<()>>>, output: &Arc<Mutex<Vec<u8>>>, drain: Duration) {
+    let _reader_result = drain_reader_with_result(reader, output, drain).await;
 }
 
-async fn drain_reader_with_result(reader: Option<JoinHandle<Result<()>>>, drain: Duration) -> Result<()> {
+async fn drain_reader_with_result(
+    reader: Option<JoinHandle<Result<()>>>,
+    output: &Arc<Mutex<Vec<u8>>>,
+    drain: Duration,
+) -> Result<()> {
     if let Some(mut reader) = reader {
-        tokio::select! {
-            _ = tokio::time::sleep(drain) => {
-                reader.abort();
-                let _abort_join_result = reader.await;
-                Ok(())
-            }
-            result = &mut reader => {
-                result
-                    .map_err(|error| Error::other(format!("process output reader failed: {error}")))?
+        let idle_timer = tokio::time::sleep(drain);
+        let max_timer = tokio::time::sleep(max_post_process_drain(drain));
+        tokio::pin!(idle_timer);
+        tokio::pin!(max_timer);
+
+        let mut last_len = output_len(output);
+
+        loop {
+            tokio::select! {
+                _ = &mut max_timer => {
+                    reader.abort();
+                    let _abort_join_result = reader.await;
+                    return Ok(());
+                }
+                _ = &mut idle_timer => {
+                    let current_len = output_len(output);
+                    if current_len == last_len {
+                        reader.abort();
+                        let _abort_join_result = reader.await;
+                        return Ok(());
+                    }
+
+                    last_len = current_len;
+                    idle_timer.as_mut().reset(Instant::now() + drain);
+                }
+                result = &mut reader => {
+                    return result
+                        .map_err(|error| Error::other(format!("process output reader failed: {error}")))?;
+                }
             }
         }
     } else {
         Ok(())
     }
+}
+
+fn max_post_process_drain(drain: Duration) -> Duration {
+    drain.checked_mul(5).unwrap_or(Duration::MAX).max(drain)
+}
+
+fn output_len(output: &Arc<Mutex<Vec<u8>>>) -> usize {
+    output
+        .lock()
+        .expect("process output mutex should not be poisoned")
+        .len()
 }
 
 fn take_output(output: Arc<Mutex<Vec<u8>>>) -> Vec<u8> {

--- a/crates/aion-process/src/runner_test.rs
+++ b/crates/aion-process/src/runner_test.rs
@@ -78,6 +78,27 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn runner_captures_delayed_output_after_parent_shell_exits() {
+        #[cfg(windows)]
+        let script = "Start-Process -FilePath powershell -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Milliseconds 500; Write-Output runner_delayed_descendant_stdout' -NoNewWindow";
+        #[cfg(not(windows))]
+        let script = "(sleep 0.5; printf 'runner_delayed_descendant_stdout\n') &";
+
+        let result = CommandRunner::new(shell_command(script))
+            .run()
+            .await
+            .expect("runner should complete successfully");
+
+        assert!(!result.timed_out);
+        assert_eq!(result.exit_code, Some(0));
+        assert!(
+            String::from_utf8_lossy(&result.stdout).contains("runner_delayed_descendant_stdout"),
+            "stdout was: {}",
+            String::from_utf8_lossy(&result.stdout)
+        );
+    }
+
     #[cfg(not(windows))]
     #[tokio::test]
     async fn runner_does_not_hang_when_background_process_keeps_output_pipe_open() {
@@ -148,6 +169,7 @@ mod tests {
     async fn runner_completed_command_keeps_windows_background_descendant_running() {
         let script = "$p = Start-Process -FilePath powershell -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 10' -PassThru -WindowStyle Hidden; Write-Output $p.Id";
         let result = CommandRunner::new(shell_command(script))
+            .post_process_drain(Duration::from_millis(50))
             .run()
             .await
             .expect("runner should complete successfully");


### PR DESCRIPTION
## Summary
- Fix `ExecCommand` losing stdout/stderr when Windows PowerShell wrappers or CLI launchers exit before a child/descendant process finishes writing output.
- Replace the fixed short post-exit read window with an idle-based drain that keeps reading while stdout/stderr continues to grow, with a hard upper bound.
- Increase the default post-process drain window so slightly delayed command output is still captured.
- Initialize PowerShell UTF-8 input/output settings more completely before running scripts.

## Problem
On Windows, `ExecCommand` can return `Exit code: 0` with empty `STDOUT` and `STDERR` even though the command writes output shortly after the parent shell exits. This commonly affects commands run through PowerShell wrappers, CLI launchers, Python console entry points, or nested child processes.

The previous runner waited for the process to exit and then drained stdout/stderr for a fixed short window. That avoided hangs from long-lived descendants, but it could also abort the output reader before legitimate delayed output arrived.

## Fix
The runner now tracks the buffered stdout/stderr length during post-exit draining. If new bytes arrive, it resets the idle timer and continues reading. It stops only when the stream remains idle for the drain window or the maximum drain bound is reached.

PowerShell startup now also sets input/output encoding, `$OutputEncoding`, and default `Out-File` encoding to UTF-8 to avoid Windows PowerShell encoding mismatches.

Fixes #182