### PR TITLE
fix(agent): fingerprint tool-call failure breaker

### DIFF
--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -19,8 +19,9 @@ use crate::plan::state::PlanState;
 use crate::session::{Session, SessionManager};
 use crate::stream::StreamOutcome;
 use crate::tool_call::{
-    DEFAULT_MAX_TOOL_CALL_FAILURE, DEFAULT_MAX_TOOL_CALL_MALFORMED, ToolCallMalformedFingerprint, merge_tool_results,
-    tool_call_malformed_fingerprint, tool_call_malformed_reason,
+    DEFAULT_MAX_TOOL_CALL_FAILURE, DEFAULT_MAX_TOOL_CALL_MALFORMED, ToolCallFailureFingerprint,
+    ToolCallMalformedFingerprint, merge_tool_results, tool_call_failure_fingerprint, tool_call_malformed_fingerprint,
+    tool_call_malformed_reason,
 };
 use crate::turn::{FinalizationReason, TurnGuardAction, TurnGuards, TurnKind, TurnOutcome};
 use aion_compact::CompactLevel;
@@ -445,7 +446,7 @@ impl AgentEngine {
                 tool_results,
                 tool_modifiers,
                 tool_call_malformed_fingerprint,
-                tool_call_failure_round,
+                tool_call_failure_fingerprint,
             } = self.execute_tool_round(&tool_calls, &assistant_text).await?;
 
             // Apply any context modifiers from skill executions before the next turn.
