### PR TITLE
test(provider): cover PR 203 thinking edge cases

### DIFF
--- a/crates/aion-config/src/config_test.rs
+++ b/crates/aion-config/src/config_test.rs
@@ -1257,6 +1257,69 @@ effort_levels = ["low", "medium"]
     }
 
     #[test]
+    fn test_config_resolve_cli_thinking_disabled_does_not_enable_capability() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cli = CliArgs {
+            provider: Some("openai".into()),
+            api_key: Some("test-key".into()),
+            base_url: None,
+            model: None,
+            max_tokens: None,
+            thinking: Some("disabled".into()),
+            thinking_budget: None,
+            max_turns: None,
+            max_tool_call_malformed_turns: None,
+            max_tool_call_failure_turns: None,
+            system_prompt: None,
+            profile: None,
+            auto_approve: false,
+            project_dir: Some(tmp.path().to_path_buf()),
+        };
+
+        let config = Config::resolve(&cli).unwrap();
+
+        assert!(!config.compat.supports_thinking());
+        assert!(matches!(config.thinking, Some(ThinkingConfig::Disabled)));
+    }
+
+    #[test]
+    fn test_config_resolve_cli_thinking_preserves_explicit_unsupported_capability() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".aionrs.toml"),
+            r#"
+[providers.openai.compat]
+supports_thinking = false
+"#,
+        )
+        .unwrap();
+        let cli = CliArgs {
+            provider: Some("openai".into()),
+            api_key: Some("test-key".into()),
+            base_url: None,
+            model: None,
+            max_tokens: None,
+            thinking: Some("enabled".into()),
+            thinking_budget: Some(16_000),
+            max_turns: None,
+            max_tool_call_malformed_turns: None,
+            max_tool_call_failure_turns: None,
+            system_prompt: None,
+            profile: None,
+            auto_approve: false,
+            project_dir: Some(tmp.path().to_path_buf()),
+        };
+
+        let config = Config::resolve(&cli).unwrap();
+
+        assert!(!config.compat.supports_thinking());
+        assert!(matches!(
+            config.thinking,
+            Some(ThinkingConfig::Enabled { budget_tokens: 16_000 })
+        ));
+    }
+
+    #[test]
     fn test_config_resolve_rejects_invalid_cli_thinking() {
         let tmp = tempfile::tempdir().unwrap();
         let cli = CliArgs {

--- a/crates/aion-providers/src/projector_test.rs
+++ b/crates/aion-providers/src/projector_test.rs
@@ -438,6 +438,17 @@ mod tests {
     }
 
     #[test]
+    fn test_openai_projector_preserves_enabled_thinking_budget_when_supported() {
+        let request = test_request(vec![], Some(ThinkingConfig::Enabled { budget_tokens: 16_000 }));
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.reasoning.supports_thinking = Some(true);
+
+        let body = OpenAiProjector::project(&request, &compat).expect("request body projection should succeed");
+
+        assert_eq!(body["thinking"]["budget_tokens"], 16_000);
+    }
+
+    #[test]
     fn test_openai_projector_emits_disabled_thinking_when_supported() {
         let request = test_request(vec![], Some(ThinkingConfig::Disabled));
         let mut compat = ProviderCompat::openai_defaults();

--- a/crates/aion-providers/src/transport_test.rs
+++ b/crates/aion-providers/src/transport_test.rs
@@ -78,6 +78,22 @@ mod tests {
     }
 
     #[test]
+    fn openai_transport_normalizes_official_openai_root_base_url() {
+        let transport = OpenAiTransport::new("test-key", "https://api.openai.com");
+        let compat = ProviderCompat::openai_defaults();
+
+        let request = transport
+            .build_projected_request(
+                json!({ "model": "gpt-test" }),
+                &compat,
+                ResolvedToolWireShape::OpenAiFunction,
+            )
+            .expect("request projection should succeed");
+
+        assert_eq!(request.url, "https://api.openai.com/v1/chat/completions");
+    }
+
+    #[test]
     fn openai_transport_custom_api_path_overrides_default_chat_path() {
         let transport = OpenAiTransport::new("test-key", "https://open.bigmodel.cn/api/paas/v4/");
         let mut compat = ProviderCompat::openai_defaults();


### PR DESCRIPTION
This is a test-only PR against #203's branch. I am not changing production behavior here; the intent is to make the debated edge cases executable so we can decide whether the behavior is acceptable.

The new tests currently fail on `jiahe/fix/openai-compatible-thinking-path`:

1. `rtk cargo test -p aion-config test_config_resolve_cli_thinking_disabled_does_not_enable_capability`
   - Fails because `--thinking disabled` still flips `compat.supports_thinking()` to `true`.
   - My concern: `supports_thinking` is a provider capability, not the requested per-run state. A disabled request should not cause unsupported OpenAI-compatible providers to emit a `thinking` object.

2. `rtk cargo test -p aion-config test_config_resolve_cli_thinking_preserves_explicit_unsupported_capability`
   - Fails because explicit `[providers.openai.compat] supports_thinking = false` is overwritten by CLI `--thinking enabled`.
   - My concern: user/provider compat says the provider does not support this wire field, but CLI mutates the capability anyway.

3. `rtk cargo test -p aion-providers test_openai_projector_preserves_enabled_thinking_budget_when_supported`
   - Fails with `left: Null`, `right: 16000` for `thinking.budget_tokens`.
   - My concern: the CLI/docs expose `--thinking-budget` in the OpenAI-compatible example, but the request body drops the value silently. If this is intentional, the docs/help text should probably say the budget is Anthropic-only or ignored for this wire path.

4. `rtk cargo test -p aion-providers openai_transport_normalizes_official_openai_root_base_url`
   - Fails with `https://api.openai.com/chat/completions` instead of `https://api.openai.com/v1/chat/completions`.
   - My concern: #203 normalizes this in `Config::resolve`, but `aion_providers::openai::OpenAIProvider::new` remains a public entry point and still reproduces the root URL issue.

If these tests encode the wrong contract, feel free to close this. If they look reasonable, they give concrete regression coverage for the behaviors I was worried about.