### PR TITLE
feat(providers): preserve response body on 429 rate-limit errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,6 +4203,7 @@ dependencies = [
  "toml_parser",
  "tracing",
  "tracing-core",
+ "uuid",
  "windows-sys 0.52.0",
  "windows-sys 0.61.2",
  "winnow",

--- a/crates/aion-providers/src/bedrock.rs
+++ b/crates/aion-providers/src/bedrock.rs
@@ -264,7 +264,10 @@ impl BedrockTransportState {
         if !status.is_success() {
             let body_text = response.text().await.unwrap_or_default();
             if status.as_u16() == 429 {
-                return Err(ProviderError::RateLimited { retry_after_ms: 5000 });
+                return Err(ProviderError::RateLimited {
+                    retry_after_ms: 5000,
+                    body: (!body_text.is_empty()).then_some(body_text),
+                });
             }
             if let Some(message) = classify_tools_wire_shape_mismatch(status.as_u16(), &body_text, tool_wire_shape) {
                 return Err(ProviderError::Api {

--- a/crates/aion-providers/src/error.rs
+++ b/crates/aion-providers/src/error.rs
@@ -6,8 +6,12 @@ pub enum ProviderError {
     Api { status: u16, message: String },
     #[error("SSE parse error: {0}")]
     Parse(String),
+    // Display intentionally omits `body` — it may contain provider response
+    // payload (potentially sensitive) and would leak into logs via
+    // `tracing::error!("{err}")`. Consumers that need the body must pattern
+    // match on the variant explicitly.
     #[error("Rate limited, retry after {retry_after_ms}ms")]
-    RateLimited { retry_after_ms: u64 },
+    RateLimited { retry_after_ms: u64, body: Option<String> },
     #[error("Prompt too long: {0}")]
     PromptTooLong(String),
     #[error("Connection error: {0}")]

--- a/crates/aion-providers/src/error_test.rs
+++ b/crates/aion-providers/src/error_test.rs
@@ -14,7 +14,13 @@ mod retryable_tests {
             }
             .is_retryable()
         );
-        assert!(ProviderError::RateLimited { retry_after_ms: 1000 }.is_retryable());
+        assert!(
+            ProviderError::RateLimited {
+                retry_after_ms: 1000,
+                body: None,
+            }
+            .is_retryable()
+        );
         assert!(ProviderError::Connection("x".into()).is_retryable());
     }
 }

--- a/crates/aion-providers/src/retry_test.rs
+++ b/crates/aion-providers/src/retry_test.rs
@@ -99,14 +99,20 @@ mod tests {
             let counter = Arc::clone(&counter);
             async move {
                 counter.fetch_add(1, Ordering::SeqCst);
-                Err::<(), _>(ProviderError::RateLimited { retry_after_ms: 5000 })
+                Err::<(), _>(ProviderError::RateLimited {
+                    retry_after_ms: 5000,
+                    body: None,
+                })
             }
         })
         .await;
 
         assert!(matches!(
             result.unwrap_err(),
-            ProviderError::RateLimited { retry_after_ms: 5000 }
+            ProviderError::RateLimited {
+                retry_after_ms: 5000,
+                body: None,
+            }
         ));
         assert_eq!(counter.load(Ordering::SeqCst), 1);
     }

--- a/crates/aion-providers/src/transport.rs
+++ b/crates/aion-providers/src/transport.rs
@@ -262,7 +262,10 @@ async fn send_projected_json_request(
 
 fn map_common_status(status: u16, body_text: String, tool_wire_shape: ResolvedToolWireShape) -> ProviderError {
     if status == 429 {
-        return ProviderError::RateLimited { retry_after_ms: 5000 };
+        return ProviderError::RateLimited {
+            retry_after_ms: 5000,
+            body: (!body_text.is_empty()).then_some(body_text),
+        };
     }
 
     if let Some(message) = classify_tools_wire_shape_mismatch(status, &body_text, tool_wire_shape) {

--- a/crates/aion-providers/src/transport_test.rs
+++ b/crates/aion-providers/src/transport_test.rs
@@ -161,7 +161,44 @@ mod tests {
             .await
             .expect_err("429 should map to rate limited");
 
-        assert!(matches!(error, ProviderError::RateLimited { retry_after_ms: 5000 }));
+        match error {
+            ProviderError::RateLimited { retry_after_ms, body } => {
+                assert_eq!(retry_after_ms, 5000);
+                assert_eq!(body.as_deref(), Some("Too Many Requests"));
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn openai_transport_preserves_429_body_as_none_when_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(429).set_body_string(""))
+            .mount(&server)
+            .await;
+        let transport = ProviderTransport::OpenAi(OpenAiTransport::new("test-key", &server.uri()));
+        let compat = ProviderCompat::openai_defaults();
+        let (body, tool_wire_shape) = transport
+            .project_body(&test_request(vec![]), &compat)
+            .expect("request body projection should succeed");
+        let request = transport
+            .build_projected_request("test-model", body, &compat, tool_wire_shape)
+            .expect("projected request should build");
+
+        let error = transport
+            .send(request)
+            .await
+            .expect_err("empty-body 429 should still map to rate limited");
+
+        assert!(matches!(
+            error,
+            ProviderError::RateLimited {
+                retry_after_ms: 5000,
+                body: None,
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/aion-providers/src/vertex.rs
+++ b/crates/aion-providers/src/vertex.rs
@@ -281,7 +281,10 @@ impl VertexTransportState {
         if !status.is_success() {
             let body_text = response.text().await.unwrap_or_default();
             if status.as_u16() == 429 {
-                return Err(ProviderError::RateLimited { retry_after_ms: 5000 });
+                return Err(ProviderError::RateLimited {
+                    retry_after_ms: 5000,
+                    body: (!body_text.is_empty()).then_some(body_text),
+                });
             }
             if let Some(message) = classify_tools_wire_shape_mismatch(status.as_u16(), &body_text, tool_wire_shape) {
                 return Err(ProviderError::Api {

--- a/crates/aion-providers/tests/provider_anthropic_test.rs
+++ b/crates/aion-providers/tests/provider_anthropic_test.rs
@@ -358,8 +358,12 @@ async fn test_anthropic_rate_limit_retryable() {
 
     // Assert: RateLimited error, which is retryable
     match result {
-        Err(ProviderError::RateLimited { retry_after_ms }) => {
+        Err(ProviderError::RateLimited { retry_after_ms, body }) => {
             assert!(retry_after_ms > 0, "retry_after_ms should be positive");
+            assert!(
+                body.as_deref().is_some_and(|b| b.contains("rate_limit_error")),
+                "429 body should be preserved, got: {body:?}",
+            );
         }
         Err(other) => panic!("expected RateLimited error, got: {other:?}"),
         Ok(_) => panic!("expected an error but stream succeeded"),

--- a/crates/aion-providers/tests/provider_openai_test.rs
+++ b/crates/aion-providers/tests/provider_openai_test.rs
@@ -612,8 +612,9 @@ async fn test_openai_rate_limited() {
 
     assert!(result.is_err());
     match result.unwrap_err() {
-        aion_providers::ProviderError::RateLimited { retry_after_ms } => {
+        aion_providers::ProviderError::RateLimited { retry_after_ms, body } => {
             assert_eq!(retry_after_ms, 5000);
+            assert_eq!(body.as_deref(), Some("Too Many Requests"));
         }
         e => panic!("expected RateLimited error, got: {:?}", e),
     }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -35,6 +35,7 @@ toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
 tracing = { version = "0.1" }
 tracing-core = { version = "0.1" }
+uuid = { version = "1", features = ["v7"] }
 winnow = { version = "1" }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary

- `ProviderError::RateLimited` currently discards the upstream response body — every 429 becomes `retry_after_ms: 5000` with no upstream signal.
- Add an `Option<String> body` field and populate it from `response.text()` in the three 429 construction sites (transport, bedrock, vertex).
- `Display` intentionally still omits `body` so response payloads don't leak into `tracing::error!("{err}")` output; callers must pattern-match to read it.

## Motivation

Downstream host apps (AionUI in our case) want to distinguish transient throttling from permanent conditions like `insufficient_quota` / `payment_required` / hard credit limits. Today the body is thrown away before any consumer sees it, so all 429s look identical and the UI can only say "rate limited, please retry" — which mislead users whose account is actually out of quota.

This PR only preserves the information. It does not add any classification logic; consumers decide what to do with the body.

## Compatibility

`ProviderError::RateLimited` is a `pub enum` variant, so adding a field is a breaking change for direct pattern matches. All in-repo pattern matches have been updated; existing tests pass unchanged in semantics.

## Test plan

- [x] `cargo build -p aion-providers`
- [x] `cargo test -p aion-providers` (19 tests pass, including 2 new/updated 429 body assertions)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `just push` full pipeline (2092 tests / hakari-verify green)

Companion follow-up in AionUI (aioncore) will surface the body in the technical-details UI drawer so users see the actual provider message instead of just "rate limited".

## Note on the second commit

The `chore(workspace-hack): regenerate hakari` commit is unrelated mechanical drift: `cargo hakari generate --diff` reports the same missing `uuid` v7 entry on `main` as well. Included here so `just push` / CI's `hakari-verify` can pass. Happy to drop it if a separate PR is preferred.