@@ -458,7 +459,7 @@ impl AgentEngine {
             // Save session after each tool round.
             self.save_session();
 
-            match guards.after_tool_round(tool_call_malformed_fingerprint, tool_call_failure_round) {
+            match guards.after_tool_round(tool_call_malformed_fingerprint, tool_call_failure_fingerprint) {
                 TurnGuardAction::Continue => {}
                 TurnGuardAction::Finalize => {
                     return self
@@ -609,18 +610,20 @@ impl AgentEngine {
             executable_modifiers,
         );
 
-        let tool_call_failure_round = tool_call_malformed_fingerprint.is_none()
+        let tool_call_failure_fingerprint = (tool_call_malformed_fingerprint.is_none()
             && assistant_text.trim().is_empty()
             && !tool_results.is_empty()
             && tool_results
                 .iter()
-                .all(|result| matches!(result, ContentBlock::ToolResult { is_error: true, .. }));
+                .all(|result| matches!(result, ContentBlock::ToolResult { is_error: true, .. })))
+        .then(|| tool_call_failure_fingerprint(tool_calls))
+        .flatten();
 
         Ok(ToolRoundOutput {
             tool_results,
             tool_modifiers,
             tool_call_malformed_fingerprint,
-            tool_call_failure_round,
+            tool_call_failure_fingerprint,
         })
     }
 
@@ -1228,10 +1231,10 @@ struct ToolRoundOutput {
     /// `Some` only when every tool call in the round was malformed; feeds the
     /// tool-call-malformed breaker.
     tool_call_malformed_fingerprint: Option<ToolCallMalformedFingerprint>,
-    /// True when this round produced executable (non-malformed) tool calls
-    /// that all errored and the model emitted no visible text; feeds the
-    /// consecutive-tool-call-failure breaker.
-    tool_call_failure_round: bool,
+    /// `Some` when this round produced executable (non-malformed) tool calls
+    /// with the same name+input pattern, all errored, and the model emitted no
+    /// visible text; feeds the consecutive-tool-call-failure breaker.
+    tool_call_failure_fingerprint: Option<ToolCallFailureFingerprint>,
 }
 
 /// Assemble the assistant message content blocks (thinking, text, tool calls)

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -1326,16 +1326,27 @@ mod tests_loop_helpers {
 
     use super::{AgentError, merge_tool_results, tool_call_malformed_fingerprint};
     use crate::stream::StreamOutcome;
-    use crate::tool_call::{DEFAULT_MAX_TOOL_CALL_FAILURE, ToolCallMalformedReason};
+    use crate::tool_call::{
+        DEFAULT_MAX_TOOL_CALL_FAILURE, ToolCallFailureFingerprint, ToolCallMalformedReason,
+        tool_call_failure_fingerprint,
+    };
     use crate::turn::{FinalizationReason, TurnGuardAction, TurnGuards, TurnKind, TurnOutcome};
 
     fn tool_use(id: &str, name: &str) -> ContentBlock {
+        tool_use_with_input(id, name, json!({}))
+    }
+
+    fn tool_use_with_input(id: &str, name: &str, input: serde_json::Value) -> ContentBlock {
         ContentBlock::ToolUse {
             id: id.to_string(),
             name: name.to_string(),
-            input: json!({}),
+            input,
             extra: None,
         }
+    }
+
+    fn failed_exec_fingerprint() -> Option<ToolCallFailureFingerprint> {
+        tool_call_failure_fingerprint(&[tool_use("call", "ExecCommand")])
     }
 
     fn executed_result(id: &str) -> ContentBlock {
@@ -1416,11 +1427,14 @@ mod tests_loop_helpers {
         let mut guards = TurnGuards::new(Some(100), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
         // First N-1 tool-call-failure rounds: no stop yet.
         for _ in 0..DEFAULT_MAX_TOOL_CALL_FAILURE - 1 {
-            assert!(matches!(guards.after_tool_round(None, true), TurnGuardAction::Continue));
+            assert!(matches!(
+                guards.after_tool_round(None, failed_exec_fingerprint()),
+                TurnGuardAction::Continue
+            ));
         }
         // The Nth consecutive tool-call-failure round trips the breaker.
         assert!(matches!(
-            guards.after_tool_round(None, true),
+            guards.after_tool_round(None, failed_exec_fingerprint()),
             TurnGuardAction::Stop(AgentError::ToolCallFailures { .. })
         ));
     }
@@ -1428,25 +1442,44 @@ mod tests_loop_helpers {
     #[test]
     fn after_tool_round_resets_tool_call_failure_streak_on_success() {
         let mut guards = TurnGuards::new(Some(100), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
-        assert!(matches!(guards.after_tool_round(None, true), TurnGuardAction::Continue));
-        // A non-error tool round resets the streak.
         assert!(matches!(
-            guards.after_tool_round(None, false),
+            guards.after_tool_round(None, failed_exec_fingerprint()),
             TurnGuardAction::Continue
         ));
+        // A non-error tool round resets the streak.
+        assert!(matches!(guards.after_tool_round(None, None), TurnGuardAction::Continue));
         assert_eq!(guards.tool_call_failure_count(), 0);
         // So a single subsequent tool-call-failure round must not trip the breaker.
-        assert!(matches!(guards.after_tool_round(None, true), TurnGuardAction::Continue));
+        assert!(matches!(
+            guards.after_tool_round(None, failed_exec_fingerprint()),
+            TurnGuardAction::Continue
+        ));
+    }
+
+    #[test]
+    fn after_tool_round_does_not_trip_failure_breaker_for_different_tool_inputs() {
+        let mut guards = TurnGuards::new(Some(100), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
+
+        for index in 0..DEFAULT_MAX_TOOL_CALL_FAILURE {
+            let fingerprint = tool_call_failure_fingerprint(&[tool_use_with_input(
+                &format!("call-{index}"),
+                "ExecCommand",
+                json!({ "cmd": format!("command-{index}") }),
+            )]);
+
+            assert!(matches!(
+                guards.after_tool_round(None, fingerprint),
+                TurnGuardAction::Continue
+            ));
+            assert_eq!(guards.tool_call_failure_count(), 1);
+        }
     }
 
     #[test]
     fn after_tool_round_requests_finalize_when_budget_is_exhausted() {
         let mut guards = TurnGuards::new(Some(1), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
         guards.record_counted_turn();
-        assert!(matches!(
-            guards.after_tool_round(None, false),
-            TurnGuardAction::Finalize
-        ));
+        assert!(matches!(guards.after_tool_round(None, None), TurnGuardAction::Finalize));
     }
 
     #[test]
@@ -1459,7 +1492,7 @@ mod tests_loop_helpers {
         let fingerprint = tool_call_malformed_fingerprint(&calls, &reasons);
 
         assert!(matches!(
-            guards.after_tool_round(fingerprint, false),
+            guards.after_tool_round(fingerprint, None),
             TurnGuardAction::Stop(AgentError::ToolCallMalformed { count: 1, limit: 1 })
         ));
     }

--- a/crates/aion-agent/src/tool_call.rs
+++ b/crates/aion-agent/src/tool_call.rs
@@ -38,9 +38,20 @@ pub(crate) struct ToolCallMalformedFingerprint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolCallFailureFingerprint {
+    calls: Vec<ToolCallFailureFingerprintPart>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ToolCallMalformedFingerprintPart {
     reason: ToolCallMalformedReason,
     id: String,
+    name: String,
+    input: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolCallFailureFingerprintPart {
     name: String,
     input: String,
 }
@@ -123,6 +134,27 @@ pub(crate) fn tool_call_malformed_fingerprint(
     Some(ToolCallMalformedFingerprint { calls })
 }
 
+pub(crate) fn tool_call_failure_fingerprint(tool_calls: &[ContentBlock]) -> Option<ToolCallFailureFingerprint> {
+    if tool_calls.is_empty() {
+        return None;
+    }
+
+    let calls: Option<Vec<_>> = tool_calls
+        .iter()
+        .map(|block| {
+            let ContentBlock::ToolUse { name, input, .. } = block else {
+                return None;
+            };
+            Some(ToolCallFailureFingerprintPart {
+                name: name.trim().to_string(),
+                input: serde_json::to_string(input).unwrap_or_default(),
+            })
+        })
+        .collect();
+
+    Some(ToolCallFailureFingerprint { calls: calls? })
+}
+
 /// Interleave synthetic malformed-call results with executed-tool results back
 /// into the original `tool_calls` order.
 ///
@@ -182,13 +214,18 @@ pub(crate) fn merge_tool_results(
 }
 
 pub(crate) struct ToolCallFailureTracker {
+    last: Option<ToolCallFailureFingerprint>,
     count: usize,
     limit: usize,
 }
 
 impl ToolCallFailureTracker {
     pub(crate) fn new(limit: usize) -> Self {
-        Self { count: 0, limit }
+        Self {
+            last: None,
+            count: 0,
+            limit,
+        }
     }
 
     pub(crate) fn limit(&self) -> usize {
@@ -199,11 +236,18 @@ impl ToolCallFailureTracker {
         self.limit > 0 && self.count >= self.limit
     }
 
-    pub(crate) fn observe(&mut self, failed_round: bool) -> usize {
-        if failed_round {
+    pub(crate) fn observe(&mut self, current: Option<ToolCallFailureFingerprint>) -> usize {
+        let Some(current) = current else {
+            self.last = None;
+            self.count = 0;
+            return 0;
+        };
+
+        if self.last.as_ref() == Some(&current) {
             self.count += 1;
         } else {
-            self.count = 0;
+            self.last = Some(current);
+            self.count = 1;
         }
 
         self.count

--- a/crates/aion-agent/src/tool_call_test.rs
+++ b/crates/aion-agent/src/tool_call_test.rs
@@ -60,28 +60,57 @@ mod tests {
     }
 
     #[test]
-    fn tool_call_failure_tracker_counts_consecutive_failed_rounds() {
+    fn tool_call_failure_tracker_counts_only_same_fingerprint() {
+        let command_a = ContentBlock::ToolUse {
+            id: "call-a".into(),
+            name: "ExecCommand".into(),
+            input: json!({ "cmd": "python update_config.py" }),
+            extra: None,
+        };
+        let command_a_reissued = ContentBlock::ToolUse {
+            id: "call-a-reissued".into(),
+            name: "ExecCommand".into(),
+            input: json!({ "cmd": "python update_config.py" }),
+            extra: None,
+        };
+        let command_b = ContentBlock::ToolUse {
+            id: "call-b".into(),
+            name: "ExecCommand".into(),
+            input: json!({ "cmd": "aioncore assistants update" }),
+            extra: None,
+        };
+        let command_a = tool_call_failure_fingerprint(&[command_a]);
+        let command_a_reissued = tool_call_failure_fingerprint(&[command_a_reissued]);
+        let command_b = tool_call_failure_fingerprint(&[command_b]);
         let mut tracker = ToolCallFailureTracker::new(3);
 
-        assert_eq!(tracker.observe(true), 1);
-        assert_eq!(tracker.observe(true), 2);
-        assert_eq!(tracker.observe(false), 0);
-        assert_eq!(tracker.observe(true), 1);
+        assert_eq!(tracker.observe(command_a.clone()), 1);
+        assert_eq!(tracker.observe(command_a_reissued), 2);
+        assert_eq!(tracker.observe(command_b), 1);
         assert_eq!(tracker.count(), 1);
         assert!(!tracker.is_limit_exceeded());
-        assert_eq!(tracker.observe(true), 2);
-        assert_eq!(tracker.observe(true), 3);
+        assert_eq!(tracker.observe(None), 0);
+        assert_eq!(tracker.observe(command_a.clone()), 1);
+        assert_eq!(tracker.observe(command_a.clone()), 2);
+        assert_eq!(tracker.observe(command_a), 3);
         assert!(tracker.is_limit_exceeded());
         assert_eq!(tracker.limit(), 3);
     }
 
     #[test]
     fn tool_call_failure_tracker_limit_zero_disables_breaker() {
+        let call = ContentBlock::ToolUse {
+            id: "call-a".into(),
+            name: "ExecCommand".into(),
+            input: json!({ "cmd": "python update_config.py" }),
+            extra: None,
+        };
+        let fingerprint = tool_call_failure_fingerprint(&[call]);
         let mut tracker = ToolCallFailureTracker::new(0);
 
-        assert_eq!(tracker.observe(true), 1);
+        assert_eq!(tracker.observe(fingerprint.clone()), 1);
         assert!(!tracker.is_limit_exceeded());
-        assert_eq!(tracker.observe(true), 2);
+        assert_eq!(tracker.observe(fingerprint), 2);
         assert!(!tracker.is_limit_exceeded());
     }
 }

--- a/crates/aion-agent/src/turn.rs
+++ b/crates/aion-agent/src/turn.rs
@@ -1,6 +1,8 @@
 use crate::error::AgentError;
 use crate::stream::StreamOutcome;
-use crate::tool_call::{ToolCallFailureTracker, ToolCallMalformedFingerprint, ToolCallMalformedTracker};
+use crate::tool_call::{
+    ToolCallFailureFingerprint, ToolCallFailureTracker, ToolCallMalformedFingerprint, ToolCallMalformedTracker,
+};
 use aion_types::message::StopReason;
 
 pub(crate) enum TurnOutcome {
@@ -145,7 +147,7 @@ impl TurnGuards {
     pub(crate) fn after_tool_round(
         &mut self,
         tool_call_malformed_fingerprint: Option<ToolCallMalformedFingerprint>,
-        tool_call_failure_round: bool,
+        tool_call_failure_fingerprint: Option<ToolCallFailureFingerprint>,
     ) -> TurnGuardAction {
         let malformed_count = self.tool_call_malformed.observe(tool_call_malformed_fingerprint);
         if self.tool_call_malformed.is_limit_exceeded() {
@@ -161,7 +163,7 @@ impl TurnGuards {
             });
         }
 
-        let tool_call_failure_count = self.tool_call_failures.observe(tool_call_failure_round);
+        let tool_call_failure_count = self.tool_call_failures.observe(tool_call_failure_fingerprint);
         if self.tool_call_failures.is_limit_exceeded() {
             tracing::warn!(
                 target: "aion_agent",


### PR DESCRIPTION
## Summary
- Track consecutive tool-call failures by tool name and input fingerprint instead of a broad failed-round boolean.
- Generate failure fingerprints only for non-malformed, no-text tool rounds where every result errored.
- Add regression tests so different ExecCommand inputs do not trip the 3/3 breaker while repeated identical failures still do.

## Test Plan
- cargo fmt --all -- --check
- cargo test -p aion-agent
- cargo clippy -p aion-agent -- -D warnings