### PR TITLE
fix: recover reasoning-only compact summaries instead of failing with EmptyResponse

### DIFF
--- a/crates/aion-agent/src/compact/auto.rs
+++ b/crates/aion-agent/src/compact/auto.rs
@@ -193,22 +193,44 @@ pub async fn autocompact(
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-/// Collect all text from a streaming LLM response.
+/// Collect the summary text from a streaming LLM response.
+///
+/// Reasoning models (e.g. MiniMax M2.5) may emit their entire summary as
+/// reasoning content rather than plain text: the OpenAI-compatible provider
+/// maps `reasoning_content` to `LlmEvent::ThinkingDelta`, and
+/// `ThinkingConfig::Disabled` is not honored by every provider. When the model
+/// produces no text, fall back to the reasoning content so compaction still
+/// succeeds instead of failing with `EmptyResponse`. `format_compact_summary`
+/// degrades gracefully when the `<summary>` block is absent from that text.
 async fn collect_stream_text(mut rx: mpsc::Receiver<LlmEvent>) -> Result<(String, TokenUsage), CompactError> {
     let mut text = String::new();
+    let mut thinking = String::new();
 
     while let Some(event) = rx.recv().await {
         match event {
             LlmEvent::TextDelta(delta) => text.push_str(&delta),
-            LlmEvent::Done { usage, .. } => return Ok((text, usage)),
+            LlmEvent::ThinkingDelta(delta) => thinking.push_str(&delta),
+            LlmEvent::Done { usage, .. } => return Ok((resolve_summary_text(text, thinking), usage)),
             LlmEvent::Error(e) => return Err(CompactError::StreamError(e)),
-            // Ignore thinking deltas and tool calls (shouldn't happen in compact)
+            // Ignore tool calls and thinking signatures (shouldn't happen in compact)
             _ => {}
         }
     }
 
-    // Channel closed without a Done event
-    Err(CompactError::EmptyResponse)
+    // Channel closed without a Done event: salvage reasoning content if the
+    // model spoke only via reasoning, otherwise report the empty response.
+    let resolved = resolve_summary_text(text, thinking);
+    if resolved.trim().is_empty() {
+        return Err(CompactError::EmptyResponse);
+    }
+    Ok((resolved, TokenUsage::default()))
+}
+
+/// Prefer the model's text output, falling back to reasoning content when the
+/// model emitted its summary as reasoning (reasoning models that ignore
+/// `ThinkingConfig::Disabled`).
+fn resolve_summary_text(text: String, thinking: String) -> String {
+    if text.trim().is_empty() { thinking } else { text }
 }
 
 /// Truncate the oldest ~20% of messages for PTL retry.

--- a/crates/aion-agent/tests/autocompact_test.rs
+++ b/crates/aion-agent/tests/autocompact_test.rs
@@ -466,6 +466,37 @@ async fn empty_response_fails() {
 }
 
 #[tokio::test]
+async fn reasoning_only_response_is_recovered() {
+    // Reasoning models (e.g. MiniMax M2.5) may emit the summary as reasoning
+    // content, which the OpenAI-compatible provider surfaces as ThinkingDelta
+    // with no TextDelta. Compaction must recover it rather than fail with
+    // EmptyResponse.
+    let provider = MockProvider::new(vec![Ok(vec![
+        LlmEvent::ThinkingDelta("<summary>Recovered from reasoning.</summary>".to_string()),
+        LlmEvent::Done {
+            stop_reason: StopReason::EndTurn,
+            usage: TokenUsage::default(),
+        },
+    ])]);
+
+    let messages = sample_conversation(10);
+    let config = default_config();
+    let mut state = CompactState::new();
+
+    let result = autocompact(&provider, &messages, "test-model", &config, &mut state)
+        .await
+        .expect("reasoning-only response should be recovered");
+
+    let recovered = result
+        .messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .any(|block| matches!(block, ContentBlock::Text { text } if text.contains("Recovered from reasoning.")));
+    assert!(recovered, "summary should include the recovered reasoning content");
+    assert_eq!(state.consecutive_failures, 0);
+}
+
+#[tokio::test]
 async fn stream_error_fails() {
     let provider = MockProvider::new(vec![Ok(vec![
         LlmEvent::TextDelta("partial".to_string()),


### PR DESCRIPTION
## Problem

Running `/compact` (and autocompact) fails with **`Compact failed: Empty response from LLM`** when the conversation model is a *reasoning* model served via an OpenAI‑compatible endpoint. Observed in AionUi with **MiniMax M2.5** (`custom` provider): the model generates for ~17s, then the turn ends with `event_type="Error" text_len=0`.

## Root cause

- The compact request sets `thinking: ThinkingConfig::Disabled` (`crates/aion-agent/src/compact/auto.rs`), but the OpenAI projector only acts on `ThinkingConfig::Enabled` (`crates/aion-providers/src/projector.rs`), so "disabled" never reaches the wire — reasoning models reason anyway.
- The OpenAI-compatible stream parser maps `reasoning_content` deltas to `LlmEvent::ThinkingDelta` (`crates/aion-providers/src/openai.rs`).
- `collect_stream_text` in `compact/auto.rs` accumulated only `TextDelta` and **discarded** thinking deltas. A model that emits its whole summary as reasoning yields an empty string → `CompactError::EmptyResponse`, even though a complete summary was produced (output budget is not the issue — `COMPACT_MAX_OUTPUT_TOKENS` is 20k).

## Fix

`collect_stream_text` now accumulates thinking deltas alongside text and **falls back to the reasoning content when the model produced no plain text**. `format_compact_summary` already degrades gracefully when `<summary>` tags are absent, so the recovered content flows through the existing parsing unchanged.

Behavior is otherwise preserved:

- Text output, when present, always wins — reasoning is only used as a fallback.
- A truly empty response (no text, no reasoning) still fails with `EmptyResponse`.
- A channel that closes without `Done` can now salvage reasoning-only output; if nothing was received it still fails with `EmptyResponse` as before.

## Testing

- New regression test `reasoning_only_response_is_recovered` (ThinkingDelta-only stream → compaction succeeds, summary contains the recovered content, failure counter untouched).
- Existing `empty_response_fails` still passes (truly empty stream → `EmptyResponse`).
- `cargo test -p aion-agent` — all tests pass.
- `cargo fmt --all -- --check` and `cargo clippy -p aion-agent -- -D warnings` — clean.

## Repro context

AionUi desktop → aionrs conversation → MiniMax M2.5 (`custom` OpenAI-compatible provider) → `/compact` → `Compact failed: Empty response from LLM`. With this change the reasoning-only summary is recovered and compaction completes.
