### PR TITLE
fix(providers): add sanitized stream diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "tracing-subscriber",
  "url",
  "wiremock",
  "workspace-hack",

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -455,6 +455,14 @@ impl AgentEngine {
                         .await;
                 }
                 TurnOutcome::EmptyFinal(outcome) => {
+                    warn!(
+                        target: "aion_agent",
+                        stop_reason = ?outcome.stop_reason,
+                        assistant_text_bytes = outcome.assistant_text.len(),
+                        thinking_text_bytes = outcome.thinking_text.len(),
+                        tool_call_count = outcome.tool_calls.len(),
+                        "provider turn produced no valid final answer; retrying finalization"
+                    );
                     return self
                         .finalize_once(
                             FinalizationReason::EmptyFinal,
@@ -730,15 +738,25 @@ impl AgentEngine {
     }
 
     async fn run_turn(&mut self, kind: TurnKind) -> Result<StreamOutcome, AgentError> {
-        // Run multi-level compaction before each API call.
-        // On the first model turn last_input_tokens is 0 so neither
-        // autocompact nor emergency will fire.
-        self.run_compaction().await?;
-        let request = self.build_request(kind);
-        let mut rx = self.provider.stream(&request).await?;
-        let outcome = self.consume_stream(&mut rx).await?;
-        self.record_turn_usage(&outcome.usage);
-        Ok(outcome)
+        let span = info_span!(
+            target: "aion_agent",
+            "llm_generation",
+            generation_phase = kind.diagnostic_phase(),
+            tools_disabled = kind.disable_tools(),
+        );
+        async {
+            // Run multi-level compaction before each API call.
+            // On the first model turn last_input_tokens is 0 so neither
+            // autocompact nor emergency will fire.
+            self.run_compaction().await?;
+            let request = self.build_request(kind);
+            let mut rx = self.provider.stream(&request).await?;
+            let outcome = self.consume_stream(&mut rx).await?;
+            self.record_turn_usage(&outcome.usage);
+            Ok(outcome)
+        }
+        .instrument(span)
+        .await
     }
 
     async fn finalize_once(
@@ -766,6 +784,15 @@ impl AgentEngine {
             });
         }
 
+        warn!(
+            target: "aion_agent",
+            finalization_reason = ?reason,
+            stop_reason = ?outcome.stop_reason,
+            assistant_text_bytes = outcome.assistant_text.len(),
+            thinking_text_bytes = outcome.thinking_text.len(),
+            tool_call_count = outcome.tool_calls.len(),
+            "provider finalization did not produce a valid final answer"
+        );
         let fallback = reason.fallback_prompt();
         self.output.emit_error(fallback);
         let fallback_text = if combined_text.trim().is_empty() {

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -1806,9 +1806,11 @@ mod tests_loop_helpers {
     fn turn_kind_finalization_has_control_prompt_and_disables_tools() {
         assert!(TurnKind::Normal.control_prompt().is_none());
         assert!(!TurnKind::Normal.disable_tools());
+        assert_eq!(TurnKind::Normal.diagnostic_phase(), "normal");
 
         let kind = TurnKind::Finalization(FinalizationReason::TurnBudget);
         assert!(kind.disable_tools());
+        assert_eq!(kind.diagnostic_phase(), "turn_budget_finalization");
         assert!(
             kind.control_prompt()
                 .expect("finalization must have a control prompt")
@@ -1818,20 +1820,22 @@ mod tests_loop_helpers {
 
     #[test]
     fn turn_kind_max_tokens_prompt_names_truncation() {
-        let prompt = TurnKind::Finalization(FinalizationReason::MaxTokens)
+        let kind = TurnKind::Finalization(FinalizationReason::MaxTokens);
+        let prompt = kind
             .control_prompt()
             .expect("max token continuation must have a prompt");
 
+        assert_eq!(kind.diagnostic_phase(), "max_tokens_finalization");
         assert!(prompt.contains("previous response was cut off"));
         assert!(prompt.contains("Finish the answer"));
     }
 
     #[test]
     fn turn_kind_empty_final_prompt_requests_visible_answer() {
-        let prompt = TurnKind::Finalization(FinalizationReason::EmptyFinal)
-            .control_prompt()
-            .expect("empty final nudge must have a prompt");
+        let kind = TurnKind::Finalization(FinalizationReason::EmptyFinal);
+        let prompt = kind.control_prompt().expect("empty final nudge must have a prompt");
 
+        assert_eq!(kind.diagnostic_phase(), "empty_final_retry");
         assert!(prompt.contains("visible answer text"));
         assert!(prompt.contains("Do not send reasoning only"));
     }

--- a/crates/aion-agent/src/turn.rs
+++ b/crates/aion-agent/src/turn.rs
@@ -72,6 +72,15 @@ impl TurnKind {
             ),
         }
     }
+
+    pub(crate) fn diagnostic_phase(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Finalization(FinalizationReason::TurnBudget) => "turn_budget_finalization",
+            Self::Finalization(FinalizationReason::MaxTokens) => "max_tokens_finalization",
+            Self::Finalization(FinalizationReason::EmptyFinal) => "empty_final_retry",
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/aion-providers/Cargo.toml
+++ b/crates/aion-providers/Cargo.toml
@@ -33,6 +33,7 @@ tracing.workspace        = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
-wiremock.workspace   = true
-tokio-test.workspace = true
-insta.workspace      = true
+wiremock.workspace           = true
+tokio-test.workspace         = true
+insta.workspace              = true
+tracing-subscriber.workspace = true

--- a/crates/aion-providers/src/composed.rs
+++ b/crates/aion-providers/src/composed.rs
@@ -34,7 +34,15 @@ impl LlmProvider for ComposedProvider {
     async fn stream(&self, request: &LlmRequest) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
         let (body, tool_wire_shape) = self.transport.project_body(request, &self.compat)?;
 
-        tracing::debug!(target: "aion_providers", body = %serde_json::to_string_pretty(&body).unwrap_or_default(), "outgoing request");
+        tracing::debug!(
+            target: "aion_providers",
+            model = %request.model,
+            message_count = request.messages.len(),
+            tool_count = request.tools.len(),
+            max_tokens = ?request.max_tokens,
+            thinking_configured = request.thinking.is_some(),
+            "provider request projected"
+        );
 
         let transport = self.transport.clone();
         let compat = self.compat.clone();

--- a/crates/aion-providers/src/lib.rs
+++ b/crates/aion-providers/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod parser;
 pub(crate) mod projector;
 pub mod provider;
 pub mod retry;
+pub(crate) mod stream_diagnostics;
 pub(crate) mod stream_process;
 pub(crate) mod stream_runner;
 mod tool_call_sanitize;

--- a/crates/aion-providers/src/lib.rs
+++ b/crates/aion-providers/src/lib.rs
@@ -13,6 +13,8 @@ pub mod retry;
 pub(crate) mod stream_diagnostics;
 pub(crate) mod stream_process;
 pub(crate) mod stream_runner;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod tool_call_sanitize;
 pub(crate) mod transport;
 pub mod vertex;

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -7,6 +9,7 @@ use aion_types::message::{StopReason, TokenUsage};
 
 use crate::composed::ComposedProvider;
 use crate::openai_messages::generate_call_id;
+use crate::stream_diagnostics::{OpenAiStreamDiagnostics, StreamTermination};
 use crate::transport::{OpenAiTransport, ProviderTransport};
 use crate::{LlmProvider, ProviderError};
 use aion_config::compat::ProviderCompat;
@@ -43,6 +46,7 @@ pub(crate) struct StreamState {
     tool_calls: Vec<ToolCallAccumulator>,
     input_tokens: u64,
     output_tokens: u64,
+    diagnostics: OpenAiStreamDiagnostics,
     /// Deferred Done event: populated when finish_reason arrives, emitted on
     /// [DONE] so the final usage-only chunk has a chance to update token counts.
     pending_done: Option<LlmEvent>,
@@ -54,6 +58,7 @@ impl StreamState {
             tool_calls: Vec::new(),
             input_tokens: 0,
             output_tokens: 0,
+            diagnostics: OpenAiStreamDiagnostics::default(),
             pending_done: None,
         }
     }
@@ -90,6 +95,15 @@ impl StreamState {
         }
         &mut self.tool_calls[index]
     }
+
+    pub(crate) fn diagnostics_mut(&mut self) -> &mut OpenAiStreamDiagnostics {
+        &mut self.diagnostics
+    }
+
+    pub(crate) fn emit_diagnostics(&self, termination: StreamTermination, duration: Duration) {
+        self.diagnostics
+            .emit_summary(termination, duration, self.input_tokens, self.output_tokens);
+    }
 }
 
 pub(crate) fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id: bool) -> Vec<LlmEvent> {
@@ -97,8 +111,12 @@ pub(crate) fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id:
 
     let json: Value = match serde_json::from_str(data) {
         Ok(v) => v,
-        Err(_) => return events,
+        Err(_) => {
+            state.diagnostics.observe_invalid_json();
+            return events;
+        }
     };
+    state.diagnostics.observe_json(&json);
 
     // Extract usage if present
     if let Some(usage) = json.get("usage") {

--- a/crates/aion-providers/src/stream_diagnostics.rs
+++ b/crates/aion-providers/src/stream_diagnostics.rs
@@ -1,0 +1,356 @@
+use std::time::Duration;
+
+use aion_types::llm::LlmEvent;
+use reqwest::header::HeaderMap;
+use serde_json::Value;
+use tracing::Level;
+
+use crate::framing::{Frame, FrameKind};
+
+const REQUEST_ID_HEADERS: &[&str] = &["x-request-id", "request-id"];
+const MAX_REQUEST_ID_CHARS: usize = 128;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum FinishReasonKind {
+    #[default]
+    Missing,
+    Stop,
+    ToolCalls,
+    Length,
+    ContentFilter,
+    FunctionCall,
+    Other,
+}
+
+impl FinishReasonKind {
+    fn from_wire(value: &str) -> Self {
+        match value {
+            "stop" => Self::Stop,
+            "tool_calls" => Self::ToolCalls,
+            "length" => Self::Length,
+            "content_filter" => Self::ContentFilter,
+            "function_call" => Self::FunctionCall,
+            _ => Self::Other,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::Stop => "stop",
+            Self::ToolCalls => "tool_calls",
+            Self::Length => "length",
+            Self::ContentFilter => "content_filter",
+            Self::FunctionCall => "function_call",
+            Self::Other => "other",
+        }
+    }
+
+    fn is_supported(self) -> bool {
+        matches!(self, Self::Stop | Self::ToolCalls | Self::Length)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StreamTermination {
+    Done,
+    Eof,
+    ConsumerDropped,
+    ConnectionError,
+}
+
+impl StreamTermination {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Done => "done",
+            Self::Eof => "eof",
+            Self::ConsumerDropped => "consumer_dropped",
+            Self::ConnectionError => "connection_error",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct OpenAiStreamDiagnostics {
+    // HTTP and framing.
+    http_status: u16,
+    request_id: Option<String>,
+    network_chunk_count: u64,
+    network_bytes: u64,
+    sse_frame_count: u64,
+    sse_data_frame_count: u64,
+    done_seen: bool,
+
+    // JSON envelope shape.
+    valid_json_frame_count: u64,
+    invalid_json_frame_count: u64,
+    choices_field_seen: bool,
+    choices_array_frame_count: u64,
+    empty_choices_frame_count: u64,
+    delta_field_seen: bool,
+    usage_field_seen: bool,
+    finish_reason_field_seen: bool,
+    finish_reason: FinishReasonKind,
+
+    // Recognized OpenAI-compatible output fields. Only presence and sizes are
+    // retained; payload values are never stored.
+    content_field_seen: bool,
+    content_delta_count: u64,
+    content_bytes: u64,
+    content_non_whitespace_seen: bool,
+    reasoning_content_field_seen: bool,
+    reasoning_delta_count: u64,
+    reasoning_bytes: u64,
+    tool_calls_field_seen: bool,
+    tool_call_delta_count: u64,
+    tool_call_count: u64,
+
+    // Common alternative response shapes that the current projector does not
+    // consume. Record booleans only so compatibility gaps are diagnosable
+    // without logging model output.
+    delta_reasoning_field_seen: bool,
+    delta_thinking_field_seen: bool,
+    delta_analysis_field_seen: bool,
+    delta_output_text_field_seen: bool,
+    choice_message_field_seen: bool,
+    choice_message_content_field_seen: bool,
+    choice_text_field_seen: bool,
+    top_level_output_field_seen: bool,
+    top_level_output_text_field_seen: bool,
+    top_level_type_field_seen: bool,
+    top_level_delta_field_seen: bool,
+
+    // Provider-neutral events produced by the parser.
+    parsed_text_event_count: u64,
+    parsed_thinking_event_count: u64,
+    parsed_tool_call_event_count: u64,
+    parsed_done_event_count: u64,
+}
+
+impl OpenAiStreamDiagnostics {
+    pub(crate) fn observe_response(&mut self, status: u16, headers: &HeaderMap) {
+        self.http_status = status;
+        self.request_id = REQUEST_ID_HEADERS.iter().find_map(|name| {
+            let value = headers.get(*name)?.to_str().ok()?;
+            let sanitized = value
+                .chars()
+                .filter(|character| !character.is_control())
+                .take(MAX_REQUEST_ID_CHARS)
+                .collect::<String>();
+            (!sanitized.is_empty()).then_some(sanitized)
+        });
+    }
+
+    pub(crate) fn observe_network_chunk(&mut self, byte_count: usize) {
+        self.network_chunk_count = self.network_chunk_count.saturating_add(1);
+        self.network_bytes = self.network_bytes.saturating_add(usize_to_u64(byte_count));
+    }
+
+    pub(crate) fn observe_frame(&mut self, frame: &Frame) {
+        self.sse_frame_count = self.sse_frame_count.saturating_add(1);
+        match frame.kind {
+            FrameKind::Data => {
+                self.sse_data_frame_count = self.sse_data_frame_count.saturating_add(1);
+            }
+            FrameKind::Done => self.done_seen = true,
+        }
+    }
+
+    pub(crate) fn observe_invalid_json(&mut self) {
+        self.invalid_json_frame_count = self.invalid_json_frame_count.saturating_add(1);
+    }
+
+    pub(crate) fn observe_json(&mut self, json: &Value) {
+        self.valid_json_frame_count = self.valid_json_frame_count.saturating_add(1);
+        self.usage_field_seen |= json.get("usage").is_some();
+        self.top_level_output_field_seen |= json.get("output").is_some();
+        self.top_level_output_text_field_seen |= json.get("output_text").is_some();
+        self.top_level_type_field_seen |= json.get("type").is_some();
+        self.top_level_delta_field_seen |= json.get("delta").is_some();
+
+        let Some(choices) = json.get("choices") else {
+            return;
+        };
+        self.choices_field_seen = true;
+
+        let Some(choices) = choices.as_array() else {
+            return;
+        };
+        self.choices_array_frame_count = self.choices_array_frame_count.saturating_add(1);
+        if choices.is_empty() {
+            self.empty_choices_frame_count = self.empty_choices_frame_count.saturating_add(1);
+            return;
+        }
+
+        let choice = &choices[0];
+        self.choice_message_field_seen |= choice.get("message").is_some();
+        self.choice_message_content_field_seen |= choice
+            .get("message")
+            .and_then(|message| message.get("content"))
+            .is_some();
+        self.choice_text_field_seen |= choice.get("text").is_some();
+
+        if let Some(finish_reason) = choice.get("finish_reason") {
+            self.finish_reason_field_seen = true;
+            if let Some(finish_reason) = finish_reason.as_str() {
+                self.finish_reason = FinishReasonKind::from_wire(finish_reason);
+            }
+        }
+
+        let Some(delta) = choice.get("delta") else {
+            return;
+        };
+        self.delta_field_seen = true;
+        self.delta_reasoning_field_seen |= delta.get("reasoning").is_some();
+        self.delta_thinking_field_seen |= delta.get("thinking").is_some();
+        self.delta_analysis_field_seen |= delta.get("analysis").is_some();
+        self.delta_output_text_field_seen |= delta.get("output_text").is_some();
+
+        if let Some(content) = delta.get("content") {
+            self.content_field_seen = true;
+            if let Some(content) = content.as_str().filter(|content| !content.is_empty()) {
+                self.content_delta_count = self.content_delta_count.saturating_add(1);
+                self.content_bytes = self.content_bytes.saturating_add(usize_to_u64(content.len()));
+                self.content_non_whitespace_seen |= content.chars().any(|character| !character.is_whitespace());
+            }
+        }
+
+        if let Some(reasoning) = delta.get("reasoning_content") {
+            self.reasoning_content_field_seen = true;
+            if let Some(reasoning) = reasoning.as_str().filter(|reasoning| !reasoning.is_empty()) {
+                self.reasoning_delta_count = self.reasoning_delta_count.saturating_add(1);
+                self.reasoning_bytes = self.reasoning_bytes.saturating_add(usize_to_u64(reasoning.len()));
+            }
+        }
+
+        if let Some(tool_calls) = delta.get("tool_calls") {
+            self.tool_calls_field_seen = true;
+            self.tool_call_delta_count = self.tool_call_delta_count.saturating_add(1);
+            if let Some(tool_calls) = tool_calls.as_array() {
+                self.tool_call_count = self.tool_call_count.saturating_add(usize_to_u64(tool_calls.len()));
+            }
+        }
+    }
+
+    pub(crate) fn observe_event(&mut self, event: &LlmEvent) {
+        match event {
+            LlmEvent::TextDelta(_) => {
+                self.parsed_text_event_count = self.parsed_text_event_count.saturating_add(1);
+            }
+            LlmEvent::ThinkingDelta(_) => {
+                self.parsed_thinking_event_count = self.parsed_thinking_event_count.saturating_add(1);
+            }
+            LlmEvent::ToolUse { .. } => {
+                self.parsed_tool_call_event_count = self.parsed_tool_call_event_count.saturating_add(1);
+            }
+            LlmEvent::Done { .. } => {
+                self.parsed_done_event_count = self.parsed_done_event_count.saturating_add(1);
+            }
+            LlmEvent::ThinkingSignature(_) | LlmEvent::Error(_) => {}
+        }
+    }
+
+    pub(crate) fn emit_summary(
+        &self,
+        termination: StreamTermination,
+        duration: Duration,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) {
+        let duration_ms = u128_to_u64(duration.as_millis());
+        let request_id = self.request_id.as_deref().unwrap_or("none");
+        let empty_answer = !self.content_non_whitespace_seen && self.parsed_tool_call_event_count == 0;
+        let incomplete_stream = termination != StreamTermination::Done || !self.done_seen;
+        let malformed_json = self.invalid_json_frame_count > 0;
+        let unexpected_finish_reason = !self.finish_reason.is_supported();
+        let anomalous = empty_answer || incomplete_stream || malformed_json || unexpected_finish_reason;
+
+        macro_rules! emit {
+            ($level:expr) => {
+                tracing::event!(
+                    target: "aion_providers",
+                    $level,
+                    diagnostic_event = "provider_stream_summary",
+                    protocol = "openai_sse",
+                    http_status = self.http_status,
+                    request_id,
+                    duration_ms,
+                    termination = termination.as_str(),
+                    network_chunk_count = self.network_chunk_count,
+                    network_bytes = self.network_bytes,
+                    sse_frame_count = self.sse_frame_count,
+                    sse_data_frame_count = self.sse_data_frame_count,
+                    done_seen = self.done_seen,
+                    valid_json_frame_count = self.valid_json_frame_count,
+                    invalid_json_frame_count = self.invalid_json_frame_count,
+                    choices_field_seen = self.choices_field_seen,
+                    choices_array_frame_count = self.choices_array_frame_count,
+                    empty_choices_frame_count = self.empty_choices_frame_count,
+                    delta_field_seen = self.delta_field_seen,
+                    usage_field_seen = self.usage_field_seen,
+                    input_tokens,
+                    output_tokens,
+                    finish_reason_field_seen = self.finish_reason_field_seen,
+                    finish_reason = self.finish_reason.as_str(),
+                    content_field_seen = self.content_field_seen,
+                    content_delta_count = self.content_delta_count,
+                    content_bytes = self.content_bytes,
+                    content_non_whitespace_seen = self.content_non_whitespace_seen,
+                    reasoning_content_field_seen = self.reasoning_content_field_seen,
+                    reasoning_delta_count = self.reasoning_delta_count,
+                    reasoning_bytes = self.reasoning_bytes,
+                    tool_calls_field_seen = self.tool_calls_field_seen,
+                    tool_call_delta_count = self.tool_call_delta_count,
+                    tool_call_count = self.tool_call_count,
+                    delta_reasoning_field_seen = self.delta_reasoning_field_seen,
+                    delta_thinking_field_seen = self.delta_thinking_field_seen,
+                    delta_analysis_field_seen = self.delta_analysis_field_seen,
+                    delta_output_text_field_seen = self.delta_output_text_field_seen,
+                    choice_message_field_seen = self.choice_message_field_seen,
+                    choice_message_content_field_seen = self.choice_message_content_field_seen,
+                    choice_text_field_seen = self.choice_text_field_seen,
+                    top_level_output_field_seen = self.top_level_output_field_seen,
+                    top_level_output_text_field_seen = self.top_level_output_text_field_seen,
+                    top_level_type_field_seen = self.top_level_type_field_seen,
+                    top_level_delta_field_seen = self.top_level_delta_field_seen,
+                    parsed_text_event_count = self.parsed_text_event_count,
+                    parsed_thinking_event_count = self.parsed_thinking_event_count,
+                    parsed_tool_call_event_count = self.parsed_tool_call_event_count,
+                    parsed_done_event_count = self.parsed_done_event_count,
+                    empty_answer,
+                    incomplete_stream,
+                    malformed_json,
+                    unexpected_finish_reason,
+                    "provider stream response shape"
+                );
+            };
+        }
+
+        if anomalous {
+            emit!(Level::WARN);
+        } else {
+            emit!(Level::DEBUG);
+        }
+    }
+
+    #[cfg(test)]
+    fn is_anomalous(&self, termination: StreamTermination) -> bool {
+        (!self.content_non_whitespace_seen && self.parsed_tool_call_event_count == 0)
+            || termination != StreamTermination::Done
+            || !self.done_seen
+            || self.invalid_json_frame_count > 0
+            || !self.finish_reason.is_supported()
+    }
+}
+
+fn usize_to_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn u128_to_u64(value: u128) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+#[path = "stream_diagnostics_test.rs"]
+mod stream_diagnostics_test;

--- a/crates/aion-providers/src/stream_diagnostics.rs
+++ b/crates/aion-providers/src/stream_diagnostics.rs
@@ -127,6 +127,20 @@ pub(crate) struct OpenAiStreamDiagnostics {
     parsed_done_event_count: u64,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct StreamAssessment {
+    empty_answer: bool,
+    incomplete_stream: bool,
+    malformed_json: bool,
+    unexpected_finish_reason: bool,
+}
+
+impl StreamAssessment {
+    fn is_anomalous(self) -> bool {
+        self.empty_answer || self.incomplete_stream || self.malformed_json || self.unexpected_finish_reason
+    }
+}
+
 impl OpenAiStreamDiagnostics {
     pub(crate) fn observe_response(&mut self, status: u16, headers: &HeaderMap) {
         self.http_status = status;
@@ -259,11 +273,7 @@ impl OpenAiStreamDiagnostics {
     ) {
         let duration_ms = u128_to_u64(duration.as_millis());
         let request_id = self.request_id.as_deref().unwrap_or("none");
-        let empty_answer = !self.content_non_whitespace_seen && self.parsed_tool_call_event_count == 0;
-        let incomplete_stream = termination != StreamTermination::Done || !self.done_seen;
-        let malformed_json = self.invalid_json_frame_count > 0;
-        let unexpected_finish_reason = !self.finish_reason.is_supported();
-        let anomalous = empty_answer || incomplete_stream || malformed_json || unexpected_finish_reason;
+        let assessment = self.assess(termination);
 
         macro_rules! emit {
             ($level:expr) => {
@@ -317,29 +327,38 @@ impl OpenAiStreamDiagnostics {
                     parsed_thinking_event_count = self.parsed_thinking_event_count,
                     parsed_tool_call_event_count = self.parsed_tool_call_event_count,
                     parsed_done_event_count = self.parsed_done_event_count,
-                    empty_answer,
-                    incomplete_stream,
-                    malformed_json,
-                    unexpected_finish_reason,
+                    empty_answer = assessment.empty_answer,
+                    incomplete_stream = assessment.incomplete_stream,
+                    malformed_json = assessment.malformed_json,
+                    unexpected_finish_reason = assessment.unexpected_finish_reason,
                     "provider stream response shape"
                 );
             };
         }
 
-        if anomalous {
+        if assessment.is_anomalous() {
             emit!(Level::WARN);
         } else {
             emit!(Level::DEBUG);
         }
     }
 
-    #[cfg(test)]
-    fn is_anomalous(&self, termination: StreamTermination) -> bool {
-        (!self.content_non_whitespace_seen && self.parsed_tool_call_event_count == 0)
-            || termination != StreamTermination::Done
-            || !self.done_seen
-            || self.invalid_json_frame_count > 0
-            || !self.finish_reason.is_supported()
+    fn assess(&self, termination: StreamTermination) -> StreamAssessment {
+        if termination == StreamTermination::ConsumerDropped {
+            return StreamAssessment {
+                empty_answer: false,
+                incomplete_stream: false,
+                malformed_json: false,
+                unexpected_finish_reason: false,
+            };
+        }
+
+        StreamAssessment {
+            empty_answer: !self.content_non_whitespace_seen && self.parsed_tool_call_event_count == 0,
+            incomplete_stream: termination != StreamTermination::Done || !self.done_seen,
+            malformed_json: self.invalid_json_frame_count > 0,
+            unexpected_finish_reason: !self.finish_reason.is_supported(),
+        }
     }
 }
 

--- a/crates/aion-providers/src/stream_diagnostics_test.rs
+++ b/crates/aion-providers/src/stream_diagnostics_test.rs
@@ -1,0 +1,251 @@
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use aion_types::llm::LlmEvent;
+use aion_types::message::{StopReason, TokenUsage};
+use reqwest::header::{HeaderMap, HeaderValue};
+use serde_json::json;
+use tracing::{Level, subscriber};
+use tracing_subscriber::fmt::MakeWriter;
+
+use super::*;
+
+#[derive(Clone, Default)]
+struct SharedLogWriter {
+    bytes: Arc<Mutex<Vec<u8>>>,
+}
+
+struct SharedLogGuard {
+    bytes: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for SharedLogGuard {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.bytes
+            .lock()
+            .expect("log buffer mutex should not be poisoned")
+            .extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'writer> MakeWriter<'writer> for SharedLogWriter {
+    type Writer = SharedLogGuard;
+
+    fn make_writer(&'writer self) -> Self::Writer {
+        SharedLogGuard {
+            bytes: Arc::clone(&self.bytes),
+        }
+    }
+}
+
+impl SharedLogWriter {
+    fn contents(&self) -> String {
+        String::from_utf8(
+            self.bytes
+                .lock()
+                .expect("log buffer mutex should not be poisoned")
+                .clone(),
+        )
+        .expect("structured log should be UTF-8")
+    }
+}
+
+fn data_frame() -> Frame {
+    Frame {
+        event: None,
+        data: String::new(),
+        kind: FrameKind::Data,
+    }
+}
+
+fn done_frame() -> Frame {
+    Frame {
+        event: None,
+        data: String::new(),
+        kind: FrameKind::Done,
+    }
+}
+
+#[test]
+fn diagnostics_retain_shape_without_payload_values() {
+    let mut diagnostics = OpenAiStreamDiagnostics::default();
+    let secret_content = "SENSITIVE_VISIBLE_CONTENT";
+    let secret_reasoning = "SENSITIVE_REASONING_CONTENT";
+    let payload = json!({
+        "choices": [{
+            "delta": {
+                "content": secret_content,
+                "reasoning_content": secret_reasoning,
+                "reasoning": "alternative reasoning",
+                "tool_calls": []
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 3}
+    });
+
+    diagnostics.observe_frame(&data_frame());
+    diagnostics.observe_json(&payload);
+    diagnostics.observe_event(&LlmEvent::TextDelta(secret_content.to_string()));
+    diagnostics.observe_event(&LlmEvent::ThinkingDelta(secret_reasoning.to_string()));
+    diagnostics.observe_frame(&done_frame());
+    diagnostics.observe_event(&LlmEvent::Done {
+        stop_reason: StopReason::EndTurn,
+        usage: TokenUsage::default(),
+    });
+
+    assert_eq!(diagnostics.content_delta_count, 1);
+    assert_eq!(diagnostics.content_bytes, secret_content.len() as u64);
+    assert_eq!(diagnostics.reasoning_delta_count, 1);
+    assert_eq!(diagnostics.reasoning_bytes, secret_reasoning.len() as u64);
+    assert!(diagnostics.delta_reasoning_field_seen);
+    assert!(!diagnostics.is_anomalous(StreamTermination::Done));
+
+    let debug = format!("{diagnostics:?}");
+    assert!(!debug.contains(secret_content));
+    assert!(!debug.contains(secret_reasoning));
+    assert!(!debug.contains("alternative reasoning"));
+}
+
+#[test]
+fn thinking_only_response_is_anomalous() {
+    let mut diagnostics = OpenAiStreamDiagnostics::default();
+    diagnostics.observe_frame(&data_frame());
+    diagnostics.observe_json(&json!({
+        "choices": [{
+            "delta": {"reasoning_content": "private reasoning"},
+            "finish_reason": "stop"
+        }]
+    }));
+    diagnostics.observe_event(&LlmEvent::ThinkingDelta("private reasoning".to_string()));
+    diagnostics.observe_frame(&done_frame());
+
+    assert!(diagnostics.is_anomalous(StreamTermination::Done));
+    assert_eq!(diagnostics.parsed_thinking_event_count, 1);
+    assert_eq!(diagnostics.parsed_text_event_count, 0);
+}
+
+#[test]
+fn alternative_response_shapes_are_recorded_as_presence_only() {
+    let mut diagnostics = OpenAiStreamDiagnostics::default();
+    diagnostics.observe_json(&json!({
+        "type": "response.output_text.delta",
+        "delta": "sensitive top-level delta",
+        "output": [{"content": "sensitive output"}],
+        "output_text": "sensitive output text",
+        "choices": [{
+            "message": {"content": "sensitive message"},
+            "text": "sensitive legacy text",
+            "delta": {
+                "reasoning": "sensitive reasoning",
+                "thinking": "sensitive thinking",
+                "analysis": "sensitive analysis",
+                "output_text": "sensitive delta output"
+            },
+            "finish_reason": "custom_reason"
+        }]
+    }));
+
+    assert!(diagnostics.top_level_type_field_seen);
+    assert!(diagnostics.top_level_delta_field_seen);
+    assert!(diagnostics.top_level_output_field_seen);
+    assert!(diagnostics.top_level_output_text_field_seen);
+    assert!(diagnostics.choice_message_field_seen);
+    assert!(diagnostics.choice_message_content_field_seen);
+    assert!(diagnostics.choice_text_field_seen);
+    assert!(diagnostics.delta_reasoning_field_seen);
+    assert!(diagnostics.delta_thinking_field_seen);
+    assert!(diagnostics.delta_analysis_field_seen);
+    assert!(diagnostics.delta_output_text_field_seen);
+    assert_eq!(diagnostics.finish_reason, FinishReasonKind::Other);
+
+    let debug = format!("{diagnostics:?}");
+    assert!(!debug.contains("sensitive"));
+}
+
+#[test]
+fn request_id_is_sanitized_and_bounded() {
+    let mut headers = HeaderMap::new();
+    let request_id = "r".repeat(MAX_REQUEST_ID_CHARS + 20);
+    headers.insert(
+        "x-request-id",
+        HeaderValue::from_str(&request_id).expect("request ID should be a valid header"),
+    );
+    let mut diagnostics = OpenAiStreamDiagnostics::default();
+
+    diagnostics.observe_response(200, &headers);
+
+    assert_eq!(diagnostics.http_status, 200);
+    assert_eq!(
+        diagnostics.request_id.as_deref().map(str::len),
+        Some(MAX_REQUEST_ID_CHARS)
+    );
+}
+
+#[test]
+fn invalid_json_or_incomplete_stream_is_anomalous() {
+    let mut diagnostics = OpenAiStreamDiagnostics::default();
+    diagnostics.observe_invalid_json();
+
+    assert!(diagnostics.is_anomalous(StreamTermination::Eof));
+    assert_eq!(diagnostics.invalid_json_frame_count, 1);
+}
+
+#[test]
+fn unsupported_standard_finish_reason_is_classified_without_wire_value_storage() {
+    let mut diagnostics = OpenAiStreamDiagnostics::default();
+    diagnostics.observe_json(&json!({
+        "choices": [{
+            "delta": {"content": "blocked"},
+            "finish_reason": "content_filter"
+        }]
+    }));
+    diagnostics.observe_event(&LlmEvent::TextDelta("blocked".to_string()));
+    diagnostics.observe_frame(&done_frame());
+
+    assert_eq!(diagnostics.finish_reason, FinishReasonKind::ContentFilter);
+    assert!(diagnostics.is_anomalous(StreamTermination::Done));
+}
+
+#[test]
+fn emitted_summary_contains_shape_but_not_payload_values() {
+    let secret_content = "SENSITIVE_LOG_CONTENT";
+    let secret_reasoning = "SENSITIVE_LOG_REASONING";
+    let mut diagnostics = OpenAiStreamDiagnostics::default();
+    diagnostics.observe_json(&json!({
+        "choices": [{
+            "delta": {
+                "content": secret_content,
+                "reasoning_content": secret_reasoning
+            },
+            "finish_reason": "stop"
+        }]
+    }));
+    diagnostics.observe_event(&LlmEvent::TextDelta(secret_content.to_string()));
+    diagnostics.observe_event(&LlmEvent::ThinkingDelta(secret_reasoning.to_string()));
+    diagnostics.observe_frame(&done_frame());
+
+    let writer = SharedLogWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_max_level(Level::TRACE)
+        .with_writer(writer.clone())
+        .finish();
+    subscriber::with_default(subscriber, || {
+        diagnostics.emit_summary(StreamTermination::Done, Duration::from_millis(42), 10, 3);
+    });
+
+    let output = writer.contents();
+    assert!(output.contains("provider_stream_summary"));
+    assert!(output.contains("\"content_delta_count\":1"));
+    assert!(output.contains("\"reasoning_delta_count\":1"));
+    assert!(output.contains("\"duration_ms\":42"));
+    assert!(!output.contains(secret_content));
+    assert!(!output.contains(secret_reasoning));
+}

--- a/crates/aion-providers/src/stream_diagnostics_test.rs
+++ b/crates/aion-providers/src/stream_diagnostics_test.rs
@@ -1,60 +1,13 @@
-use std::io::Write;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use aion_types::llm::LlmEvent;
 use aion_types::message::{StopReason, TokenUsage};
 use reqwest::header::{HeaderMap, HeaderValue};
-use serde_json::json;
+use serde_json::{Value, json};
 use tracing::{Level, subscriber};
-use tracing_subscriber::fmt::MakeWriter;
 
 use super::*;
-
-#[derive(Clone, Default)]
-struct SharedLogWriter {
-    bytes: Arc<Mutex<Vec<u8>>>,
-}
-
-struct SharedLogGuard {
-    bytes: Arc<Mutex<Vec<u8>>>,
-}
-
-impl Write for SharedLogGuard {
-    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
-        self.bytes
-            .lock()
-            .expect("log buffer mutex should not be poisoned")
-            .extend_from_slice(buffer);
-        Ok(buffer.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-impl<'writer> MakeWriter<'writer> for SharedLogWriter {
-    type Writer = SharedLogGuard;
-
-    fn make_writer(&'writer self) -> Self::Writer {
-        SharedLogGuard {
-            bytes: Arc::clone(&self.bytes),
-        }
-    }
-}
-
-impl SharedLogWriter {
-    fn contents(&self) -> String {
-        String::from_utf8(
-            self.bytes
-                .lock()
-                .expect("log buffer mutex should not be poisoned")
-                .clone(),
-        )
-        .expect("structured log should be UTF-8")
-    }
-}
+use crate::test_support::SharedLogWriter;
 
 fn data_frame() -> Frame {
     Frame {
@@ -105,7 +58,7 @@ fn diagnostics_retain_shape_without_payload_values() {
     assert_eq!(diagnostics.reasoning_delta_count, 1);
     assert_eq!(diagnostics.reasoning_bytes, secret_reasoning.len() as u64);
     assert!(diagnostics.delta_reasoning_field_seen);
-    assert!(!diagnostics.is_anomalous(StreamTermination::Done));
+    assert!(!diagnostics.assess(StreamTermination::Done).is_anomalous());
 
     let debug = format!("{diagnostics:?}");
     assert!(!debug.contains(secret_content));
@@ -126,7 +79,7 @@ fn thinking_only_response_is_anomalous() {
     diagnostics.observe_event(&LlmEvent::ThinkingDelta("private reasoning".to_string()));
     diagnostics.observe_frame(&done_frame());
 
-    assert!(diagnostics.is_anomalous(StreamTermination::Done));
+    assert!(diagnostics.assess(StreamTermination::Done).is_anomalous());
     assert_eq!(diagnostics.parsed_thinking_event_count, 1);
     assert_eq!(diagnostics.parsed_text_event_count, 0);
 }
@@ -193,7 +146,7 @@ fn invalid_json_or_incomplete_stream_is_anomalous() {
     let mut diagnostics = OpenAiStreamDiagnostics::default();
     diagnostics.observe_invalid_json();
 
-    assert!(diagnostics.is_anomalous(StreamTermination::Eof));
+    assert!(diagnostics.assess(StreamTermination::Eof).is_anomalous());
     assert_eq!(diagnostics.invalid_json_frame_count, 1);
 }
 
@@ -210,7 +163,57 @@ fn unsupported_standard_finish_reason_is_classified_without_wire_value_storage()
     diagnostics.observe_frame(&done_frame());
 
     assert_eq!(diagnostics.finish_reason, FinishReasonKind::ContentFilter);
-    assert!(diagnostics.is_anomalous(StreamTermination::Done));
+    assert!(diagnostics.assess(StreamTermination::Done).is_anomalous());
+}
+
+fn capture_summary(diagnostics: &OpenAiStreamDiagnostics, termination: StreamTermination) -> Value {
+    let writer = SharedLogWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_max_level(Level::TRACE)
+        .with_writer(writer.clone())
+        .finish();
+    subscriber::with_default(subscriber, || {
+        diagnostics.emit_summary(termination, Duration::from_millis(42), 10, 3);
+    });
+
+    serde_json::from_str(writer.contents().trim()).expect("summary should be valid JSON")
+}
+
+#[test]
+fn consumer_drop_is_debug_and_not_anomalous() {
+    let diagnostics = OpenAiStreamDiagnostics::default();
+
+    let output = capture_summary(&diagnostics, StreamTermination::ConsumerDropped);
+
+    assert!(!diagnostics.assess(StreamTermination::ConsumerDropped).is_anomalous());
+    assert_eq!(output["level"], "DEBUG");
+    assert_eq!(output["fields"]["termination"], "consumer_dropped");
+    assert_eq!(output["fields"]["empty_answer"], false);
+    assert_eq!(output["fields"]["incomplete_stream"], false);
+    assert_eq!(output["fields"]["malformed_json"], false);
+    assert_eq!(output["fields"]["unexpected_finish_reason"], false);
+}
+
+#[test]
+fn anomalous_summary_is_warn_with_all_reason_fields() {
+    let mut diagnostics = OpenAiStreamDiagnostics::default();
+    diagnostics.observe_invalid_json();
+    diagnostics.observe_json(&json!({
+        "choices": [{
+            "delta": {"reasoning_content": "private reasoning"},
+            "finish_reason": "content_filter"
+        }]
+    }));
+
+    let output = capture_summary(&diagnostics, StreamTermination::Eof);
+
+    assert!(diagnostics.assess(StreamTermination::Eof).is_anomalous());
+    assert_eq!(output["level"], "WARN");
+    assert_eq!(output["fields"]["empty_answer"], true);
+    assert_eq!(output["fields"]["incomplete_stream"], true);
+    assert_eq!(output["fields"]["malformed_json"], true);
+    assert_eq!(output["fields"]["unexpected_finish_reason"], true);
 }
 
 #[test]
@@ -231,17 +234,7 @@ fn emitted_summary_contains_shape_but_not_payload_values() {
     diagnostics.observe_event(&LlmEvent::ThinkingDelta(secret_reasoning.to_string()));
     diagnostics.observe_frame(&done_frame());
 
-    let writer = SharedLogWriter::default();
-    let subscriber = tracing_subscriber::fmt()
-        .json()
-        .with_max_level(Level::TRACE)
-        .with_writer(writer.clone())
-        .finish();
-    subscriber::with_default(subscriber, || {
-        diagnostics.emit_summary(StreamTermination::Done, Duration::from_millis(42), 10, 3);
-    });
-
-    let output = writer.contents();
+    let output = capture_summary(&diagnostics, StreamTermination::Done).to_string();
     assert!(output.contains("provider_stream_summary"));
     assert!(output.contains("\"content_delta_count\":1"));
     assert!(output.contains("\"reasoning_delta_count\":1"));

--- a/crates/aion-providers/src/stream_process.rs
+++ b/crates/aion-providers/src/stream_process.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use tokio::sync::mpsc;
 
 use aion_types::llm::LlmEvent;
@@ -6,6 +8,7 @@ use aion_types::message::{StopReason, TokenUsage};
 use crate::error::ProviderError;
 use crate::framing::{FrameKind, SseBlockFramer, SseLineFramer, bedrock_payload_to_frame};
 use crate::parser::{AnthropicParser, OpenAiParser, ResponseParser};
+use crate::stream_diagnostics::StreamTermination;
 use crate::stream_runner::StreamOutcome;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -34,6 +37,10 @@ pub(crate) async fn process_openai_sse_stream(
 
     let parser = OpenAiParser { auto_tool_id };
     let mut state = parser.new_state();
+    state
+        .diagnostics_mut()
+        .observe_response(response.status().as_u16(), response.headers());
+    let started_at = Instant::now();
     let mut framer = SseLineFramer::default();
     let mut stream = response.bytes_stream();
     let mut emitted_content = false;
@@ -43,19 +50,23 @@ pub(crate) async fn process_openai_sse_stream(
             Ok(c) => c,
             Err(e) => {
                 let err = ProviderError::Connection(e.to_string());
-                return if emitted_content {
+                let outcome = if emitted_content {
                     StreamOutcome::FailedPartial(err)
                 } else {
                     StreamOutcome::FailedEmpty(err)
                 };
+                state.emit_diagnostics(StreamTermination::ConnectionError, started_at.elapsed());
+                return outcome;
             }
         };
+        state.diagnostics_mut().observe_network_chunk(chunk.len());
         let text = String::from_utf8_lossy(&chunk);
         for frame in framer.push_text(&text, "[DONE]") {
-            tracing::debug!(target: "aion_providers", chunk = %frame.data, "sse chunk received");
+            state.diagnostics_mut().observe_frame(&frame);
             let is_done = frame.kind == FrameKind::Done;
             let events = parser.parse_frame(&frame, &mut state);
             for event in events {
+                state.diagnostics_mut().observe_event(&event);
                 if matches!(
                     event,
                     LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
@@ -63,21 +74,26 @@ pub(crate) async fn process_openai_sse_stream(
                     emitted_content = true;
                 }
                 if tx.send(event).await.is_err() {
+                    state.emit_diagnostics(StreamTermination::ConsumerDropped, started_at.elapsed());
                     return StreamOutcome::Ok;
                 }
             }
             if is_done {
+                state.emit_diagnostics(StreamTermination::Done, started_at.elapsed());
                 return StreamOutcome::Ok;
             }
         }
     }
 
     for event in parser.finish(&mut state) {
+        state.diagnostics_mut().observe_event(&event);
         if tx.send(event).await.is_err() {
+            state.emit_diagnostics(StreamTermination::ConsumerDropped, started_at.elapsed());
             return StreamOutcome::Ok;
         }
     }
 
+    state.emit_diagnostics(StreamTermination::Eof, started_at.elapsed());
     StreamOutcome::Ok
 }
 
@@ -107,7 +123,6 @@ pub(crate) async fn process_anthropic_sse_stream(
         };
         let text = String::from_utf8_lossy(&chunk);
         for frame in framer.push_text(&text) {
-            tracing::debug!(target: "aion_providers", chunk = %frame.data, "sse chunk received");
             let events = parser.parse_frame(&frame, &mut state);
             for event in events {
                 if matches!(
@@ -170,7 +185,6 @@ pub(crate) async fn process_bedrock_aws_event_stream(
             };
 
             if let Some(frame) = bedrock_payload_to_frame(&payload) {
-                tracing::debug!(target: "aion_providers", chunk = %frame.data, "bedrock event chunk");
                 let events = parser.parse_frame(&frame, &mut state);
                 for event in events {
                     if matches!(

--- a/crates/aion-providers/src/stream_process_test.rs
+++ b/crates/aion-providers/src/stream_process_test.rs
@@ -5,10 +5,13 @@ mod tests {
     use super::*;
     use base64::Engine as _;
     use base64::engine::general_purpose::STANDARD;
-    use serde_json::json;
+    use serde_json::{Value, json};
     use tokio::sync::mpsc;
+    use tracing::{Level, subscriber};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::test_support::SharedLogWriter;
 
     fn aws_event_message(payload: &[u8]) -> Vec<u8> {
         let total_len = 12 + payload.len() + 4;
@@ -50,6 +53,39 @@ mod tests {
         events
     }
 
+    fn openai_sse_body(include_done: bool) -> Vec<u8> {
+        let content = json!({
+            "choices": [{
+                "delta": {"content": "Hello"},
+                "finish_reason": null
+            }]
+        });
+        let finish = json!({
+            "choices": [{
+                "delta": {},
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 12,
+                "completion_tokens": 3
+            }
+        });
+        let mut body = format!("data: {content}\n\ndata: {finish}\n\n");
+        if include_done {
+            body.push_str("data: [DONE]\n\n");
+        }
+        body.into_bytes()
+    }
+
+    fn provider_stream_summary(writer: &SharedLogWriter) -> Value {
+        writer
+            .contents()
+            .lines()
+            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+            .find(|event| event["fields"]["diagnostic_event"] == "provider_stream_summary")
+            .expect("provider stream summary should be logged")
+    }
+
     #[test]
     fn parse_aws_event_waits_for_complete_message_and_extracts_payload() {
         let payload = b"payload";
@@ -60,6 +96,61 @@ mod tests {
         let (event_data, consumed) = parse_aws_event(&message).expect("complete event should parse");
         assert_eq!(event_data, Some(payload.to_vec()));
         assert_eq!(consumed, message.len());
+    }
+
+    #[tokio::test]
+    async fn openai_sse_stream_logs_done_termination_from_real_processing_path() {
+        let response = mock_response(openai_sse_body(true)).await;
+        let (tx, rx) = mpsc::channel(8);
+        let writer = SharedLogWriter::default();
+        let log_subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_max_level(Level::TRACE)
+            .with_writer(writer.clone())
+            .finish();
+        let _guard = subscriber::set_default(log_subscriber);
+
+        let outcome = process_openai_sse_stream(response, &tx, false).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+        let summary = provider_stream_summary(&writer);
+
+        assert!(matches!(outcome, StreamOutcome::Ok));
+        assert_eq!(events.len(), 2);
+        assert_eq!(summary["level"], "DEBUG");
+        assert_eq!(summary["fields"]["termination"], "done");
+        assert_eq!(summary["fields"]["done_seen"], true);
+        assert_eq!(summary["fields"]["incomplete_stream"], false);
+        assert_eq!(summary["fields"]["parsed_text_event_count"], 1);
+        assert_eq!(summary["fields"]["parsed_done_event_count"], 1);
+    }
+
+    #[tokio::test]
+    async fn openai_sse_stream_logs_eof_termination_from_real_processing_path() {
+        let response = mock_response(openai_sse_body(false)).await;
+        let (tx, rx) = mpsc::channel(8);
+        let writer = SharedLogWriter::default();
+        let log_subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_max_level(Level::TRACE)
+            .with_writer(writer.clone())
+            .finish();
+        let _guard = subscriber::set_default(log_subscriber);
+
+        let outcome = process_openai_sse_stream(response, &tx, false).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+        let summary = provider_stream_summary(&writer);
+
+        assert!(matches!(outcome, StreamOutcome::Ok));
+        assert_eq!(events.len(), 1);
+        assert_eq!(summary["level"], "WARN");
+        assert_eq!(summary["fields"]["termination"], "eof");
+        assert_eq!(summary["fields"]["done_seen"], false);
+        assert_eq!(summary["fields"]["incomplete_stream"], true);
+        assert_eq!(summary["fields"]["empty_answer"], false);
+        assert_eq!(summary["fields"]["malformed_json"], false);
+        assert_eq!(summary["fields"]["unexpected_finish_reason"], false);
     }
 
     #[tokio::test]

--- a/crates/aion-providers/src/stream_runner.rs
+++ b/crates/aion-providers/src/stream_runner.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
+use tracing::Instrument;
 
 use aion_types::llm::LlmEvent;
 
@@ -69,7 +70,8 @@ where
 
     let (tx, rx) = mpsc::channel(64);
 
-    tokio::spawn(async move {
+    let stream_span = tracing::Span::current();
+    let stream_task = async move {
         let mut response = response;
 
         match process.clone()(response, tx.clone()).await {
@@ -137,7 +139,8 @@ where
                 let _ = tx.send(LlmEvent::Error(final_err.to_string())).await;
             }
         }
-    });
+    };
+    tokio::spawn(stream_task.instrument(stream_span));
 
     Ok(rx)
 }

--- a/crates/aion-providers/src/test_support.rs
+++ b/crates/aion-providers/src/test_support.rs
@@ -1,0 +1,49 @@
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+use tracing_subscriber::fmt::MakeWriter;
+
+#[derive(Clone, Default)]
+pub(crate) struct SharedLogWriter {
+    bytes: Arc<Mutex<Vec<u8>>>,
+}
+
+pub(crate) struct SharedLogGuard {
+    bytes: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for SharedLogGuard {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.bytes
+            .lock()
+            .expect("log buffer mutex should not be poisoned")
+            .extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'writer> MakeWriter<'writer> for SharedLogWriter {
+    type Writer = SharedLogGuard;
+
+    fn make_writer(&'writer self) -> Self::Writer {
+        SharedLogGuard {
+            bytes: Arc::clone(&self.bytes),
+        }
+    }
+}
+
+impl SharedLogWriter {
+    pub(crate) fn contents(&self) -> String {
+        String::from_utf8(
+            self.bytes
+                .lock()
+                .expect("log buffer mutex should not be poisoned")
+                .clone(),
+        )
+        .expect("structured log should be UTF-8")
+    }
+}


### PR DESCRIPTION
## Summary

- Add payload-safe response-shape diagnostics for OpenAI-compatible SSE streams, including framing, JSON shape, parsed events, token usage, termination, and anomaly flags.
- Correlate provider summaries with agent generation phases and log EmptyFinal retry/finalization outcomes without prompts, response text, reasoning text, or tool payloads.
- Treat `consumer_dropped` as an expected cancellation at `DEBUG`, and remove raw request-body and raw SSE/Bedrock chunk logging.

## Scope

- Structured `provider_stream_summary` diagnostics currently cover only the OpenAI-compatible SSE receive/parse path.
- Send-stage connection resets before an HTTP response is received do not emit this summary; they remain covered by the existing transport and retry errors. Connection errors while reading an established response stream are reported as `connection_error`.
- Anthropic and Bedrock raw chunk logs are removed, but structured summaries for those protocols are a follow-up. The follow-up should reuse the transport/framing counters while adding protocol-specific response-shape observers.

## Validation

- `cargo test -p aion-providers stream_diagnostics`
- `cargo test -p aion-providers stream_process`
- `cargo clippy -p aion-providers --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `just push` — 2177 tests passed, 2 skipped; Hakari verified