### PR TITLE
fix(agent): enforce runtime tool policies

### DIFF
--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -160,7 +160,7 @@ impl AgentBootstrap {
 
         self.register_agent_tools(&mut registry, &provider, &environment.workspace, skills);
         let plan_active_flag = self.register_plan_tools(&mut registry);
-        Self::register_tool_search(&mut registry);
+        self.register_tool_search(&mut registry);
 
         let has_mcp = mcp.has_mcp();
         let mcp_managers = mcp.managers;
@@ -320,8 +320,8 @@ impl AgentBootstrap {
         plan_active_flag
     }
 
-    fn register_tool_search(registry: &mut ToolRegistry) {
-        let tool_defs_snapshot = registry.to_tool_defs();
+    fn register_tool_search(&self, registry: &mut ToolRegistry) {
+        let tool_defs_snapshot = registry.to_tool_defs_filtered(|tool| self.tool_policy.allows(tool.name()));
         registry.register(Box::new(ToolSearchTool::new(tool_defs_snapshot)));
     }
 

--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -24,7 +24,7 @@ use aion_tools::write::WriteTool;
 use anyhow::Result;
 use tracing::info;
 
-use crate::context::{SystemPromptCache, build_system_prompt_with_shell};
+use crate::context::{SystemPromptCache, build_system_prompt_with_shell_and_tool_policy};
 use crate::engine::AgentEngine;
 use crate::output::OutputSink;
 use crate::plan::tools::{EnterPlanModeTool, ExitPlanModeTool};
@@ -32,6 +32,7 @@ use crate::session::Session;
 use crate::skill_tool::SkillTool;
 use crate::spawn_tool::SpawnTool;
 use crate::spawner::AgentSpawner;
+use crate::tool_policy::ToolPolicy;
 
 /// Result of bootstrapping an agent engine with all features initialized.
 pub struct BootstrapResult {
@@ -68,6 +69,7 @@ pub struct AgentBootstrap {
     provider: Option<Arc<dyn LlmProvider>>,
     resume_session: Option<Session>,
     runtime_env: Vec<(String, String)>,
+    tool_policy: ToolPolicy,
 }
 
 struct BootstrapEnvironment {
@@ -104,6 +106,7 @@ impl AgentBootstrap {
             provider: None,
             resume_session: None,
             runtime_env: Vec::new(),
+            tool_policy: ToolPolicy::default(),
         }
     }
 
@@ -122,6 +125,12 @@ impl AgentBootstrap {
     /// Inject process environment for tools/hooks/MCP subprocesses owned by this engine.
     pub fn runtime_env(mut self, runtime_env: Vec<(String, String)>) -> Self {
         self.runtime_env = runtime_env;
+        self
+    }
+
+    /// Restrict which registered tools can be advertised and executed.
+    pub fn tool_policy(mut self, tool_policy: ToolPolicy) -> Self {
+        self.tool_policy = tool_policy;
         self
     }
 
@@ -257,7 +266,7 @@ impl AgentBootstrap {
     fn configure_system_prompt(&mut self, environment: &BootstrapEnvironment, skills: &[SkillMetadata]) {
         let mut prompt_cache = SystemPromptCache::new();
         let workspace = self.workspace.to_string_lossy();
-        let system_prompt = build_system_prompt_with_shell(
+        let system_prompt = build_system_prompt_with_shell_and_tool_policy(
             &mut prompt_cache,
             self.config.system_prompt.as_deref(),
             &workspace,
@@ -268,6 +277,7 @@ impl AgentBootstrap {
             environment.memory_dir.as_deref(),
             false,
             self.config.compact.toon,
+            &self.tool_policy,
         );
         self.config.system_prompt = Some(system_prompt);
     }
@@ -337,6 +347,7 @@ impl AgentBootstrap {
             AgentEngine::new_with_provider_and_env(provider, self.config, registry, self.output, workspace, runtime_env)
         };
         engine.set_plan_active_flag(plan_active_flag);
+        engine.set_tool_policy(self.tool_policy);
         engine
     }
 }

--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -305,6 +305,7 @@ impl AgentBootstrap {
             self.config.clone(),
             workspace.to_path_buf(),
             self.runtime_env.clone(),
+            self.tool_policy.clone(),
         );
         registry.register(Box::new(SpawnTool::new(Arc::new(spawner))));
     }

--- a/crates/aion-agent/src/bootstrap_test.rs
+++ b/crates/aion-agent/src/bootstrap_test.rs
@@ -6,15 +6,56 @@ mod tests {
     use std::sync::Arc;
 
     use aion_config::config::{CliArgs, McpServerConfig, TransportType};
+    use aion_protocol::events::ToolCategory;
+    use aion_tools::Tool;
+    use aion_types::tool::ToolResult;
+    use async_trait::async_trait;
+    use serde_json::{Value, json};
 
     use crate::output::OutputSink;
     use crate::output::null_sink::NullSink;
+    use crate::tool_policy::ToolPolicy;
 
     use super::*;
 
-    #[test]
-    fn mcp_servers_with_runtime_env_uses_server_env_as_override() {
-        let mut config = Config::resolve(&CliArgs {
+    struct DeferredTestTool(&'static str);
+
+    #[async_trait]
+    impl Tool for DeferredTestTool {
+        fn name(&self) -> &str {
+            self.0
+        }
+
+        fn description(&self) -> &str {
+            "deferred test tool"
+        }
+
+        fn input_schema(&self) -> Value {
+            json!({"type": "object"})
+        }
+
+        fn is_concurrency_safe(&self, _input: &Value) -> bool {
+            true
+        }
+
+        async fn execute(&self, _input: Value) -> ToolResult {
+            ToolResult {
+                content: "unused".to_string(),
+                is_error: false,
+            }
+        }
+
+        fn category(&self) -> ToolCategory {
+            ToolCategory::Info
+        }
+
+        fn is_deferred(&self) -> bool {
+            true
+        }
+    }
+
+    fn test_config() -> Config {
+        Config::resolve(&CliArgs {
             provider: Some("anthropic".to_string()),
             api_key: Some("sk-test".to_string()),
             base_url: None,
@@ -30,7 +71,12 @@ mod tests {
             auto_approve: false,
             project_dir: None,
         })
-        .unwrap();
+        .unwrap()
+    }
+
+    #[test]
+    fn mcp_servers_with_runtime_env_uses_server_env_as_override() {
+        let mut config = test_config();
         config.mcp.servers.insert(
             "stdio".to_string(),
             McpServerConfig {
@@ -63,5 +109,25 @@ mod tests {
         assert_eq!(env.get("OVERRIDE").map(String::as_str), Some("server"));
         assert_eq!(env.get("SERVER_ONLY").map(String::as_str), Some("1"));
         assert_eq!(env.get("RUNTIME_ONLY").map(String::as_str), Some("1"));
+    }
+
+    #[tokio::test]
+    async fn tool_search_snapshot_excludes_policy_denied_tools() {
+        let output: Arc<dyn OutputSink> = Arc::new(NullSink);
+        let bootstrap = AgentBootstrap::new(test_config(), "/tmp", output)
+            .tool_policy(ToolPolicy::allow_only(["ToolSearch", "AllowedDeferred"]));
+        let mut registry = ToolRegistry::new();
+        registry.register(Box::new(DeferredTestTool("AllowedDeferred")));
+        registry.register(Box::new(DeferredTestTool("DeniedDeferred")));
+
+        bootstrap.register_tool_search(&mut registry);
+
+        let tool_search = registry.get("ToolSearch").expect("ToolSearch should be registered");
+        let allowed = tool_search.execute(json!({"query": "AllowedDeferred"})).await;
+        let denied = tool_search.execute(json!({"query": "DeniedDeferred"})).await;
+
+        assert!(allowed.content.contains("AllowedDeferred"));
+        assert!(denied.content.starts_with("No deferred tools matching"));
+        assert!(!denied.content.contains("\"name\": \"DeniedDeferred\""));
     }
 }

--- a/crates/aion-agent/src/context.rs
+++ b/crates/aion-agent/src/context.rs
@@ -9,6 +9,7 @@ use aion_types::message::{ContentBlock, Message, Role};
 
 use crate::agents_md;
 use crate::plan::prompt as plan_prompt;
+use crate::tool_policy::ToolPolicy;
 
 /// Session-scoped cache for system prompt sections.
 ///
@@ -26,6 +27,8 @@ pub struct SystemPromptCache {
     pub(crate) last_toon_enabled: bool,
     /// Track shell prompt text to invalidate intro when shell resolution changes.
     pub(crate) last_shell_prompt: Option<String>,
+    /// Track runtime tool authorization to keep guidance and skill reminders aligned.
+    pub(crate) last_tool_policy: ToolPolicy,
 }
 
 impl SystemPromptCache {
@@ -36,6 +39,7 @@ impl SystemPromptCache {
             last_plan_mode: false,
             last_toon_enabled: false,
             last_shell_prompt: None,
+            last_tool_policy: ToolPolicy::default(),
         }
     }
 
@@ -60,12 +64,11 @@ impl Default for SystemPromptCache {
 
 /// Return the tool-usage guidance section for the system prompt.
 ///
-/// This section teaches the model when to prefer dedicated tools over ExecCommand,
-/// how to handle parallel vs sequential calls, and cross-tool best practices.
-/// Intentionally redundant with individual tool descriptions — the dual
-/// placement ensures the model follows the rules regardless of attention span.
-fn tool_usage_guidance() -> &'static str {
-    "\
+/// For unrestricted agents this includes the full cross-tool guidance. For
+/// restricted agents it only names tools authorized by the runtime policy.
+fn tool_usage_guidance(tool_policy: &ToolPolicy) -> String {
+    if matches!(tool_policy, ToolPolicy::Unrestricted) {
+        return "\
 # Using your tools
  - Do NOT use ExecCommand when a dedicated tool is available. Using dedicated tools \
 allows the user to better understand and review your work:
@@ -82,6 +85,48 @@ the diff, which is easier to review.
  - Always Read a file before editing it.
  - Some tools are deferred — only their names are visible. Before calling \
 a deferred tool, use ToolSearch to load its full schema first."
+            .to_string();
+    }
+
+    let mut guidance = vec!["# Using your tools".to_string()];
+    let dedicated_tools = [
+        ("Glob", "File search: Glob"),
+        ("Grep", "Content search: Grep"),
+        ("Read", "Read files: Read"),
+        ("Edit", "Edit files: Edit"),
+        ("Write", "Write files: Write"),
+    ]
+    .into_iter()
+    .filter_map(|(name, text)| tool_policy.allows(name).then_some(text))
+    .collect::<Vec<_>>();
+
+    if !dedicated_tools.is_empty() {
+        guidance.push(" - Use the available dedicated workspace tools when they fit the task:".to_string());
+        guidance.extend(dedicated_tools.into_iter().map(|tool| format!("   - {tool}")));
+    }
+
+    guidance.push(
+        " - You can call multiple tools in a single response. If there are no dependencies between them, make all independent calls in parallel. However, if one call depends on a previous result, run them sequentially."
+            .to_string(),
+    );
+
+    if tool_policy.allows("Edit") && tool_policy.allows("Write") {
+        guidance.push(
+            " - Prefer Edit over Write for modifying existing files — Edit sends only the diff, which is easier to review."
+                .to_string(),
+        );
+    }
+    if tool_policy.allows("Read") && tool_policy.allows("Edit") {
+        guidance.push(" - Always Read a file before editing it.".to_string());
+    }
+    if tool_policy.allows("ToolSearch") {
+        guidance.push(
+            " - Some tools are deferred — only their names are visible. Before calling a deferred tool, use ToolSearch to load its full schema first."
+                .to_string(),
+        );
+    }
+
+    guidance.join("\n")
 }
 
 /// Build the system prompt from config and environment.
@@ -98,7 +143,7 @@ a deferred tool, use ToolSearch to load its full schema first."
 /// Session-permanent sections (intro, tool guidance, custom prompt, AGENTS.md)
 /// are cached in `cache.sections` and reused across calls. The `joined` field
 /// caches the final concatenated result; it is returned on subsequent calls
-/// unless plan_mode_active has changed.
+/// unless a dynamic input such as plan mode or tool policy has changed.
 #[allow(clippy::too_many_arguments)]
 pub fn build_system_prompt(
     cache: &mut SystemPromptCache,
@@ -140,6 +185,43 @@ pub fn build_system_prompt_with_shell(
     plan_mode_active: bool,
     toon_enabled: bool,
 ) -> String {
+    build_system_prompt_with_shell_and_tool_policy(
+        cache,
+        custom_prompt,
+        cwd,
+        model,
+        shell,
+        skills,
+        context_window_tokens,
+        memory_dir,
+        plan_mode_active,
+        toon_enabled,
+        &ToolPolicy::Unrestricted,
+    )
+}
+
+/// Build the system prompt while keeping tool guidance consistent with the
+/// runtime authorization policy.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_system_prompt_with_shell_and_tool_policy(
+    cache: &mut SystemPromptCache,
+    custom_prompt: Option<&str>,
+    cwd: &str,
+    model: &str,
+    shell: &ResolvedShell,
+    skills: &[SkillMetadata],
+    context_window_tokens: Option<usize>,
+    memory_dir: Option<&Path>,
+    plan_mode_active: bool,
+    toon_enabled: bool,
+    tool_policy: &ToolPolicy,
+) -> String {
+    if cache.last_tool_policy != *tool_policy {
+        cache.invalidate("tool_guidance");
+        cache.invalidate("skills");
+        cache.last_tool_policy = tool_policy.clone();
+    }
+
     let shell_prompt = render_shell_prompt(shell);
     if cache.last_shell_prompt.as_deref() != Some(shell_prompt.as_str()) {
         cache.invalidate("intro");
@@ -178,7 +260,7 @@ pub fn build_system_prompt_with_shell(
     let guidance = cache
         .sections
         .entry("tool_guidance")
-        .or_insert_with(|| tool_usage_guidance().to_string());
+        .or_insert_with(|| tool_usage_guidance(tool_policy));
     parts.push(guidance.clone());
 
     // Section: custom prompt (session permanent)
@@ -224,7 +306,11 @@ pub fn build_system_prompt_with_shell(
     }
 
     // Section: skills (cached, event-invalidated)
-    let visible_skills: Vec<SkillMetadata> = skills.iter().filter(|s| !s.disable_model_invocation).cloned().collect();
+    let visible_skills: Vec<SkillMetadata> = if tool_policy.allows("Skill") {
+        skills.iter().filter(|s| !s.disable_model_invocation).cloned().collect()
+    } else {
+        Vec::new()
+    };
 
     if !visible_skills.is_empty() {
         let skills_section = cache.sections.entry("skills").or_insert_with(|| {

--- a/crates/aion-agent/src/context_test.rs
+++ b/crates/aion-agent/src/context_test.rs
@@ -827,6 +827,72 @@ mod tests {
     }
 
     #[test]
+    fn restricted_policy_only_mentions_authorized_tools() {
+        let skills = vec![make_test_skill("hidden-by-policy", "A skill", false, false)];
+        let policy = ToolPolicy::allow_only(["Read", "Grep", "Glob", "team_members"]);
+        let result = build_system_prompt_with_shell_and_tool_policy(
+            &mut SystemPromptCache::new(),
+            None,
+            "/tmp",
+            "test-model",
+            &default_shell(),
+            &skills,
+            None,
+            None,
+            false,
+            false,
+            &policy,
+        );
+
+        assert!(result.contains("File search: Glob"));
+        assert!(result.contains("Content search: Grep"));
+        assert!(result.contains("Read files: Read"));
+        for unavailable in ["ExecCommand", "Edit files", "Write files", "ToolSearch", "Skill tool"] {
+            assert!(
+                !result.contains(unavailable),
+                "restricted prompt should not mention unavailable tool guidance: {unavailable}"
+            );
+        }
+        assert!(!result.contains("hidden-by-policy"));
+    }
+
+    #[test]
+    fn changing_tool_policy_invalidates_cached_guidance() {
+        let mut cache = SystemPromptCache::new();
+        let shell = default_shell();
+        let restricted = ToolPolicy::allow_only(["Read"]);
+        let restricted_prompt = build_system_prompt_with_shell_and_tool_policy(
+            &mut cache,
+            None,
+            "/tmp",
+            "test-model",
+            &shell,
+            &[],
+            None,
+            None,
+            false,
+            false,
+            &restricted,
+        );
+        assert!(!restricted_prompt.contains("ExecCommand"));
+
+        let unrestricted_prompt = build_system_prompt_with_shell_and_tool_policy(
+            &mut cache,
+            None,
+            "/tmp",
+            "test-model",
+            &shell,
+            &[],
+            None,
+            None,
+            false,
+            false,
+            &ToolPolicy::Unrestricted,
+        );
+        assert!(unrestricted_prompt.contains("ExecCommand"));
+    }
+
+    #[test]
     fn tool_guidance_before_memory() {
         let tmp = tempfile::TempDir::new().unwrap();
         let mem_dir = tmp.path().join("memory");

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -23,6 +23,7 @@ use crate::tool_call::{
     ToolCallMalformedFingerprint, merge_tool_results, tool_call_failure_fingerprint, tool_call_malformed_fingerprint,
     tool_call_malformed_reason,
 };
+use crate::tool_policy::ToolPolicy;
 use crate::turn::{FinalizationReason, TurnGuardAction, TurnGuards, TurnKind, TurnOutcome};
 use aion_compact::CompactLevel;
 use aion_config::compact::CompactConfig;
@@ -86,6 +87,8 @@ pub struct AgentEngine {
     // Tool execution policy.
     /// Registry of tools available to the engine.
     tools: ToolRegistry,
+    /// Runtime authorization applied to tool advertisement and execution.
+    tool_policy: ToolPolicy,
     /// Shared tool confirmer used for approval policy decisions.
     confirmer: Arc<Mutex<ToolConfirmer>>,
     /// Tool names currently allowed without additional approval.
@@ -188,6 +191,7 @@ impl AgentEngine {
                 .max_tool_call_failure_turns
                 .unwrap_or(DEFAULT_MAX_TOOL_CALL_FAILURE),
             tools,
+            tool_policy: ToolPolicy::default(),
             confirmer: Arc::new(Mutex::new(confirmer)),
             allow_list,
             hooks: Some(HookEngine::new_with_env(config.hooks.clone(), cwd.clone(), runtime_env)),
@@ -274,6 +278,7 @@ impl AgentEngine {
                 .max_tool_call_failure_turns
                 .unwrap_or(DEFAULT_MAX_TOOL_CALL_FAILURE),
             tools,
+            tool_policy: ToolPolicy::default(),
             confirmer: Arc::new(Mutex::new(confirmer)),
             allow_list,
             hooks: Some(HookEngine::new_with_env(config.hooks.clone(), cwd, runtime_env)),
@@ -313,6 +318,11 @@ impl AgentEngine {
 
     pub fn registry_mut(&mut self) -> &mut ToolRegistry {
         &mut self.tools
+    }
+
+    /// Replace the runtime authorization policy for registered tools.
+    pub(crate) fn set_tool_policy(&mut self, tool_policy: ToolPolicy) {
+        self.tool_policy = tool_policy;
     }
 
     /// Get the current session ID (if sessions are enabled and initialized)
@@ -484,11 +494,13 @@ impl AgentEngine {
             Vec::new()
         } else if self.plan_state.is_active {
             // Plan mode: only Info-category tools (excluding EnterPlanMode)
-            self.tools
-                .to_tool_defs_filtered(|t| t.category() == ToolCategory::Info && t.name() != "EnterPlanMode")
+            self.tools.to_tool_defs_filtered(|t| {
+                self.tool_policy.allows(t.name()) && t.category() == ToolCategory::Info && t.name() != "EnterPlanMode"
+            })
         } else {
             // Normal mode: all tools except ExitPlanMode
-            self.tools.to_tool_defs_filtered(|t| t.name() != "ExitPlanMode")
+            self.tools
+                .to_tool_defs_filtered(|t| self.tool_policy.allows(t.name()) && t.name() != "ExitPlanMode")
         };
 
         // Build system prompt: append plan mode instructions when active
@@ -547,11 +559,25 @@ impl AgentEngine {
             })
             .collect();
         let tool_call_malformed_fingerprint = tool_call_malformed_fingerprint(tool_calls, &tool_call_malformed_reasons);
+        let policy_denied_tool_names: Vec<_> = tool_calls
+            .iter()
+            .zip(&tool_call_malformed_reasons)
+            .map(|(call, malformed_reason)| {
+                if malformed_reason.is_some() {
+                    return None;
+                }
+                let ContentBlock::ToolUse { name, .. } = call else {
+                    return None;
+                };
+                (!self.tool_policy.allows(name)).then(|| name.clone())
+            })
+            .collect();
         let executable_tool_calls: Vec<_> = tool_calls
             .iter()
             .zip(&tool_call_malformed_reasons)
-            .filter(|(_, reason)| reason.is_none())
-            .map(|(call, _)| call.clone())
+            .zip(&policy_denied_tool_names)
+            .filter(|((_, malformed_reason), denied_name)| malformed_reason.is_none() && denied_name.is_none())
+            .map(|((call, _), _)| call.clone())
             .collect();
 
         let (executable_results, executable_modifiers) = if executable_tool_calls.is_empty() {
@@ -606,6 +632,7 @@ impl AgentEngine {
         let (tool_results, tool_modifiers) = merge_tool_results(
             tool_calls,
             &tool_call_malformed_reasons,
+            &policy_denied_tool_names,
             executable_results,
             executable_modifiers,
         );

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -58,6 +58,7 @@ mod tests_set_config {
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
             tools: ToolRegistry::new(),
+            tool_policy: Default::default(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
             allow_list: vec![],
             hooks: None,
@@ -398,6 +399,7 @@ mod tests_phase6 {
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
             tools: ToolRegistry::new(),
+            tool_policy: Default::default(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, allow_list.clone()))),
             allow_list,
             hooks: None,
@@ -638,6 +640,7 @@ mod tests_compact {
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
             tools: ToolRegistry::new(),
+            tool_policy: Default::default(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
             allow_list: vec![],
             hooks: None,
@@ -1004,6 +1007,7 @@ mod tests_plan_mode {
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
             tools: ToolRegistry::new(),
+            tool_policy: Default::default(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, allow_list.clone()))),
             allow_list,
             hooks: None,
@@ -1211,6 +1215,7 @@ mod tests_handle_command {
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
             tools: ToolRegistry::new(),
+            tool_policy: Default::default(),
             confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
             allow_list: vec![],
             hooks: None,
@@ -1367,7 +1372,8 @@ mod tests_loop_helpers {
         let executed = vec![executed_result("ok1"), executed_result("ok2")];
         let modifiers = vec![None, None];
 
-        let (results, mods) = merge_tool_results(&calls, &reasons, executed, modifiers);
+        let denied = vec![None, None, None];
+        let (results, mods) = merge_tool_results(&calls, &reasons, &denied, executed, modifiers);
 
         assert_eq!(results.len(), 3);
         // Slot 0: synthetic malformed error result for "bad".
@@ -1395,7 +1401,8 @@ mod tests_loop_helpers {
             Some(ToolCallMalformedReason::EmptyFunctionName),
         ];
 
-        let (results, mods) = merge_tool_results(&calls, &reasons, Vec::new(), Vec::new());
+        let denied = vec![None, None];
+        let (results, mods) = merge_tool_results(&calls, &reasons, &denied, Vec::new(), Vec::new());
 
         assert_eq!(results.len(), 2);
         assert!(
@@ -1403,6 +1410,30 @@ mod tests_loop_helpers {
                 .iter()
                 .all(|r| matches!(r, ContentBlock::ToolResult { is_error: true, .. }))
         );
+        assert!(mods.iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn merge_interleaves_policy_denial_without_executing_it() {
+        let calls = vec![tool_use("denied", "ExecCommand"), tool_use("ok", "Read")];
+        let reasons = vec![None, None];
+        let denied = vec![Some("ExecCommand".to_string()), None];
+        let executed = vec![executed_result("ok")];
+
+        let (results, mods) = merge_tool_results(&calls, &reasons, &denied, executed, vec![None]);
+
+        assert!(matches!(
+            &results[0],
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error: true,
+            } if tool_use_id == "denied" && content.contains("not available")
+        ));
+        assert!(matches!(
+            &results[1],
+            ContentBlock::ToolResult { tool_use_id, is_error: false, .. } if tool_use_id == "ok"
+        ));
         assert!(mods.iter().all(Option::is_none));
     }
 
@@ -1572,5 +1603,174 @@ mod tests_loop_helpers {
         let outcome = stream_outcome("   ", StopReason::EndTurn, Vec::new());
 
         assert!(matches!(TurnOutcome::from_stream(outcome), TurnOutcome::EmptyFinal(_)));
+    }
+}
+
+#[cfg(test)]
+mod tests_tool_policy_enforcement {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use aion_protocol::events::ToolCategory;
+    use aion_providers::error::ProviderError;
+    use aion_providers::provider::LlmProvider;
+    use aion_tools::Tool;
+    use aion_tools::registry::ToolRegistry;
+    use aion_types::llm::{LlmEvent, LlmRequest};
+    use aion_types::message::ContentBlock;
+    use aion_types::tool::ToolResult;
+    use async_trait::async_trait;
+    use serde_json::{Value, json};
+
+    use super::{AgentEngine, CacheBreakDetector, CompactLevel, CompactState, ProviderCompat};
+    use crate::commands::default_registry;
+    use crate::confirm::ToolConfirmer;
+    use crate::output::OutputSink;
+    use crate::tool_policy::ToolPolicy;
+    use crate::turn::TurnKind;
+
+    struct NullOutput;
+
+    impl OutputSink for NullOutput {
+        fn emit_text_delta(&self, _: &str, _: &str) {}
+        fn emit_thinking(&self, _: &str, _: &str) {}
+        fn emit_tool_call(&self, _: &str, _: &str, _: &str) {}
+        fn emit_tool_result(&self, _: &str, _: &str, _: bool, _: &str) {}
+        fn emit_stream_start(&self, _: &str) {}
+        fn emit_stream_end(&self, _: &str, _: usize, _: u64, _: u64, _: u64, _: u64) {}
+        fn emit_error(&self, _: &str) {}
+        fn emit_info(&self, _: &str) {}
+    }
+
+    struct NullProvider;
+
+    #[async_trait]
+    impl LlmProvider for NullProvider {
+        async fn stream(&self, _: &LlmRequest) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(rx)
+        }
+    }
+
+    struct CountingTool {
+        name: &'static str,
+        executions: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for CountingTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn description(&self) -> &str {
+            "count executions"
+        }
+
+        fn input_schema(&self) -> Value {
+            json!({"type": "object"})
+        }
+
+        fn is_concurrency_safe(&self, _: &Value) -> bool {
+            true
+        }
+
+        async fn execute(&self, _: Value) -> ToolResult {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            ToolResult {
+                content: "ok".to_string(),
+                is_error: false,
+            }
+        }
+
+        fn category(&self) -> ToolCategory {
+            ToolCategory::Info
+        }
+    }
+
+    fn make_engine(read_executions: Arc<AtomicUsize>, exec_executions: Arc<AtomicUsize>) -> AgentEngine {
+        let mut tools = ToolRegistry::new();
+        tools.register(Box::new(CountingTool {
+            name: "Read",
+            executions: read_executions,
+        }));
+        tools.register(Box::new(CountingTool {
+            name: "ExecCommand",
+            executions: exec_executions,
+        }));
+
+        AgentEngine {
+            provider: Arc::new(NullProvider),
+            compat: ProviderCompat::anthropic_defaults(),
+            thinking: None,
+            system_prompt: String::new(),
+            model: "test-model".to_string(),
+            reasoning_effort: None,
+            messages: Vec::new(),
+            total_usage: Default::default(),
+            msg_id: "test-message".to_string(),
+            max_tokens: Some(4096),
+            max_turns_per_run: Some(10),
+            max_tool_call_malformed_turns: 3,
+            max_tool_call_failure_turns: 3,
+            tools,
+            tool_policy: ToolPolicy::allow_only(["Read"]),
+            confirmer: Arc::new(Mutex::new(ToolConfirmer::new(true, vec![]))),
+            allow_list: vec![],
+            hooks: None,
+            session_manager: None,
+            current_session: None,
+            output: Arc::new(NullOutput),
+            approval_manager: None,
+            protocol_writer: None,
+            compact_config: Default::default(),
+            compact_state: CompactState::new(),
+            compact_level: CompactLevel::default(),
+            toon_enabled: false,
+            plan_state: Default::default(),
+            plan_active_flag: None,
+            cache_detector: CacheBreakDetector::new(),
+            commands: default_registry(),
+        }
+    }
+
+    fn tool_use(id: &str, name: &str) -> ContentBlock {
+        ContentBlock::ToolUse {
+            id: id.to_string(),
+            name: name.to_string(),
+            input: json!({}),
+            extra: None,
+        }
+    }
+
+    #[test]
+    fn build_request_only_advertises_policy_allowed_tools() {
+        let mut engine = make_engine(Arc::new(AtomicUsize::new(0)), Arc::new(AtomicUsize::new(0)));
+
+        let request = engine.build_request(TurnKind::Normal);
+        let tool_names: Vec<_> = request.tools.iter().map(|tool| tool.name.as_str()).collect();
+
+        assert_eq!(tool_names, vec!["Read"]);
+    }
+
+    #[tokio::test]
+    async fn execute_tool_round_rejects_denied_tools_before_execution() {
+        let read_executions = Arc::new(AtomicUsize::new(0));
+        let exec_executions = Arc::new(AtomicUsize::new(0));
+        let mut engine = make_engine(Arc::clone(&read_executions), Arc::clone(&exec_executions));
+        let calls = vec![tool_use("denied", "ExecCommand"), tool_use("allowed", "Read")];
+
+        let output = engine.execute_tool_round(&calls, "").await.unwrap();
+
+        assert_eq!(exec_executions.load(Ordering::SeqCst), 0);
+        assert_eq!(read_executions.load(Ordering::SeqCst), 1);
+        assert!(matches!(
+            &output.tool_results[0],
+            ContentBlock::ToolResult { is_error: true, content, .. } if content.contains("not available")
+        ));
+        assert!(matches!(
+            &output.tool_results[1],
+            ContentBlock::ToolResult { is_error: false, .. }
+        ));
     }
 }

--- a/crates/aion-agent/src/lib.rs
+++ b/crates/aion-agent/src/lib.rs
@@ -18,6 +18,7 @@ pub mod spawn_tool;
 pub mod spawner;
 mod stream;
 mod tool_call;
+pub mod tool_policy;
 mod turn;
 pub mod vcr;
 

--- a/crates/aion-agent/src/spawner.rs
+++ b/crates/aion-agent/src/spawner.rs
@@ -17,6 +17,7 @@ use aion_types::message::TokenUsage;
 use crate::engine::AgentEngine;
 use crate::output::OutputSink;
 use crate::output::null_sink::NullSink;
+use crate::tool_policy::ToolPolicy;
 
 // Re-export from aion-types — single source of truth
 pub use aion_types::spawner::{ForkOverrides, Spawner, SubAgentConfig, SubAgentResult};
@@ -28,20 +29,19 @@ pub use aion_types::spawner::{ForkOverrides, Spawner, SubAgentConfig, SubAgentRe
 /// parent which emits them as a single `tool_result` event — matching the
 /// Claude Code pattern where only the parent writes to stdout.
 ///
-/// The parent runtime tool policy is intentionally not inherited: authorizing
-/// `Spawn` grants delegation to an independent execution context. Direct
-/// children receive their standard tool registry, while forked child access
-/// can be restricted separately through [`ForkOverrides::allowed_tools`].
+/// Children inherit the parent's runtime tool policy. Fork overrides can
+/// further narrow that policy, but cannot restore tools denied to the parent.
 pub struct AgentSpawner {
     provider: Arc<dyn LlmProvider>,
     base_config: Config,
     cwd: PathBuf,
     runtime_env: Vec<(String, String)>,
+    tool_policy: ToolPolicy,
 }
 
 impl AgentSpawner {
-    pub fn new(provider: Arc<dyn LlmProvider>, config: Config, cwd: PathBuf) -> Self {
-        Self::new_with_env(provider, config, cwd, Vec::new())
+    pub fn new(provider: Arc<dyn LlmProvider>, config: Config, cwd: PathBuf, tool_policy: ToolPolicy) -> Self {
+        Self::new_with_env(provider, config, cwd, Vec::new(), tool_policy)
     }
 
     pub fn new_with_env(
@@ -49,12 +49,14 @@ impl AgentSpawner {
         config: Config,
         cwd: PathBuf,
         runtime_env: Vec<(String, String)>,
+        tool_policy: ToolPolicy,
     ) -> Self {
         Self {
             provider,
             base_config: config,
             cwd,
             runtime_env,
+            tool_policy,
         }
     }
 
@@ -71,7 +73,8 @@ impl AgentSpawner {
 
         tracing::info!(target: "aion_agent", cwd = %self.cwd.display(), "sub-agent spawned with workspace cwd");
 
-        let tools = build_tool_registry(&[], &self.cwd, &self.runtime_env);
+        let child_policy = effective_child_tool_policy(&self.tool_policy, &[]);
+        let tools = build_tool_registry(&child_policy, &self.cwd, &self.runtime_env);
         let output: Arc<dyn OutputSink> = Arc::new(NullSink);
         let mut engine = AgentEngine::new_with_provider_and_env(
             self.provider.clone(),
@@ -81,6 +84,7 @@ impl AgentSpawner {
             self.cwd.clone(),
             self.runtime_env.clone(),
         );
+        engine.set_tool_policy(child_policy);
 
         match engine.run(&sub_config.prompt, "").await {
             Ok(result) => SubAgentResult {
@@ -132,6 +136,7 @@ impl AgentSpawner {
             base_config: self.base_config.clone(),
             cwd: self.cwd.clone(),
             runtime_env: self.runtime_env.clone(),
+            tool_policy: self.tool_policy.clone(),
         }
     }
 }
@@ -151,7 +156,8 @@ impl Spawner for AgentSpawner {
             config.model = model;
         }
 
-        let tools = build_tool_registry(&overrides.allowed_tools, &self.cwd, &self.runtime_env);
+        let child_policy = effective_child_tool_policy(&self.tool_policy, &overrides.allowed_tools);
+        let tools = build_tool_registry(&child_policy, &self.cwd, &self.runtime_env);
         let output: Arc<dyn OutputSink> = Arc::new(NullSink);
         let mut engine = AgentEngine::new_with_provider_and_env(
             self.provider.clone(),
@@ -162,6 +168,7 @@ impl Spawner for AgentSpawner {
             self.runtime_env.clone(),
         );
         engine.set_initial_reasoning_effort(overrides.effort.clone());
+        engine.set_tool_policy(child_policy);
 
         match engine.run(&sub_config.prompt, "").await {
             Ok(result) => SubAgentResult {
@@ -182,7 +189,20 @@ impl Spawner for AgentSpawner {
     }
 }
 
-fn build_tool_registry(allowed: &[String], cwd: &Path, runtime_env: &[(String, String)]) -> ToolRegistry {
+fn effective_child_tool_policy(parent: &ToolPolicy, allowed_tools: &[String]) -> ToolPolicy {
+    if allowed_tools.is_empty() {
+        return parent.clone();
+    }
+
+    ToolPolicy::allow_only(
+        allowed_tools
+            .iter()
+            .filter(|tool_name| parent.allows(tool_name))
+            .cloned(),
+    )
+}
+
+fn build_tool_registry(policy: &ToolPolicy, cwd: &Path, runtime_env: &[(String, String)]) -> ToolRegistry {
     let all_tools: Vec<(&str, Box<dyn aion_tools::Tool>)> = vec![
         ("Read", Box::new(ReadTool::new(None))),
         ("Write", Box::new(WriteTool::new(None))),
@@ -197,7 +217,7 @@ fn build_tool_registry(allowed: &[String], cwd: &Path, runtime_env: &[(String, S
 
     let mut registry = ToolRegistry::new();
     for (name, tool) in all_tools {
-        if allowed.is_empty() || allowed.iter().any(|a| a.as_str() == name) {
+        if policy.allows(name) {
             registry.register(tool);
         }
     }

--- a/crates/aion-agent/src/spawner.rs
+++ b/crates/aion-agent/src/spawner.rs
@@ -27,6 +27,11 @@ pub use aion_types::spawner::{ForkOverrides, Spawner, SubAgentConfig, SubAgentRe
 /// discarded.  Results are collected via `engine.run()` and returned to the
 /// parent which emits them as a single `tool_result` event — matching the
 /// Claude Code pattern where only the parent writes to stdout.
+///
+/// The parent runtime tool policy is intentionally not inherited: authorizing
+/// `Spawn` grants delegation to an independent execution context. Direct
+/// children receive their standard tool registry, while forked child access
+/// can be restricted separately through [`ForkOverrides::allowed_tools`].
 pub struct AgentSpawner {
     provider: Arc<dyn LlmProvider>,
     base_config: Config,

--- a/crates/aion-agent/src/spawner_test.rs
+++ b/crates/aion-agent/src/spawner_test.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[cfg(test)]
 mod phase7_tests {
-    use super::{ForkOverrides, SubAgentConfig, build_tool_registry};
+    use super::{ForkOverrides, SubAgentConfig, ToolPolicy, build_tool_registry, effective_child_tool_policy};
 
     #[test]
     fn tc_7_1_fork_overrides_default_values() {
@@ -13,20 +13,42 @@ mod phase7_tests {
     }
 
     #[test]
-    fn tc_7_40_build_tool_registry_empty_allowed_registers_all() {
-        let registry = build_tool_registry(&[], &std::env::temp_dir(), &[]);
+    fn tc_7_40_build_tool_registry_unrestricted_registers_all() {
+        let registry = build_tool_registry(&ToolPolicy::Unrestricted, &std::env::temp_dir(), &[]);
         for name in &["Read", "Write", "Edit", "ExecCommand", "Grep", "Glob"] {
             assert!(registry.get(name).is_some(), "tool '{name}' should be registered");
         }
     }
 
     #[test]
-    fn tc_7_43_build_tool_registry_filters_to_allowed() {
-        let allowed = vec!["ExecCommand".to_string(), "Read".to_string()];
-        let registry = build_tool_registry(&allowed, &std::env::temp_dir(), &[]);
+    fn tc_7_43_build_tool_registry_filters_to_policy() {
+        let policy = ToolPolicy::allow_only(["ExecCommand", "Read"]);
+        let registry = build_tool_registry(&policy, &std::env::temp_dir(), &[]);
         assert!(registry.get("ExecCommand").is_some());
         assert!(registry.get("Read").is_some());
         assert!(registry.get("Write").is_none());
+    }
+
+    #[test]
+    fn fork_overrides_can_only_narrow_parent_policy() {
+        let parent = ToolPolicy::allow_only(["Read", "Grep", "Spawn"]);
+        let allowed_tools = vec!["Read".to_string(), "ExecCommand".to_string()];
+
+        let child = effective_child_tool_policy(&parent, &allowed_tools);
+
+        assert!(child.allows("Read"));
+        assert!(!child.allows("Grep"));
+        assert!(!child.allows("ExecCommand"));
+        assert!(!child.allows("Write"));
+    }
+
+    #[test]
+    fn empty_fork_override_inherits_parent_policy() {
+        let parent = ToolPolicy::allow_only(["Read", "Grep", "Spawn"]);
+
+        let child = effective_child_tool_policy(&parent, &[]);
+
+        assert_eq!(child, parent);
     }
 
     #[test]

--- a/crates/aion-agent/src/tool_call.rs
+++ b/crates/aion-agent/src/tool_call.rs
@@ -159,12 +159,14 @@ pub(crate) fn tool_call_failure_fingerprint(tool_calls: &[ContentBlock]) -> Opti
 /// into the original `tool_calls` order.
 ///
 /// `tool_call_malformed_reasons[i]` is `Some` when call `i` was malformed (and gets a
-/// synthetic error result), otherwise the next executed result/modifier is
-/// pulled from the `executable_*` iterators. Kept as a free function so the
-/// interleaving invariant can be unit-tested in isolation.
+/// synthetic error result). `policy_denied_tool_names[i]` is `Some` when the
+/// runtime policy rejected an otherwise valid call. Remaining calls consume
+/// the next result/modifier from the `executable_*` iterators. Kept as a free
+/// function so the interleaving invariant can be unit-tested in isolation.
 pub(crate) fn merge_tool_results(
     tool_calls: &[ContentBlock],
     tool_call_malformed_reasons: &[Option<ToolCallMalformedReason>],
+    policy_denied_tool_names: &[Option<String>],
     executable_results: Vec<ContentBlock>,
     executable_modifiers: Vec<Option<ContextModifier>>,
 ) -> (Vec<ContentBlock>, Vec<Option<ContextModifier>>) {
@@ -173,7 +175,11 @@ pub(crate) fn merge_tool_results(
     let mut tool_results = Vec::with_capacity(tool_calls.len());
     let mut tool_modifiers = Vec::with_capacity(tool_calls.len());
 
-    for (call, reason) in tool_calls.iter().zip(tool_call_malformed_reasons) {
+    for ((call, reason), denied_name) in tool_calls
+        .iter()
+        .zip(tool_call_malformed_reasons)
+        .zip(policy_denied_tool_names)
+    {
         if let Some(reason) = reason {
             let ContentBlock::ToolUse { id, name, .. } = call else {
                 continue;
@@ -192,6 +198,26 @@ pub(crate) fn merge_tool_results(
                     "Malformed tool call: {}. Re-issue the tool call with a non-empty {} if still needed, or answer in text.",
                     reason.description(),
                     reason.reissue_field()
+                ),
+                is_error: true,
+            });
+            tool_modifiers.push(None);
+        } else if let Some(denied_name) = denied_name {
+            let ContentBlock::ToolUse { id, .. } = call else {
+                continue;
+            };
+            tracing::warn!(
+                target: "aion_agent",
+                event = "agent.tool_policy.denied",
+                tool_call_id = %id,
+                tool = %denied_name,
+                "rejected tool call by runtime policy"
+            );
+
+            tool_results.push(ContentBlock::ToolResult {
+                tool_use_id: id.clone(),
+                content: format!(
+                    "Tool '{denied_name}' is not available in this runtime. Use an available tool or answer in text."
                 ),
                 is_error: true,
             });

--- a/crates/aion-agent/src/tool_policy.rs
+++ b/crates/aion-agent/src/tool_policy.rs
@@ -1,0 +1,35 @@
+use std::collections::BTreeSet;
+
+/// Runtime authorization policy for tools registered with an agent engine.
+///
+/// The policy is enforced both when tool definitions are sent to the model and
+/// immediately before a requested tool is executed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ToolPolicy {
+    /// Every registered tool is available.
+    #[default]
+    Unrestricted,
+    /// Only tools whose exact names are present in the set are available.
+    AllowOnly(BTreeSet<String>),
+}
+
+impl ToolPolicy {
+    pub fn allow_only<I, S>(tool_names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self::AllowOnly(tool_names.into_iter().map(Into::into).collect())
+    }
+
+    pub fn allows(&self, tool_name: &str) -> bool {
+        match self {
+            Self::Unrestricted => true,
+            Self::AllowOnly(tool_names) => tool_names.contains(tool_name),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "tool_policy_test.rs"]
+mod tool_policy_test;

--- a/crates/aion-agent/src/tool_policy_test.rs
+++ b/crates/aion-agent/src/tool_policy_test.rs
@@ -1,0 +1,16 @@
+use super::ToolPolicy;
+
+#[test]
+fn unrestricted_policy_allows_every_tool() {
+    assert!(ToolPolicy::Unrestricted.allows("ExecCommand"));
+}
+
+#[test]
+fn allow_only_policy_matches_exact_tool_names() {
+    let policy = ToolPolicy::allow_only(["Read", "team_send_message"]);
+
+    assert!(policy.allows("Read"));
+    assert!(policy.allows("team_send_message"));
+    assert!(!policy.allows("Write"));
+    assert!(!policy.allows("read"));
+}

--- a/crates/aion-agent/tests/spawn_description_test.rs
+++ b/crates/aion-agent/tests/spawn_description_test.rs
@@ -9,12 +9,18 @@ use std::sync::Arc;
 
 use aion_agent::spawn_tool::SpawnTool;
 use aion_agent::spawner::AgentSpawner;
+use aion_agent::tool_policy::ToolPolicy;
 use aion_tools::Tool;
 use common::{MockLlmProvider, test_config};
 
 fn make_spawn_tool() -> SpawnTool {
     let provider = Arc::new(MockLlmProvider::with_text_response("ok"));
-    let spawner = Arc::new(AgentSpawner::new(provider, test_config(), std::env::temp_dir()));
+    let spawner = Arc::new(AgentSpawner::new(
+        provider,
+        test_config(),
+        std::env::temp_dir(),
+        ToolPolicy::Unrestricted,
+    ));
     SpawnTool::new(spawner)
 }
 

--- a/crates/aion-agent/tests/spawn_test.rs
+++ b/crates/aion-agent/tests/spawn_test.rs
@@ -1,11 +1,37 @@
 mod common;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use aion_agent::spawner::{AgentSpawner, SubAgentConfig};
-use aion_types::llm::LlmEvent;
+use aion_agent::tool_policy::ToolPolicy;
+use aion_providers::{LlmProvider, ProviderError};
+use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{StopReason, TokenUsage};
+use async_trait::async_trait;
 use common::{MockLlmProvider, test_config};
+use tokio::sync::mpsc;
+
+struct ToolRecordingProvider {
+    tool_names: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl LlmProvider for ToolRecordingProvider {
+    async fn stream(&self, request: &LlmRequest) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+        let mut tool_names: Vec<_> = request.tools.iter().map(|tool| tool.name.clone()).collect();
+        tool_names.sort();
+        *self.tool_names.lock().unwrap() = tool_names;
+
+        let (tx, rx) = mpsc::channel(2);
+        tx.try_send(LlmEvent::TextDelta("done".to_string())).unwrap();
+        tx.try_send(LlmEvent::Done {
+            stop_reason: StopReason::EndTurn,
+            usage: TokenUsage::default(),
+        })
+        .unwrap();
+        Ok(rx)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Helper: build a minimal SubAgentConfig for testing
@@ -29,7 +55,7 @@ fn make_sub_config(name: &str) -> SubAgentConfig {
 #[tokio::test]
 async fn test_spawn_single_agent() {
     let provider = Arc::new(MockLlmProvider::with_text_response("Sub-agent done"));
-    let spawner = AgentSpawner::new(provider, test_config(), std::env::temp_dir());
+    let spawner = AgentSpawner::new(provider, test_config(), std::env::temp_dir(), ToolPolicy::Unrestricted);
 
     let result = spawner.spawn_one(make_sub_config("agent-1")).await;
 
@@ -37,6 +63,25 @@ async fn test_spawn_single_agent() {
     assert!(!result.is_error, "expected no error, got: {}", result.text);
     assert_eq!(result.turns, 1);
     assert_eq!(result.name, "agent-1");
+}
+
+#[tokio::test]
+async fn restricted_parent_policy_limits_spawned_agent_tools() {
+    let tool_names = Arc::new(Mutex::new(Vec::new()));
+    let provider = Arc::new(ToolRecordingProvider {
+        tool_names: Arc::clone(&tool_names),
+    });
+    let spawner = AgentSpawner::new(
+        provider,
+        test_config(),
+        std::env::temp_dir(),
+        ToolPolicy::allow_only(["Spawn", "Read", "Grep"]),
+    );
+
+    let result = spawner.spawn_one(make_sub_config("restricted-agent")).await;
+
+    assert!(!result.is_error, "expected restricted sub-agent to complete");
+    assert_eq!(*tool_names.lock().unwrap(), vec!["Grep", "Read"]);
 }
 
 /// Parallel sub-agents all complete successfully and return distinct results.
@@ -64,7 +109,7 @@ async fn test_spawn_parallel_agents() {
         make_turn("result-C"),
     ]));
 
-    let spawner = AgentSpawner::new(provider, test_config(), std::env::temp_dir());
+    let spawner = AgentSpawner::new(provider, test_config(), std::env::temp_dir(), ToolPolicy::Unrestricted);
 
     let sub_configs = vec![
         make_sub_config("agent-A"),
@@ -125,7 +170,12 @@ async fn test_spawn_shares_provider() {
 
     // Both sub-agents share the same underlying provider via Arc.
     let provider_dyn: Arc<dyn aion_providers::LlmProvider> = provider;
-    let spawner = AgentSpawner::new(Arc::clone(&provider_dyn), test_config(), std::env::temp_dir());
+    let spawner = AgentSpawner::new(
+        Arc::clone(&provider_dyn),
+        test_config(),
+        std::env::temp_dir(),
+        ToolPolicy::Unrestricted,
+    );
 
     let result1 = spawner.spawn_one(make_sub_config("seq-1")).await;
     let result2 = spawner.spawn_one(make_sub_config("seq-2")).await;
@@ -145,7 +195,7 @@ async fn test_spawn_agent_error_captured() {
         "provider failed".to_string(),
     )]));
 
-    let spawner = AgentSpawner::new(provider, test_config(), std::env::temp_dir());
+    let spawner = AgentSpawner::new(provider, test_config(), std::env::temp_dir(), ToolPolicy::Unrestricted);
 
     let result = spawner.spawn_one(make_sub_config("error-agent")).await;
 

--- a/crates/aion-types/src/spawner.rs
+++ b/crates/aion-types/src/spawner.rs
@@ -24,7 +24,7 @@ pub struct ForkOverrides {
     pub model: Option<String>,
     /// Reasoning effort ("low"/"medium"/"high"/"max").
     pub effort: Option<String>,
-    /// Restrict registered tools to this list; empty = all built-in tools.
+    /// Further restrict inherited tools to this list; empty = inherit the parent policy.
     pub allowed_tools: Vec<String>,
 }
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2,7 +2,7 @@
 
 ## Sub-Agent Spawning
 
-The LLM can use the Spawn tool to create independent sub-agents that run tasks in parallel. Each sub-agent has its own conversation context and full tool set, but shares the parent agent's LLM provider (connection pool reuse).
+The LLM can use the Spawn tool to create independent sub-agents that run tasks in parallel. Each sub-agent has its own conversation context, inherits the parent agent's runtime tool policy, and shares the parent agent's LLM provider (connection pool reuse). Fork-mode overrides can further restrict inherited tools but cannot restore tools denied to the parent.
 
 ### Use Cases
 
@@ -21,6 +21,7 @@ The LLM can use the Spawn tool to create independent sub-agents that run tasks i
 ### Behavior
 
 - Sub-agents auto-approve all tool calls (no confirmation prompts)
+- Sub-agents cannot exceed the parent agent's runtime tool policy
 - Sub-agents do not save sessions
 - Sub-agents run silently (no stdout output)
 - All results are merged and returned to the parent agent


### PR DESCRIPTION
## Summary

- Add an opt-in `ToolPolicy` to `aion-agent`, with unrestricted behavior as the default for existing callers.
- Filter advertised tool definitions so the model only sees tools authorized by the runtime policy.
- Re-check authorization immediately before execution and return a safe tool error when a denied tool call is received.
- Keep system-prompt tool guidance, skill reminders, and the prompt cache aligned with the active policy.

## Why

Host applications need a runtime-enforced tool boundary for specialized roles. Prompt instructions alone cannot guarantee that an unavailable or disallowed tool will never be requested, so authorization must be applied both when building the LLM request and at the execution boundary.

## Compatibility

- Existing callers remain unrestricted unless they explicitly set a policy.
- No persisted configuration, session format, protocol, or database schema changes.
- Denied-call logs include tool metadata but do not include tool inputs or other sensitive payloads.

## Validation

- `just push -u origin jiahe/fix/team-lead-tool-policy`
  - cargo fix/clippy/fmt passed
  - 2125 tests passed, 2 skipped
  - Hakari dependency checks passed
- Added focused tests for exact-name allowlists, advertised-tool filtering, pre-execution rejection, result ordering, prompt guidance, skill visibility, and cache invalidation.

## Related PRs

- iOfficeAI/AionCore#616 consumes this API for the Team Leader runtime policy.
