### PR TITLE
feat(agent): support parallel persisted sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "uuid",
  "wiremock",
  "workspace-hack",
 ]
@@ -3590,6 +3591,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"], defau
 # Serialization
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid       = { version = "1", features = ["v7"] }
 
 # Async trait support
 async-trait = "0.1"

--- a/crates/aion-agent/Cargo.toml
+++ b/crates/aion-agent/Cargo.toml
@@ -27,6 +27,7 @@ anyhow.workspace      = true
 thiserror.workspace   = true
 glob.workspace        = true
 chrono.workspace      = true
+uuid.workspace        = true
 dirs.workspace        = true
 crossterm.workspace   = true
 is-terminal.workspace = true
@@ -51,4 +52,3 @@ path = "tests/e2e/mod.rs"
 name = "acceptance"
 path = "tests/acceptance/mod.rs"
 # Acceptance tests for evolution features; run via: cargo nextest run --profile e2e --test acceptance
-

--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -94,10 +94,6 @@ impl McpBootstrap {
     }
 }
 
-#[cfg(test)]
-#[path = "bootstrap_test.rs"]
-mod bootstrap_test;
-
 impl AgentBootstrap {
     pub fn new(config: Config, workspace: impl Into<String>, output: Arc<dyn OutputSink>) -> Self {
         Self {
@@ -344,3 +340,7 @@ impl AgentBootstrap {
         engine
     }
 }
+
+#[cfg(test)]
+#[path = "bootstrap_test.rs"]
+mod bootstrap_test;

--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
 
-use aion_config::config::Config;
+use aion_config::config::{Config, McpServerConfig};
 use aion_config::shell::{ResolvedShell, resolve_shell_config};
 use aion_mcp::manager::McpManager;
 use aion_mcp::tool_proxy::register_mcp_tools;
@@ -66,6 +67,7 @@ pub struct AgentBootstrap {
     // Optional externally supplied runtime state.
     provider: Option<Arc<dyn LlmProvider>>,
     resume_session: Option<Session>,
+    runtime_env: Vec<(String, String)>,
 }
 
 struct BootstrapEnvironment {
@@ -92,6 +94,10 @@ impl McpBootstrap {
     }
 }
 
+#[cfg(test)]
+#[path = "bootstrap_test.rs"]
+mod bootstrap_test;
+
 impl AgentBootstrap {
     pub fn new(config: Config, workspace: impl Into<String>, output: Arc<dyn OutputSink>) -> Self {
         Self {
@@ -101,6 +107,7 @@ impl AgentBootstrap {
             output,
             provider: None,
             resume_session: None,
+            runtime_env: Vec::new(),
         }
     }
 
@@ -113,6 +120,12 @@ impl AgentBootstrap {
     /// Resume from a previously saved session.
     pub fn resume(mut self, session: Session) -> Self {
         self.resume_session = Some(session);
+        self
+    }
+
+    /// Inject process environment for tools/hooks/MCP subprocesses owned by this engine.
+    pub fn runtime_env(mut self, runtime_env: Vec<(String, String)>) -> Self {
+        self.runtime_env = runtime_env;
         self
     }
 
@@ -185,7 +198,10 @@ impl AgentBootstrap {
         registry.register(Box::new(ReadTool::new(file_cache.clone())));
         registry.register(Box::new(WriteTool::new(file_cache.clone())));
         registry.register(Box::new(EditTool::new(file_cache)));
-        registry.register(Box::new(ExecCommandTool::new(workspace_path.to_path_buf())));
+        registry.register(Box::new(ExecCommandTool::new_with_env(
+            workspace_path.to_path_buf(),
+            self.runtime_env.clone(),
+        )));
         registry.register(Box::new(GrepTool::new(workspace_path.to_path_buf())));
         registry.register(Box::new(GlobTool::new(workspace_path.to_path_buf())));
 
@@ -200,11 +216,12 @@ impl AgentBootstrap {
     }
 
     async fn connect_mcp(&self, registry: &mut ToolRegistry, builtin_names: &[String]) -> McpBootstrap {
-        if self.config.mcp.servers.is_empty() {
+        let server_configs = self.mcp_servers_with_runtime_env();
+        if server_configs.is_empty() {
             return McpBootstrap::default();
         }
 
-        let manager = match McpManager::connect_all(&self.config.mcp.servers).await {
+        let manager = match McpManager::connect_all(&server_configs).await {
             Ok(manager) => Arc::new(manager),
             Err(err) => {
                 self.output.emit_error(&format!("MCP initialization error: {err}"));
@@ -212,12 +229,29 @@ impl AgentBootstrap {
             }
         };
 
-        register_mcp_tools(registry, &manager, builtin_names, &self.config.mcp.servers);
+        register_mcp_tools(registry, &manager, builtin_names, &server_configs);
 
         McpBootstrap {
             manager: Some(Arc::clone(&manager)),
             managers: vec![manager],
         }
+    }
+
+    fn mcp_servers_with_runtime_env(&self) -> HashMap<String, McpServerConfig> {
+        let mut servers = self.config.mcp.servers.clone();
+        if self.runtime_env.is_empty() {
+            return servers;
+        }
+
+        for server in servers.values_mut() {
+            let mut env: HashMap<String, String> = self.runtime_env.clone().into_iter().collect();
+            if let Some(server_env) = server.env.take() {
+                env.extend(server_env);
+            }
+            server.env = Some(env);
+        }
+
+        servers
     }
 
     async fn load_skills(&self, workspace: &Path, mcp_manager: Option<&McpManager>) -> Vec<SkillMetadata> {
@@ -260,7 +294,12 @@ impl AgentBootstrap {
             skill_checker,
         )));
 
-        let spawner = AgentSpawner::new(Arc::clone(provider), self.config.clone(), workspace.to_path_buf());
+        let spawner = AgentSpawner::new_with_env(
+            Arc::clone(provider),
+            self.config.clone(),
+            workspace.to_path_buf(),
+            self.runtime_env.clone(),
+        );
         registry.register(Box::new(SpawnTool::new(Arc::new(spawner))));
     }
 
@@ -287,10 +326,19 @@ impl AgentBootstrap {
         plan_active_flag: Arc<AtomicBool>,
         workspace: PathBuf,
     ) -> AgentEngine {
+        let runtime_env = self.runtime_env.clone();
         let mut engine = if let Some(session) = self.resume_session {
-            AgentEngine::resume_with_provider(provider, self.config, registry, self.output, session, workspace)
+            AgentEngine::resume_with_provider_and_env(
+                provider,
+                self.config,
+                registry,
+                self.output,
+                session,
+                workspace,
+                runtime_env,
+            )
         } else {
-            AgentEngine::new_with_provider(provider, self.config, registry, self.output, workspace)
+            AgentEngine::new_with_provider_and_env(provider, self.config, registry, self.output, workspace, runtime_env)
         };
         engine.set_plan_active_flag(plan_active_flag);
         engine

--- a/crates/aion-agent/src/bootstrap_test.rs
+++ b/crates/aion-agent/src/bootstrap_test.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use aion_config::config::{CliArgs, McpServerConfig, TransportType};
+
+    use crate::output::OutputSink;
+    use crate::output::null_sink::NullSink;
+
+    use super::*;
+
+    #[test]
+    fn mcp_servers_with_runtime_env_uses_server_env_as_override() {
+        let mut config = Config::resolve(&CliArgs {
+            provider: Some("anthropic".to_string()),
+            api_key: Some("sk-test".to_string()),
+            base_url: None,
+            model: Some("claude-sonnet-4-20250514".to_string()),
+            max_tokens: Some(4096),
+            max_turns: None,
+            max_tool_call_malformed_turns: None,
+            max_tool_call_failure_turns: None,
+            system_prompt: None,
+            profile: None,
+            auto_approve: false,
+            project_dir: None,
+        })
+        .unwrap();
+        config.mcp.servers.insert(
+            "stdio".to_string(),
+            McpServerConfig {
+                transport: TransportType::Stdio,
+                command: Some("server".to_string()),
+                args: None,
+                env: Some(HashMap::from([
+                    ("OVERRIDE".to_string(), "server".to_string()),
+                    ("SERVER_ONLY".to_string(), "1".to_string()),
+                ])),
+                url: None,
+                headers: None,
+                deferred: None,
+                startup_timeout_ms: None,
+            },
+        );
+
+        let output: Arc<dyn OutputSink> = Arc::new(NullSink);
+        let bootstrap = AgentBootstrap::new(config, "/tmp", output).runtime_env(vec![
+            ("OVERRIDE".to_string(), "runtime".to_string()),
+            ("RUNTIME_ONLY".to_string(), "1".to_string()),
+        ]);
+
+        let servers = bootstrap.mcp_servers_with_runtime_env();
+        let env = servers
+            .get("stdio")
+            .and_then(|server| server.env.as_ref())
+            .expect("stdio server env should exist");
+
+        assert_eq!(env.get("OVERRIDE").map(String::as_str), Some("server"));
+        assert_eq!(env.get("SERVER_ONLY").map(String::as_str), Some("1"));
+        assert_eq!(env.get("RUNTIME_ONLY").map(String::as_str), Some("1"));
+    }
+}

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -134,17 +134,6 @@ impl AgentEngine {
         Self::new_with_provider(provider, config, tools, output, cwd)
     }
 
-    pub fn new_with_env(
-        config: Config,
-        tools: ToolRegistry,
-        output: Arc<dyn OutputSink>,
-        cwd: PathBuf,
-        runtime_env: Vec<(String, String)>,
-    ) -> Self {
-        let provider = create_provider(&config);
-        Self::new_with_provider_and_env(provider, config, tools, output, cwd, runtime_env)
-    }
-
     /// Create an engine with an externally-provided provider (for sub-agent sharing)
     pub fn new_with_provider(
         provider: Arc<dyn LlmProvider>,
@@ -227,18 +216,6 @@ impl AgentEngine {
     ) -> Self {
         let provider = create_provider(&config);
         Self::resume_with_provider(provider, config, tools, output, session, cwd)
-    }
-
-    pub fn resume_with_env(
-        config: Config,
-        tools: ToolRegistry,
-        output: Arc<dyn OutputSink>,
-        session: Session,
-        cwd: PathBuf,
-        runtime_env: Vec<(String, String)>,
-    ) -> Self {
-        let provider = create_provider(&config);
-        Self::resume_with_provider_and_env(provider, config, tools, output, session, cwd, runtime_env)
     }
 
     /// Create from a resumed session with an externally-provided provider

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -134,6 +134,17 @@ impl AgentEngine {
         Self::new_with_provider(provider, config, tools, output, cwd)
     }
 
+    pub fn new_with_env(
+        config: Config,
+        tools: ToolRegistry,
+        output: Arc<dyn OutputSink>,
+        cwd: PathBuf,
+        runtime_env: Vec<(String, String)>,
+    ) -> Self {
+        let provider = create_provider(&config);
+        Self::new_with_provider_and_env(provider, config, tools, output, cwd, runtime_env)
+    }
+
     /// Create an engine with an externally-provided provider (for sub-agent sharing)
     pub fn new_with_provider(
         provider: Arc<dyn LlmProvider>,
@@ -141,6 +152,17 @@ impl AgentEngine {
         tools: ToolRegistry,
         output: Arc<dyn OutputSink>,
         cwd: PathBuf,
+    ) -> Self {
+        Self::new_with_provider_and_env(provider, config, tools, output, cwd, Vec::new())
+    }
+
+    pub fn new_with_provider_and_env(
+        provider: Arc<dyn LlmProvider>,
+        config: Config,
+        tools: ToolRegistry,
+        output: Arc<dyn OutputSink>,
+        cwd: PathBuf,
+        runtime_env: Vec<(String, String)>,
     ) -> Self {
         let system_prompt = config.system_prompt.clone().unwrap_or_default();
         let confirmer = ToolConfirmer::new(config.tools.auto_approve, config.tools.allow_list.clone());
@@ -178,7 +200,7 @@ impl AgentEngine {
             tools,
             confirmer: Arc::new(Mutex::new(confirmer)),
             allow_list,
-            hooks: Some(HookEngine::new(config.hooks.clone(), cwd.clone())),
+            hooks: Some(HookEngine::new_with_env(config.hooks.clone(), cwd.clone(), runtime_env)),
             session_manager,
             current_session: None,
             output,
@@ -207,6 +229,18 @@ impl AgentEngine {
         Self::resume_with_provider(provider, config, tools, output, session, cwd)
     }
 
+    pub fn resume_with_env(
+        config: Config,
+        tools: ToolRegistry,
+        output: Arc<dyn OutputSink>,
+        session: Session,
+        cwd: PathBuf,
+        runtime_env: Vec<(String, String)>,
+    ) -> Self {
+        let provider = create_provider(&config);
+        Self::resume_with_provider_and_env(provider, config, tools, output, session, cwd, runtime_env)
+    }
+
     /// Create from a resumed session with an externally-provided provider
     pub fn resume_with_provider(
         provider: Arc<dyn LlmProvider>,
@@ -215,6 +249,18 @@ impl AgentEngine {
         output: Arc<dyn OutputSink>,
         session: Session,
         cwd: PathBuf,
+    ) -> Self {
+        Self::resume_with_provider_and_env(provider, config, tools, output, session, cwd, Vec::new())
+    }
+
+    pub fn resume_with_provider_and_env(
+        provider: Arc<dyn LlmProvider>,
+        config: Config,
+        tools: ToolRegistry,
+        output: Arc<dyn OutputSink>,
+        session: Session,
+        cwd: PathBuf,
+        runtime_env: Vec<(String, String)>,
     ) -> Self {
         let system_prompt = config.system_prompt.clone().unwrap_or_default();
         let confirmer = ToolConfirmer::new(config.tools.auto_approve, config.tools.allow_list.clone());
@@ -252,7 +298,7 @@ impl AgentEngine {
             tools,
             confirmer: Arc::new(Mutex::new(confirmer)),
             allow_list,
-            hooks: Some(HookEngine::new(config.hooks.clone(), cwd)),
+            hooks: Some(HookEngine::new_with_env(config.hooks.clone(), cwd, runtime_env)),
             session_manager,
             current_session: Some(session),
             output,
@@ -1133,10 +1179,6 @@ impl AgentEngine {
             session.updated_at = Utc::now();
             if let Err(e) = mgr.save(session) {
                 self.output.emit_error(&format!("Failed to save session: {}", e));
-            }
-            if let Err(e) = mgr.update_index_for(session) {
-                self.output
-                    .emit_error(&format!("Failed to update session index: {}", e));
             }
         }
     }

--- a/crates/aion-agent/src/session.rs
+++ b/crates/aion-agent/src/session.rs
@@ -1,9 +1,14 @@
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use aion_types::message::{Message, TokenUsage};
+use aion_types::message::{ContentBlock, Message, Role, TokenUsage};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
@@ -48,17 +53,10 @@ impl SessionManager {
 
     /// Create a new session, return it
     pub fn create(&self, provider: &str, model: &str, cwd: &str, session_id: Option<&str>) -> anyhow::Result<Session> {
-        std::fs::create_dir_all(&self.directory)?;
-
         let id = if let Some(custom_id) = session_id {
-            // Validate that the ID doesn't already exist
-            let index = self.load_index()?;
-            if index.sessions.iter().any(|s| s.id == custom_id) {
-                anyhow::bail!("Session ID '{}' already exists", custom_id);
-            }
             custom_id.to_string()
         } else {
-            generate_short_id()
+            self.generate_unique_id()?
         };
         let session = Session {
             id,
@@ -70,147 +68,313 @@ impl SessionManager {
             total_usage: TokenUsage::default(),
             messages: Vec::new(),
         };
-        self.save(&session)?;
-        self.update_index(&session)?;
+        self.with_session_lock(&session.id, || {
+            if self.session_exists(&session.id)? {
+                anyhow::bail!("Session ID '{}' already exists", session.id);
+            }
+            self.save_unlocked(&session)
+        })?;
         self.cleanup_old()?;
         Ok(session)
     }
 
     /// Save current session state (called after each turn)
     pub fn save(&self, session: &Session) -> anyhow::Result<()> {
-        std::fs::create_dir_all(&self.directory)?;
-        let filename = format!("{}_{}.json", session.created_at.format("%Y-%m-%d"), session.id);
-        let path = self.directory.join(&filename);
-        let json = serde_json::to_string_pretty(session)?;
-        std::fs::write(path, json)?;
-        Ok(())
+        self.with_session_lock(&session.id, || self.save_unlocked(session))
     }
 
     /// Load a session by ID (or "latest")
     pub fn load(&self, id_or_latest: &str) -> anyhow::Result<Session> {
-        let index = self.load_index()?;
+        if id_or_latest == "latest" {
+            let sessions = self.list()?;
+            let latest = sessions.last().ok_or_else(|| anyhow::anyhow!("No sessions found"))?;
+            return self.load(&latest.id);
+        }
 
-        let meta = if id_or_latest == "latest" {
-            index
-                .sessions
-                .last()
-                .ok_or_else(|| anyhow::anyhow!("No sessions found"))?
-        } else {
-            index
-                .sessions
-                .iter()
-                .find(|s| s.id == id_or_latest)
-                .ok_or_else(|| anyhow::anyhow!("Session '{}' not found", id_or_latest))?
-        };
+        self.with_session_lock(id_or_latest, || {
+            if let Some(session) = self.load_current(id_or_latest)? {
+                return Ok(session);
+            }
 
-        let pattern = format!("*_{}.json", meta.id);
-        let session_files: Vec<_> = glob::glob(self.directory.join(&pattern).to_string_lossy().as_ref())?
-            .filter_map(|r| r.ok())
-            .collect();
+            if let Some(session) = self.load_legacy(id_or_latest)? {
+                self.save_unlocked(&session)?;
+                return Ok(session);
+            }
 
-        let path = session_files
-            .first()
-            .ok_or_else(|| anyhow::anyhow!("Session file not found for '{}'", meta.id))?;
-
-        let content = std::fs::read_to_string(path)?;
-        let session: Session = serde_json::from_str(&content)?;
-        Ok(session)
+            Err(anyhow::anyhow!("Session '{}' not found", id_or_latest))
+        })
     }
 
     /// List all sessions
     pub fn list(&self) -> anyhow::Result<Vec<SessionMeta>> {
-        let index = self.load_index()?;
-        Ok(index.sessions)
+        let mut merged = HashMap::new();
+
+        for meta in self.list_legacy()? {
+            merged.insert(meta.id.clone(), meta);
+        }
+        for meta in self.list_current()? {
+            merged.insert(meta.id.clone(), meta);
+        }
+
+        let mut sessions: Vec<_> = merged.into_values().collect();
+        sessions.sort_by_key(|s| s.created_at);
+        Ok(sessions)
     }
 
-    fn load_index(&self) -> anyhow::Result<SessionIndex> {
-        let index_path = self.directory.join("index.json");
-        match std::fs::read_to_string(&index_path) {
-            Ok(content) => Ok(serde_json::from_str(&content)?),
-            Err(_) => Ok(SessionIndex { sessions: Vec::new() }),
+    /// Update the session index (public, called from engine after save).
+    ///
+    /// The new file layout does not maintain a global index as source of truth.
+    /// Keep this method as a compatibility shim for existing callers/tests.
+    pub fn update_index_for(&self, session: &Session) -> anyhow::Result<()> {
+        self.save(session)
+    }
+
+    fn load_current(&self, session_id: &str) -> anyhow::Result<Option<Session>> {
+        let path = self.state_path(session_id);
+        match fs::read_to_string(path) {
+            Ok(content) => Ok(Some(serde_json::from_str(&content)?)),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
         }
     }
 
-    /// Update the session index (public, called from engine after save)
-    pub fn update_index_for(&self, session: &Session) -> anyhow::Result<()> {
-        self.update_index(session)
+    fn save_unlocked(&self, session: &Session) -> anyhow::Result<()> {
+        let session_dir = self.session_dir(&session.id);
+        fs::create_dir_all(&session_dir)?;
+        let json = serde_json::to_string_pretty(session)?;
+        write_atomic(&self.state_path(&session.id), json.as_bytes())
     }
 
-    fn update_index(&self, session: &Session) -> anyhow::Result<()> {
-        let mut index = self.load_index()?;
-
-        // Extract summary from first user message
-        let summary = session
-            .messages
-            .iter()
-            .find(|m| m.role == aion_types::message::Role::User)
-            .and_then(|m| {
-                m.content.iter().find_map(|c| {
-                    if let aion_types::message::ContentBlock::Text { text } = c {
-                        Some(truncate_str(text, 80))
-                    } else {
-                        None
-                    }
-                })
-            })
-            .unwrap_or_default();
-
-        let meta = SessionMeta {
-            id: session.id.clone(),
-            created_at: session.created_at,
-            updated_at: session.updated_at,
-            model: session.model.clone(),
-            summary,
-            message_count: session.messages.len(),
+    fn list_current(&self) -> anyhow::Result<Vec<SessionMeta>> {
+        let sessions_dir = self.sessions_dir();
+        let entries = match fs::read_dir(&sessions_dir) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
         };
 
-        // Update existing or add new
-        if let Some(existing) = index.sessions.iter_mut().find(|s| s.id == session.id) {
-            *existing = meta;
-        } else {
-            index.sessions.push(meta);
+        let mut sessions = Vec::new();
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+
+            let state_path = entry.path().join("state.json");
+            let content = match fs::read_to_string(&state_path) {
+                Ok(content) => content,
+                Err(error) if error.kind() == ErrorKind::NotFound => continue,
+                Err(error) => return Err(error.into()),
+            };
+            let session: Session = serde_json::from_str(&content)?;
+            sessions.push(meta_from_session(&session));
         }
 
-        let index_path = self.directory.join("index.json");
-        let json = serde_json::to_string_pretty(&index)?;
-        std::fs::write(index_path, json)?;
-        Ok(())
+        Ok(sessions)
     }
 
-    /// Remove oldest sessions beyond max_sessions
-    fn cleanup_old(&self) -> anyhow::Result<()> {
-        let mut index = self.load_index()?;
-        if index.sessions.len() <= self.max_sessions {
-            return Ok(());
-        }
+    fn load_legacy(&self, session_id: &str) -> anyhow::Result<Option<Session>> {
+        let Some(path) = self.find_legacy_session_file(session_id)? else {
+            return Ok(None);
+        };
 
-        // Sort by created_at, remove oldest
-        index.sessions.sort_by_key(|s| s.created_at);
-        let to_remove = index.sessions.len() - self.max_sessions;
-        let removed: Vec<_> = index.sessions.drain(..to_remove).collect();
+        let content = fs::read_to_string(path)?;
+        Ok(Some(serde_json::from_str(&content)?))
+    }
 
-        // Delete session files
-        for meta in &removed {
-            let pattern = format!("*_{}.json", meta.id);
-            if let Ok(paths) = glob::glob(self.directory.join(&pattern).to_string_lossy().as_ref()) {
-                for path in paths.flatten() {
-                    let _ = std::fs::remove_file(path);
-                }
+    fn list_legacy(&self) -> anyhow::Result<Vec<SessionMeta>> {
+        let mut sessions = HashMap::new();
+
+        if let Some(index) = self.load_legacy_index()? {
+            for meta in index.sessions {
+                sessions.insert(meta.id.clone(), meta);
             }
         }
 
-        // Save updated index
+        let entries = match fs::read_dir(&self.directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
+        };
+
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() || entry.file_name() == "index.json" {
+                continue;
+            }
+            if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+
+            let content = fs::read_to_string(entry.path())?;
+            if let Ok(session) = serde_json::from_str::<Session>(&content) {
+                sessions.insert(session.id.clone(), meta_from_session(&session));
+            }
+        }
+
+        Ok(sessions.into_values().collect())
+    }
+
+    fn load_legacy_index(&self) -> anyhow::Result<Option<SessionIndex>> {
         let index_path = self.directory.join("index.json");
-        let json = serde_json::to_string_pretty(&index)?;
-        std::fs::write(index_path, json)?;
+        match fs::read_to_string(&index_path) {
+            Ok(content) => Ok(Some(serde_json::from_str(&content)?)),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn find_legacy_session_file(&self, session_id: &str) -> anyhow::Result<Option<PathBuf>> {
+        let entries = match fs::read_dir(&self.directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() || entry.file_name() == "index.json" {
+                continue;
+            }
+            if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+
+            let content = fs::read_to_string(entry.path())?;
+            let session: Session = serde_json::from_str(&content)?;
+            if session.id == session_id {
+                return Ok(Some(entry.path()));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn session_exists(&self, session_id: &str) -> anyhow::Result<bool> {
+        if self.state_path(session_id).is_file() {
+            return Ok(true);
+        }
+        Ok(self.find_legacy_session_file(session_id)?.is_some())
+    }
+
+    fn generate_unique_id(&self) -> anyhow::Result<String> {
+        for _ in 0..10 {
+            let id = generate_session_id();
+            if !self.session_exists(&id)? {
+                return Ok(id);
+            }
+        }
+        anyhow::bail!("failed to generate unique session id")
+    }
+
+    fn sessions_dir(&self) -> PathBuf {
+        self.directory.join("sessions")
+    }
+
+    fn session_dir(&self, session_id: &str) -> PathBuf {
+        self.sessions_dir().join(encode_session_id(session_id))
+    }
+
+    fn state_path(&self, session_id: &str) -> PathBuf {
+        self.session_dir(session_id).join("state.json")
+    }
+
+    fn with_session_lock<T>(&self, session_id: &str, f: impl FnOnce() -> anyhow::Result<T>) -> anyhow::Result<T> {
+        let lock = session_lock(self.session_dir(session_id));
+        let _guard = lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("session lock poisoned for '{}'", session_id))?;
+        f()
+    }
+
+    /// Remove oldest sessions beyond max_sessions.
+    fn cleanup_old(&self) -> anyhow::Result<()> {
+        let mut sessions = self.list_current()?;
+        if sessions.len() <= self.max_sessions {
+            return Ok(());
+        }
+
+        sessions.sort_by_key(|s| s.created_at);
+        let to_remove = sessions.len() - self.max_sessions;
+        for meta in sessions.into_iter().take(to_remove) {
+            let lock = session_lock(self.session_dir(&meta.id));
+            let _guard = lock
+                .lock()
+                .map_err(|_| anyhow::anyhow!("session lock poisoned for '{}'", meta.id))?;
+            match fs::remove_dir_all(self.session_dir(&meta.id)) {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+
         Ok(())
     }
 }
 
-fn generate_short_id() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().subsec_nanos();
-    format!("{:06x}", nanos & 0xFFFFFF)
+fn meta_from_session(session: &Session) -> SessionMeta {
+    let summary = session
+        .messages
+        .iter()
+        .find(|m| m.role == Role::User)
+        .and_then(|m| {
+            m.content.iter().find_map(|c| {
+                if let ContentBlock::Text { text } = c {
+                    Some(truncate_str(text, 80))
+                } else {
+                    None
+                }
+            })
+        })
+        .unwrap_or_default();
+
+    SessionMeta {
+        id: session.id.clone(),
+        created_at: session.created_at,
+        updated_at: session.updated_at,
+        model: session.model.clone(),
+        summary,
+        message_count: session.messages.len(),
+    }
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("state path has no parent"))?;
+    fs::create_dir_all(parent)?;
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, bytes)?;
+    #[cfg(windows)]
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+fn session_lock(path: PathBuf) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+    let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut locks = locks.lock().expect("session lock registry poisoned");
+    locks.entry(path).or_insert_with(|| Arc::new(Mutex::new(()))).clone()
+}
+
+fn encode_session_id(session_id: &str) -> String {
+    let mut encoded = String::with_capacity(session_id.len());
+    for byte in session_id.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.') {
+            encoded.push(byte as char);
+        } else {
+            encoded.push('%');
+            write!(&mut encoded, "{byte:02X}").expect("writing to String cannot fail");
+        }
+    }
+    encoded
+}
+
+fn generate_session_id() -> String {
+    uuid::Uuid::now_v7().to_string()
 }
 
 fn truncate_str(s: &str, max: usize) -> String {

--- a/crates/aion-agent/src/session.rs
+++ b/crates/aion-agent/src/session.rs
@@ -3,10 +3,11 @@ use std::fmt::Write;
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use aion_types::message::{ContentBlock, Message, Role, TokenUsage};
 
@@ -161,13 +162,9 @@ impl SessionManager {
             }
 
             let state_path = entry.path().join("state.json");
-            let content = match fs::read_to_string(&state_path) {
-                Ok(content) => content,
-                Err(error) if error.kind() == ErrorKind::NotFound => continue,
-                Err(error) => return Err(error.into()),
-            };
-            let session: Session = serde_json::from_str(&content)?;
-            sessions.push(meta_from_session(&session));
+            if let Some(session) = read_session_file_if_valid(&state_path)? {
+                sessions.push(meta_from_session(&session));
+            }
         }
 
         Ok(sessions)
@@ -184,10 +181,11 @@ impl SessionManager {
 
     fn list_legacy(&self) -> anyhow::Result<Vec<SessionMeta>> {
         let mut sessions = HashMap::new();
+        let mut indexed_sessions = HashMap::new();
 
         if let Some(index) = self.load_legacy_index()? {
             for meta in index.sessions {
-                sessions.insert(meta.id.clone(), meta);
+                indexed_sessions.insert(meta.id.clone(), meta);
             }
         }
 
@@ -206,9 +204,11 @@ impl SessionManager {
                 continue;
             }
 
-            let content = fs::read_to_string(entry.path())?;
-            if let Ok(session) = serde_json::from_str::<Session>(&content) {
-                sessions.insert(session.id.clone(), meta_from_session(&session));
+            if let Some(session) = read_session_file_if_valid(&entry.path())? {
+                let meta = indexed_sessions
+                    .remove(&session.id)
+                    .unwrap_or_else(|| meta_from_session(&session));
+                sessions.insert(session.id.clone(), meta);
             }
         }
 
@@ -218,7 +218,18 @@ impl SessionManager {
     fn load_legacy_index(&self) -> anyhow::Result<Option<SessionIndex>> {
         let index_path = self.directory.join("index.json");
         match fs::read_to_string(&index_path) {
-            Ok(content) => Ok(Some(serde_json::from_str(&content)?)),
+            Ok(content) => match serde_json::from_str(&content) {
+                Ok(index) => Ok(Some(index)),
+                Err(error) => {
+                    tracing::warn!(
+                        target: "aion_agent",
+                        path = %index_path.display(),
+                        error = %error,
+                        "skipping invalid legacy session index"
+                    );
+                    Ok(None)
+                }
+            },
             Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
             Err(error) => Err(error.into()),
         }
@@ -240,8 +251,9 @@ impl SessionManager {
                 continue;
             }
 
-            let content = fs::read_to_string(entry.path())?;
-            let session: Session = serde_json::from_str(&content)?;
+            let Some(session) = read_session_file_if_valid(&entry.path())? else {
+                continue;
+            };
             if session.id == session_id {
                 return Ok(Some(entry.path()));
             }
@@ -353,11 +365,50 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn read_session_file_if_valid(path: &Path) -> anyhow::Result<Option<Session>> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+
+    match serde_json::from_str(&content) {
+        Ok(session) => Ok(Some(session)),
+        Err(error) => {
+            tracing::warn!(
+                target: "aion_agent",
+                path = %path.display(),
+                error = %error,
+                "skipping invalid session file"
+            );
+            Ok(None)
+        }
+    }
+}
+
+fn session_locks() -> &'static Mutex<HashMap<PathBuf, Weak<Mutex<()>>>> {
+    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>> = OnceLock::new();
+    LOCKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 fn session_lock(path: PathBuf) -> Arc<Mutex<()>> {
-    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
-    let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut locks = locks.lock().expect("session lock registry poisoned");
-    locks.entry(path).or_insert_with(|| Arc::new(Mutex::new(()))).clone()
+    let mut locks = session_locks().lock().expect("session lock registry poisoned");
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    if let Some(lock) = locks.get(&path).and_then(Weak::upgrade) {
+        return lock;
+    }
+
+    let lock = Arc::new(Mutex::new(()));
+    locks.insert(path, Arc::downgrade(&lock));
+    lock
+}
+
+#[cfg(test)]
+fn session_lock_registry_contains(path: &Path) -> bool {
+    session_locks()
+        .lock()
+        .expect("session lock registry poisoned")
+        .contains_key(path)
 }
 
 fn encode_session_id(session_id: &str) -> String {
@@ -374,7 +425,7 @@ fn encode_session_id(session_id: &str) -> String {
 }
 
 fn generate_session_id() -> String {
-    uuid::Uuid::now_v7().to_string()
+    Uuid::now_v7().to_string()
 }
 
 fn truncate_str(s: &str, max: usize) -> String {

--- a/crates/aion-agent/src/session_test.rs
+++ b/crates/aion-agent/src/session_test.rs
@@ -4,10 +4,13 @@ use super::*;
 mod tests {
     use super::*;
     use aion_types::message::{ContentBlock, Message, Role};
+    use chrono::Duration;
     use std::fs;
     use std::path::Path;
     use std::sync::{Arc, Barrier};
+    use std::thread;
     use tempfile::tempdir;
+    use uuid::Uuid;
 
     #[test]
     fn test_create_session() {
@@ -151,6 +154,72 @@ mod tests {
     }
 
     #[test]
+    fn test_list_current_skips_invalid_state_json() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let valid = sample_session("valid-session", "current model");
+        manager.save(&valid).unwrap();
+
+        let invalid_dir = dir.path().join("sessions").join("invalid-session");
+        fs::create_dir_all(&invalid_dir).unwrap();
+        fs::write(invalid_dir.join("state.json"), "{ invalid json").unwrap();
+
+        let list = manager.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "valid-session");
+
+        let latest = manager.load("latest").unwrap();
+        assert_eq!(latest.id, "valid-session");
+    }
+
+    #[test]
+    fn test_create_skips_invalid_legacy_json_when_checking_existing_id() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        fs::write(dir.path().join("broken.json"), "{ invalid json").unwrap();
+
+        let session = manager.create("openai", "gpt-4", "/tmp", Some("new-session")).unwrap();
+
+        assert_eq!(session.id, "new-session");
+        assert!(manager.state_path("new-session").is_file());
+    }
+
+    #[test]
+    fn test_list_skips_invalid_legacy_index() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let legacy = sample_session("legacy-session", "legacy model");
+        write_legacy_session(dir.path(), &legacy);
+        fs::write(dir.path().join("index.json"), "{ invalid json").unwrap();
+
+        let list = manager.list().unwrap();
+
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "legacy-session");
+    }
+
+    #[test]
+    fn test_list_legacy_skips_indexed_session_with_invalid_file() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let valid = sample_session("valid-session", "legacy model");
+        let mut invalid_meta = meta_from_session(&sample_session("invalid-session", "legacy model"));
+        invalid_meta.created_at = valid.created_at + Duration::seconds(1);
+        invalid_meta.updated_at = valid.updated_at + Duration::seconds(1);
+
+        write_legacy_session(dir.path(), &valid);
+        fs::write(dir.path().join("2026-07-07_invalid-session.json"), "{ invalid json").unwrap();
+        write_legacy_index(dir.path(), &[meta_from_session(&valid), invalid_meta]);
+
+        let list = manager.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "valid-session");
+
+        let latest = manager.load("latest").unwrap();
+        assert_eq!(latest.id, "valid-session");
+    }
+
+    #[test]
     fn test_cleanup_old_sessions() {
         let dir = tempdir().unwrap();
         let manager = SessionManager::new(dir.path().to_path_buf(), 2);
@@ -185,9 +254,28 @@ mod tests {
         let id2 = generate_session_id();
         assert_ne!(id1, id2);
 
-        let parsed = uuid::Uuid::parse_str(&id1).unwrap();
+        let parsed = Uuid::parse_str(&id1).unwrap();
         assert_eq!(id1.len(), 36);
         assert_eq!(parsed.get_version_num(), 7);
+    }
+
+    #[test]
+    fn test_session_lock_registry_prunes_unused_locks() {
+        let dir = tempdir().unwrap();
+        let old_path = dir.path().join("sessions").join("old-session");
+
+        {
+            let lock = session_lock(old_path.clone());
+            let _guard = lock.lock().unwrap();
+            assert!(session_lock_registry_contains(&old_path));
+        }
+
+        {
+            let new_path = dir.path().join("sessions").join("new-session");
+            let _lock = session_lock(new_path);
+        }
+
+        assert!(!session_lock_registry_contains(&old_path));
     }
 
     #[test]
@@ -200,7 +288,7 @@ mod tests {
             .map(|_| {
                 let manager = Arc::clone(&manager);
                 let barrier = Arc::clone(&barrier);
-                std::thread::spawn(move || {
+                thread::spawn(move || {
                     barrier.wait();
                     manager.create("openai", "gpt-4", "/tmp", Some("same-session"))
                 })

--- a/crates/aion-agent/src/session_test.rs
+++ b/crates/aion-agent/src/session_test.rs
@@ -4,6 +4,9 @@ use super::*;
 mod tests {
     use super::*;
     use aion_types::message::{ContentBlock, Message, Role};
+    use std::fs;
+    use std::path::Path;
+    use std::sync::{Arc, Barrier};
     use tempfile::tempdir;
 
     #[test]
@@ -19,6 +22,8 @@ mod tests {
         assert_eq!(session.model, "gpt-4");
         assert_eq!(session.cwd, "/tmp");
         assert!(session.messages.is_empty());
+        assert!(manager.state_path(&session.id).is_file());
+        assert!(!dir.path().join("index.json").exists());
     }
 
     #[test]
@@ -93,6 +98,59 @@ mod tests {
     }
 
     #[test]
+    fn test_load_legacy_session_migrates_to_current_layout() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let legacy = sample_session("legacy-session", "legacy model");
+        write_legacy_session(dir.path(), &legacy);
+        write_legacy_index(dir.path(), &[meta_from_session(&legacy)]);
+
+        let loaded = manager.load(&legacy.id).unwrap();
+
+        assert_eq!(loaded.id, legacy.id);
+        assert_eq!(loaded.model, legacy.model);
+        assert!(manager.state_path(&legacy.id).is_file());
+        assert!(dir.path().join("2026-07-07_legacy-session.json").is_file());
+        assert!(dir.path().join("index.json").is_file());
+    }
+
+    #[test]
+    fn test_load_prefers_current_layout_over_legacy_layout() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let legacy = sample_session("same-session", "legacy model");
+        let current = sample_session("same-session", "current model");
+        write_legacy_session(dir.path(), &legacy);
+        manager.save(&current).unwrap();
+
+        let loaded = manager.load("same-session").unwrap();
+
+        assert_eq!(loaded.model, "current model");
+    }
+
+    #[test]
+    fn test_list_merges_legacy_and_current_sessions() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let legacy = sample_session("legacy-session", "legacy model");
+        let current = sample_session("current-session", "current model");
+        let overridden_legacy = sample_session("same-session", "legacy model");
+        let overriding_current = sample_session("same-session", "current model");
+        write_legacy_session(dir.path(), &legacy);
+        write_legacy_session(dir.path(), &overridden_legacy);
+        manager.save(&current).unwrap();
+        manager.save(&overriding_current).unwrap();
+
+        let list = manager.list().unwrap();
+
+        assert_eq!(list.len(), 3);
+        assert!(list.iter().any(|meta| meta.id == "legacy-session"));
+        assert!(list.iter().any(|meta| meta.id == "current-session"));
+        let same = list.iter().find(|meta| meta.id == "same-session").unwrap();
+        assert_eq!(same.model, "current model");
+    }
+
+    #[test]
     fn test_cleanup_old_sessions() {
         let dir = tempdir().unwrap();
         let manager = SessionManager::new(dir.path().to_path_buf(), 2);
@@ -106,10 +164,89 @@ mod tests {
     }
 
     #[test]
-    fn test_session_id_uniqueness() {
-        let id1 = generate_short_id();
-        std::thread::sleep(std::time::Duration::from_millis(2));
-        let id2 = generate_short_id();
+    fn test_cleanup_does_not_remove_legacy_sessions() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 1);
+        let legacy = sample_session("legacy-session", "legacy model");
+        write_legacy_session(dir.path(), &legacy);
+
+        let _s1 = manager.create("openai", "gpt-4", "/tmp", None).unwrap();
+        let _s2 = manager.create("openai", "gpt-4", "/tmp", None).unwrap();
+
+        assert!(dir.path().join("2026-07-07_legacy-session.json").is_file());
+        let list = manager.list().unwrap();
+        assert_eq!(list.len(), 2);
+        assert!(list.iter().any(|meta| meta.id == "legacy-session"));
+    }
+
+    #[test]
+    fn test_session_id_is_uuid_v7() {
+        let id1 = generate_session_id();
+        let id2 = generate_session_id();
         assert_ne!(id1, id2);
+
+        let parsed = uuid::Uuid::parse_str(&id1).unwrap();
+        assert_eq!(id1.len(), 36);
+        assert_eq!(parsed.get_version_num(), 7);
+    }
+
+    #[test]
+    fn test_concurrent_create_same_custom_id_allows_one_writer() {
+        let dir = tempdir().unwrap();
+        let manager = Arc::new(SessionManager::new(dir.path().to_path_buf(), 10));
+        let barrier = Arc::new(Barrier::new(2));
+
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let manager = Arc::clone(&manager);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    manager.create("openai", "gpt-4", "/tmp", Some("same-session"))
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = handles.into_iter().map(|handle| handle.join().unwrap()).collect();
+        let success_count = results.iter().filter(|result| result.is_ok()).count();
+        let error_count = results.iter().filter(|result| result.is_err()).count();
+
+        assert_eq!(success_count, 1);
+        assert_eq!(error_count, 1);
+        assert!(manager.state_path("same-session").is_file());
+    }
+
+    fn sample_session(id: &str, model: &str) -> Session {
+        Session {
+            id: id.to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            provider: "test-provider".to_string(),
+            model: model.to_string(),
+            cwd: "/tmp".to_string(),
+            total_usage: TokenUsage::default(),
+            messages: vec![Message::new(
+                Role::User,
+                vec![ContentBlock::Text {
+                    text: format!("summary for {id}"),
+                }],
+            )],
+        }
+    }
+
+    fn write_legacy_session(directory: &Path, session: &Session) {
+        let path = directory.join(format!("2026-07-07_{}.json", session.id));
+        fs::write(path, serde_json::to_string_pretty(session).unwrap()).unwrap();
+    }
+
+    fn write_legacy_index(directory: &Path, sessions: &[SessionMeta]) {
+        let index = SessionIndex {
+            sessions: sessions.to_vec(),
+        };
+        fs::write(
+            directory.join("index.json"),
+            serde_json::to_string_pretty(&index).unwrap(),
+        )
+        .unwrap();
     }
 }

--- a/crates/aion-agent/src/spawner.rs
+++ b/crates/aion-agent/src/spawner.rs
@@ -31,14 +31,25 @@ pub struct AgentSpawner {
     provider: Arc<dyn LlmProvider>,
     base_config: Config,
     cwd: PathBuf,
+    runtime_env: Vec<(String, String)>,
 }
 
 impl AgentSpawner {
     pub fn new(provider: Arc<dyn LlmProvider>, config: Config, cwd: PathBuf) -> Self {
+        Self::new_with_env(provider, config, cwd, Vec::new())
+    }
+
+    pub fn new_with_env(
+        provider: Arc<dyn LlmProvider>,
+        config: Config,
+        cwd: PathBuf,
+        runtime_env: Vec<(String, String)>,
+    ) -> Self {
         Self {
             provider,
             base_config: config,
             cwd,
+            runtime_env,
         }
     }
 
@@ -55,9 +66,16 @@ impl AgentSpawner {
 
         tracing::info!(target: "aion_agent", cwd = %self.cwd.display(), "sub-agent spawned with workspace cwd");
 
-        let tools = build_tool_registry(&[], &self.cwd);
+        let tools = build_tool_registry(&[], &self.cwd, &self.runtime_env);
         let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-        let mut engine = AgentEngine::new_with_provider(self.provider.clone(), config, tools, output, self.cwd.clone());
+        let mut engine = AgentEngine::new_with_provider_and_env(
+            self.provider.clone(),
+            config,
+            tools,
+            output,
+            self.cwd.clone(),
+            self.runtime_env.clone(),
+        );
 
         match engine.run(&sub_config.prompt, "").await {
             Ok(result) => SubAgentResult {
@@ -108,6 +126,7 @@ impl AgentSpawner {
             provider: self.provider.clone(),
             base_config: self.base_config.clone(),
             cwd: self.cwd.clone(),
+            runtime_env: self.runtime_env.clone(),
         }
     }
 }
@@ -127,9 +146,16 @@ impl Spawner for AgentSpawner {
             config.model = model;
         }
 
-        let tools = build_tool_registry(&overrides.allowed_tools, &self.cwd);
+        let tools = build_tool_registry(&overrides.allowed_tools, &self.cwd, &self.runtime_env);
         let output: Arc<dyn OutputSink> = Arc::new(NullSink);
-        let mut engine = AgentEngine::new_with_provider(self.provider.clone(), config, tools, output, self.cwd.clone());
+        let mut engine = AgentEngine::new_with_provider_and_env(
+            self.provider.clone(),
+            config,
+            tools,
+            output,
+            self.cwd.clone(),
+            self.runtime_env.clone(),
+        );
         engine.set_initial_reasoning_effort(overrides.effort.clone());
 
         match engine.run(&sub_config.prompt, "").await {
@@ -151,12 +177,15 @@ impl Spawner for AgentSpawner {
     }
 }
 
-fn build_tool_registry(allowed: &[String], cwd: &Path) -> ToolRegistry {
+fn build_tool_registry(allowed: &[String], cwd: &Path, runtime_env: &[(String, String)]) -> ToolRegistry {
     let all_tools: Vec<(&str, Box<dyn aion_tools::Tool>)> = vec![
         ("Read", Box::new(ReadTool::new(None))),
         ("Write", Box::new(WriteTool::new(None))),
         ("Edit", Box::new(EditTool::new(None))),
-        ("ExecCommand", Box::new(ExecCommandTool::new(cwd.to_path_buf()))),
+        (
+            "ExecCommand",
+            Box::new(ExecCommandTool::new_with_env(cwd.to_path_buf(), runtime_env.to_vec())),
+        ),
         ("Grep", Box::new(GrepTool::new(cwd.to_path_buf()))),
         ("Glob", Box::new(GlobTool::new(cwd.to_path_buf()))),
     ];

--- a/crates/aion-agent/src/spawner_test.rs
+++ b/crates/aion-agent/src/spawner_test.rs
@@ -14,7 +14,7 @@ mod phase7_tests {
 
     #[test]
     fn tc_7_40_build_tool_registry_empty_allowed_registers_all() {
-        let registry = build_tool_registry(&[], &std::env::temp_dir());
+        let registry = build_tool_registry(&[], &std::env::temp_dir(), &[]);
         for name in &["Read", "Write", "Edit", "ExecCommand", "Grep", "Glob"] {
             assert!(registry.get(name).is_some(), "tool '{name}' should be registered");
         }
@@ -23,7 +23,7 @@ mod phase7_tests {
     #[test]
     fn tc_7_43_build_tool_registry_filters_to_allowed() {
         let allowed = vec!["ExecCommand".to_string(), "Read".to_string()];
-        let registry = build_tool_registry(&allowed, &std::env::temp_dir());
+        let registry = build_tool_registry(&allowed, &std::env::temp_dir(), &[]);
         assert!(registry.get("ExecCommand").is_some());
         assert!(registry.get("Read").is_some());
         assert!(registry.get("Write").is_none());

--- a/crates/aion-config/src/hooks.rs
+++ b/crates/aion-config/src/hooks.rs
@@ -43,11 +43,24 @@ fn default_hook_timeout() -> u64 {
 pub struct HookEngine {
     config: HooksConfig,
     cwd: PathBuf,
+    runtime_env: HashMap<String, String>,
 }
 
 impl HookEngine {
     pub fn new(config: HooksConfig, cwd: PathBuf) -> Self {
-        Self { config, cwd }
+        Self {
+            config,
+            cwd,
+            runtime_env: HashMap::new(),
+        }
+    }
+
+    pub fn new_with_env(config: HooksConfig, cwd: PathBuf, runtime_env: Vec<(String, String)>) -> Self {
+        Self {
+            config,
+            cwd,
+            runtime_env: runtime_env.into_iter().collect(),
+        }
     }
 
     /// Run pre-tool-use hooks. Returns Err if any hook blocks execution.
@@ -60,7 +73,7 @@ impl HookEngine {
             .collect();
 
         for hook in matching {
-            let env = build_env_vars(tool_name, tool_input);
+            let env = self.build_hook_env(tool_name, tool_input);
             let result = run_hook_command(&hook.command, &env, hook.timeout_ms, &self.cwd).await?;
             if !result.success {
                 return Err(HookError::Blocked {
@@ -88,7 +101,7 @@ impl HookEngine {
 
         let mut messages = Vec::new();
         for hook in matching {
-            let mut env = build_env_vars(tool_name, tool_input);
+            let mut env = self.build_hook_env(tool_name, tool_input);
             env.insert("TOOL_OUTPUT".to_string(), tool_output.to_string());
 
             match run_hook_command(&hook.command, &env, hook.timeout_ms, &self.cwd).await {
@@ -109,7 +122,7 @@ impl HookEngine {
     pub async fn run_stop(&self) -> Vec<String> {
         let mut messages = Vec::new();
         for hook in &self.config.stop {
-            match run_hook_command(&hook.command, &HashMap::new(), hook.timeout_ms, &self.cwd).await {
+            match run_hook_command(&hook.command, &self.runtime_env, hook.timeout_ms, &self.cwd).await {
                 Ok(result) => {
                     if !result.output.is_empty() {
                         messages.push(format!("[hook:{}] {}", hook.name, result.output.trim()));
@@ -134,6 +147,12 @@ impl HookEngine {
         merge_vec(&mut self.config.pre_tool_use, additional.pre_tool_use);
         merge_vec(&mut self.config.post_tool_use, additional.post_tool_use);
         merge_vec(&mut self.config.stop, additional.stop);
+    }
+
+    fn build_hook_env(&self, tool_name: &str, tool_input: &serde_json::Value) -> HashMap<String, String> {
+        let mut env = self.runtime_env.clone();
+        env.extend(build_env_vars(tool_name, tool_input));
+        env
     }
 }
 

--- a/crates/aion-config/src/hooks_test.rs
+++ b/crates/aion-config/src/hooks_test.rs
@@ -28,6 +28,20 @@ mod tests {
         }
     }
 
+    fn env_equals_command(name: &str, expected: &str) -> String {
+        match default_shell().kind {
+            ShellKind::PowerShell => {
+                format!("if ($env:{name} -eq '{expected}') {{ exit 0 }} else {{ exit 1 }}")
+            }
+            ShellKind::Cmd => {
+                format!(r#"if "%{name}%"=="{expected}" (exit /b 0) else (exit /b 1)"#)
+            }
+            ShellKind::Bash | ShellKind::Zsh | ShellKind::Sh => {
+                format!(r#"[ "{}" = "{expected}" ]"#, format!("${name}"))
+            }
+        }
+    }
+
     // --- Pure logic tests ---
 
     #[test]
@@ -79,6 +93,50 @@ mod tests {
         };
         let engine = HookEngine::new(config, std::env::temp_dir());
         let result = engine.run_pre_tool_use("Read", &json!({})).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_pre_hook_receives_runtime_env() {
+        let config = HooksConfig {
+            pre_tool_use: vec![make_hook(
+                "runtime-env",
+                vec!["Read"],
+                &env_equals_command("AION_RUNTIME_ENV_TEST", "hook-value"),
+            )],
+            post_tool_use: vec![],
+            stop: vec![],
+        };
+        let engine = HookEngine::new_with_env(
+            config,
+            std::env::temp_dir(),
+            vec![("AION_RUNTIME_ENV_TEST".to_string(), "hook-value".to_string())],
+        );
+
+        let result = engine.run_pre_tool_use("Read", &json!({})).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_hook_vars_override_runtime_env() {
+        let config = HooksConfig {
+            pre_tool_use: vec![make_hook(
+                "tool-env",
+                vec!["Read"],
+                &env_equals_command("TOOL_NAME", "Read"),
+            )],
+            post_tool_use: vec![],
+            stop: vec![],
+        };
+        let engine = HookEngine::new_with_env(
+            config,
+            std::env::temp_dir(),
+            vec![("TOOL_NAME".to_string(), "from-runtime".to_string())],
+        );
+
+        let result = engine.run_pre_tool_use("Read", &json!({})).await;
+
         assert!(result.is_ok());
     }
 

--- a/crates/aion-config/src/hooks_test.rs
+++ b/crates/aion-config/src/hooks_test.rs
@@ -37,7 +37,7 @@ mod tests {
                 format!(r#"if "%{name}%"=="{expected}" (exit /b 0) else (exit /b 1)"#)
             }
             ShellKind::Bash | ShellKind::Zsh | ShellKind::Sh => {
-                format!(r#"[ "{}" = "{expected}" ]"#, format!("${name}"))
+                format!(r#"[ "${name}" = "{expected}" ]"#)
             }
         }
     }

--- a/crates/aion-tools/src/exec_command.rs
+++ b/crates/aion-tools/src/exec_command.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -16,11 +17,22 @@ const MAX_TIMEOUT_MS: u64 = 600_000;
 
 pub struct ExecCommandTool {
     cwd: PathBuf,
+    runtime_env: HashMap<String, String>,
 }
 
 impl ExecCommandTool {
     pub fn new(cwd: PathBuf) -> Self {
-        Self { cwd }
+        Self {
+            cwd,
+            runtime_env: HashMap::new(),
+        }
+    }
+
+    pub fn new_with_env(cwd: PathBuf, runtime_env: Vec<(String, String)>) -> Self {
+        Self {
+            cwd,
+            runtime_env: runtime_env.into_iter().collect(),
+        }
     }
 }
 
@@ -119,7 +131,7 @@ impl Tool for ExecCommandTool {
 
         let cwd = self.cwd.clone();
         let mut command_builder = shell_command_builder(&shell, command, false);
-        command_builder.current_dir(&cwd);
+        command_builder.envs(&self.runtime_env).current_dir(&cwd);
 
         let result = CommandRunner::new(command_builder).timeout(timeout).run().await;
 

--- a/crates/aion-tools/src/exec_command_test.rs
+++ b/crates/aion-tools/src/exec_command_test.rs
@@ -43,6 +43,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_injects_runtime_env() {
+        let tool = ExecCommandTool::new_with_env(
+            std::env::temp_dir(),
+            vec![("AION_RUNTIME_ENV_TEST".to_string(), "exec-env-value".to_string())],
+        );
+        #[cfg(windows)]
+        let input = json!({"cmd": "Write-Output $env:AION_RUNTIME_ENV_TEST", "shell": "powershell"});
+        #[cfg(not(windows))]
+        let input = json!({"cmd": "printf '%s' \"$AION_RUNTIME_ENV_TEST\"", "shell": "sh"});
+
+        let result = tool.execute(input).await;
+
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert!(result.content.contains("exec-env-value"));
+    }
+
+    #[tokio::test]
     async fn execute_timeout_preserves_stdout_emitted_before_timeout() {
         let tool = ExecCommandTool::new(std::env::temp_dir());
         #[cfg(windows)]


### PR DESCRIPTION
Move aionrs session persistence from the shared index-centric JSON layout to per-session state files under sessions/<encoded-session-id>/state.json. The legacy index.json plus <date>_<session_id>.json layout remains readable, and loading a legacy session lazily writes the new layout without deleting old files.

Add session-local process locks around create, save, load migration, and cleanup so concurrent access to the same session is serialized while independent sessions can proceed in parallel. The compatibility update_index_for API now delegates to save so older callers still work.

Thread runtime environment values through AgentBootstrap, AgentEngine, ExecCommandTool, HookEngine, MCP stdio config, and sub-agent spawning. This lets hosts provide per-conversation environment values without relying on process-wide environment mutation.

Generate new implicit session ids as UUID v7 values. Existing explicit session ids, including conversation ids provided by hosts and legacy short ids, remain valid.