### PR TITLE
feat(providers): add openai responses api support

### DIFF
--- a/crates/aion-agent/src/compact/estimate.rs
+++ b/crates/aion-agent/src/compact/estimate.rs
@@ -39,6 +39,9 @@ pub fn estimate_tokens_from_messages(messages: &[Message]) -> u64 {
                     let tokens = (bytes / BYTES_PER_TOKEN).clamp(MIN_IMAGE_TOKENS, MAX_IMAGE_TOKENS);
                     total_chars += tokens * CHARS_PER_TOKEN_TEXT;
                 }
+                ContentBlock::ProviderItem { item, .. } => {
+                    json_chars += item.to_string().len();
+                }
             }
         }
     }

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -798,6 +798,7 @@ impl AgentEngine {
         let mut assistant_text = String::new();
         let mut thinking_text = String::new();
         let mut thinking_signature: Option<String> = None;
+        let mut provider_items: Vec<ContentBlock> = Vec::new();
         let mut tool_calls: Vec<ContentBlock> = Vec::new();
         let mut stop_reason = StopReason::EndTurn;
         let mut usage = TokenUsage::default();
@@ -834,6 +835,9 @@ impl AgentEngine {
                 LlmEvent::ThinkingSignature(signature) => {
                     thinking_signature = Some(signature);
                 }
+                LlmEvent::ProviderItem { provider, item } => {
+                    provider_items.push(ContentBlock::ProviderItem { provider, item });
+                }
                 LlmEvent::Done {
                     stop_reason: sr,
                     usage: u,
@@ -851,6 +855,7 @@ impl AgentEngine {
             assistant_text,
             thinking_text,
             thinking_signature,
+            provider_items,
             tool_calls,
             stop_reason,
             usage,
@@ -1354,7 +1359,7 @@ struct ToolRoundOutput {
 /// Assemble the assistant message content blocks (thinking, text, tool calls)
 /// from a completed [`StreamOutcome`], preserving the canonical block order.
 fn build_assistant_content(outcome: &StreamOutcome) -> Vec<ContentBlock> {
-    let mut content: Vec<ContentBlock> = Vec::new();
+    let mut content = outcome.provider_items.clone();
     if !outcome.thinking_text.is_empty() || outcome.thinking_signature.is_some() {
         content.push(ContentBlock::Thinking {
             thinking: outcome.thinking_text.clone(),

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    AgentEngine, AgentError, CacheBreakDetector, CompactLevel, CompactState, ProviderCompat, merge_tool_results,
-    tool_call_malformed_fingerprint,
+    AgentEngine, AgentError, CacheBreakDetector, CompactLevel, CompactState, ProviderCompat, build_assistant_content,
+    merge_tool_results, tool_call_malformed_fingerprint,
 };
 
 // ---------------------------------------------------------------------------
@@ -1603,7 +1603,7 @@ mod tests_loop_helpers {
     use aion_types::message::{ContentBlock, StopReason, TokenUsage};
     use serde_json::json;
 
-    use super::{AgentError, merge_tool_results, tool_call_malformed_fingerprint};
+    use super::{AgentError, build_assistant_content, merge_tool_results, tool_call_malformed_fingerprint};
     use crate::stream::StreamOutcome;
     use crate::tool_call::{
         DEFAULT_MAX_TOOL_CALL_FAILURE, ToolCallFailureFingerprint, ToolCallMalformedReason,
@@ -1841,6 +1841,7 @@ mod tests_loop_helpers {
             assistant_text: assistant_text.to_string(),
             thinking_text: String::new(),
             thinking_signature: None,
+            provider_items: Vec::new(),
             tool_calls,
             stop_reason,
             usage: TokenUsage::default(),
@@ -1856,6 +1857,21 @@ mod tests_loop_helpers {
         );
 
         assert!(matches!(TurnOutcome::from_stream(outcome), TurnOutcome::ToolRound(_)));
+    }
+
+    #[test]
+    fn assistant_content_keeps_provider_items_before_visible_content() {
+        let mut outcome = stream_outcome("Done", StopReason::ToolUse, vec![tool_use("call-1", "Read")]);
+        outcome.provider_items.push(ContentBlock::ProviderItem {
+            provider: "openai_responses".to_string(),
+            item: json!({"id": "rs_1", "type": "reasoning"}),
+        });
+
+        let content = build_assistant_content(&outcome);
+
+        assert!(matches!(content[0], ContentBlock::ProviderItem { .. }));
+        assert!(matches!(content[1], ContentBlock::Text { .. }));
+        assert!(matches!(content[2], ContentBlock::ToolUse { .. }));
     }
 
     #[test]

--- a/crates/aion-agent/src/stream.rs
+++ b/crates/aion-agent/src/stream.rs
@@ -8,6 +8,7 @@ pub(crate) struct StreamOutcome {
     pub(crate) assistant_text: String,
     pub(crate) thinking_text: String,
     pub(crate) thinking_signature: Option<String>,
+    pub(crate) provider_items: Vec<ContentBlock>,
     pub(crate) tool_calls: Vec<ContentBlock>,
     pub(crate) stop_reason: StopReason,
     pub(crate) usage: TokenUsage,

--- a/crates/aion-config/src/compat.rs
+++ b/crates/aion-config/src/compat.rs
@@ -30,6 +30,10 @@ pub struct ProviderCompat {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct TransportCompat {
+    /// OpenAI wire API used for request and response projection.
+    /// Default: chat_completions for backward compatibility.
+    pub openai_api_mode: Option<OpenAiApiMode>,
+
     /// Field name for max tokens in request body.
     /// Default: "max_tokens" for all providers.
     pub max_tokens_field: Option<String>,
@@ -150,6 +154,7 @@ pub struct ReasoningCompat {
 impl TransportCompat {
     fn merge(defaults: Self, user: Self) -> Self {
         Self {
+            openai_api_mode: user.openai_api_mode.or(defaults.openai_api_mode),
             max_tokens_field: user.max_tokens_field.or(defaults.max_tokens_field),
             default_max_tokens: user.default_max_tokens.or(defaults.default_max_tokens),
             model_max_tokens: user.model_max_tokens.or(defaults.model_max_tokens),
@@ -158,6 +163,14 @@ impl TransportCompat {
             include_stream_options: user.include_stream_options.or(defaults.include_stream_options),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenAiApiMode {
+    #[default]
+    ChatCompletions,
+    Responses,
 }
 
 impl MessageCompat {
@@ -270,6 +283,7 @@ impl ProviderCompat {
     pub fn openai_defaults() -> Self {
         Self {
             transport: TransportCompat {
+                openai_api_mode: Some(OpenAiApiMode::ChatCompletions),
                 max_tokens_field: Some("max_tokens".into()),
                 api_path: Some("/chat/completions".into()),
                 include_stream_options: Some(true),
@@ -313,6 +327,25 @@ impl ProviderCompat {
 
     pub fn max_tokens_field(&self) -> &str {
         self.transport.max_tokens_field.as_deref().unwrap_or("max_tokens")
+    }
+
+    pub fn openai_api_mode(&self) -> OpenAiApiMode {
+        self.transport.openai_api_mode.unwrap_or_default()
+    }
+
+    /// Resolve the OpenAI endpoint path for the selected wire API.
+    ///
+    /// The historical `/chat/completions` preset remains the default for Chat
+    /// Completions. When Responses is selected, that inherited preset is
+    /// replaced with `/responses`; non-default custom paths remain honored.
+    pub fn openai_api_path(&self) -> &str {
+        match self.openai_api_mode() {
+            OpenAiApiMode::ChatCompletions => self.api_path(),
+            OpenAiApiMode::Responses => match self.transport.api_path.as_deref() {
+                Some(path) if path != "/chat/completions" => path,
+                _ => "/responses",
+            },
+        }
     }
 
     pub fn image_input(&self) -> ImageInputCapability {

--- a/crates/aion-config/src/compat_test.rs
+++ b/crates/aion-config/src/compat_test.rs
@@ -79,6 +79,7 @@ max_tokens = 64000
     fn test_flattened_compat_serializes_to_legacy_toml_keys() {
         let compat = ProviderCompat {
             transport: TransportCompat {
+                openai_api_mode: None,
                 max_tokens_field: Some("max_completion_tokens".to_string()),
                 default_max_tokens: Some(128_000),
                 model_max_tokens: Some(vec![ModelMaxTokensRule {
@@ -274,6 +275,51 @@ max_tokens = 64000
         assert!(compat.include_stream_options());
         assert!(compat.emit_tools());
         assert_eq!(compat.default_max_tokens_for_model("gpt-5"), None);
+    }
+
+    #[test]
+    fn openai_api_mode_defaults_to_chat_completions() {
+        let compat = ProviderCompat::openai_defaults();
+
+        assert_eq!(compat.openai_api_mode(), OpenAiApiMode::ChatCompletions);
+        assert_eq!(compat.openai_api_path(), "/chat/completions");
+    }
+
+    #[test]
+    fn responses_mode_replaces_inherited_chat_path() {
+        let user = ProviderCompat {
+            transport: TransportCompat {
+                openai_api_mode: Some(OpenAiApiMode::Responses),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let compat = ProviderCompat::merge(ProviderCompat::openai_defaults(), user);
+
+        assert_eq!(compat.openai_api_mode(), OpenAiApiMode::Responses);
+        assert_eq!(compat.openai_api_path(), "/responses");
+    }
+
+    #[test]
+    fn responses_mode_preserves_custom_api_path() {
+        let user = ProviderCompat {
+            transport: TransportCompat {
+                openai_api_mode: Some(OpenAiApiMode::Responses),
+                api_path: Some("/custom/responses".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let compat = ProviderCompat::merge(ProviderCompat::openai_defaults(), user);
+
+        assert_eq!(compat.openai_api_path(), "/custom/responses");
+    }
+
+    #[test]
+    fn responses_mode_deserializes_from_compat_toml() {
+        let compat: ProviderCompat = toml::from_str("openai_api_mode = \"responses\"").unwrap();
+
+        assert_eq!(compat.openai_api_mode(), OpenAiApiMode::Responses);
     }
 
     #[test]

--- a/crates/aion-config/src/config.rs
+++ b/crates/aion-config/src/config.rs
@@ -918,6 +918,7 @@ default = "auto"                 # auto, powershell, pwsh, cmd, bash, zsh, sh, o
 
 # Provider compatibility overrides (usually not needed — defaults work)
 # [providers.openai.compat]
+# openai_api_mode = "responses"               # default: "chat_completions"
 # max_tokens_field = "max_completion_tokens"  # for OpenAI official models
 # merge_assistant_messages = true
 # clean_orphan_tool_calls = true

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -161,6 +161,7 @@ pub fn build_messages(messages: &[Message], compat: &ProviderCompat) -> Vec<Valu
                         }
                     }));
                 }
+                ContentBlock::ProviderItem { .. } => {}
             }
         }
 

--- a/crates/aion-providers/src/lib.rs
+++ b/crates/aion-providers/src/lib.rs
@@ -6,6 +6,8 @@ pub mod error;
 pub(crate) mod framing;
 pub mod openai;
 pub(crate) mod openai_messages;
+pub(crate) mod openai_responses;
+pub(crate) mod openai_responses_projector;
 pub(crate) mod parser;
 pub(crate) mod projector;
 pub mod provider;

--- a/crates/aion-providers/src/openai_responses.rs
+++ b/crates/aion-providers/src/openai_responses.rs
@@ -1,0 +1,184 @@
+use std::collections::HashSet;
+
+use aion_types::llm::LlmEvent;
+use aion_types::message::{StopReason, TokenUsage};
+use serde_json::{Map, Value};
+
+pub(crate) const PROVIDER_ITEM_OWNER: &str = "openai_responses";
+
+pub(crate) struct StreamState {
+    seen_output_items: HashSet<String>,
+    saw_tool_call: bool,
+    terminal: bool,
+}
+
+impl StreamState {
+    pub(crate) fn new() -> Self {
+        Self {
+            seen_output_items: HashSet::new(),
+            saw_tool_call: false,
+            terminal: false,
+        }
+    }
+
+    pub(crate) fn is_terminal(&self) -> bool {
+        self.terminal
+    }
+}
+
+pub(crate) fn parse_sse_chunk(data: &str, state: &mut StreamState) -> Vec<LlmEvent> {
+    let json = match serde_json::from_str::<Value>(data) {
+        Ok(json) => json,
+        Err(_) => return Vec::new(),
+    };
+    let event_type = json.get("type").and_then(Value::as_str).unwrap_or_default();
+
+    match event_type {
+        "response.output_text.delta" | "response.refusal.delta" => json
+            .get("delta")
+            .and_then(Value::as_str)
+            .filter(|delta| !delta.is_empty())
+            .map(|delta| vec![LlmEvent::TextDelta(delta.to_string())])
+            .unwrap_or_default(),
+        "response.reasoning_summary_text.delta" => json
+            .get("delta")
+            .and_then(Value::as_str)
+            .filter(|delta| !delta.is_empty())
+            .map(|delta| vec![LlmEvent::ThinkingDelta(delta.to_string())])
+            .unwrap_or_default(),
+        "response.output_item.done" => json
+            .get("item")
+            .map(|item| events_for_output_item(item, state))
+            .unwrap_or_default(),
+        "response.completed" => complete_response(&json, state),
+        "response.incomplete" => incomplete_response(&json, state),
+        "response.failed" => failed_response(&json, state),
+        "error" => error_event(&json, state),
+        _ => Vec::new(),
+    }
+}
+
+fn complete_response(event: &Value, state: &mut StreamState) -> Vec<LlmEvent> {
+    let response = event.get("response").unwrap_or(event);
+    let mut events = response
+        .get("output")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .flat_map(|item| events_for_output_item(item, state))
+        .collect::<Vec<_>>();
+
+    state.terminal = true;
+    events.push(LlmEvent::Done {
+        stop_reason: if state.saw_tool_call {
+            StopReason::ToolUse
+        } else {
+            StopReason::EndTurn
+        },
+        usage: response.get("usage").map(parse_usage).unwrap_or_default(),
+    });
+    events
+}
+
+fn incomplete_response(event: &Value, state: &mut StreamState) -> Vec<LlmEvent> {
+    let response = event.get("response").unwrap_or(event);
+    let mut events = response
+        .get("output")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .flat_map(|item| events_for_output_item(item, state))
+        .collect::<Vec<_>>();
+    let reason = response
+        .pointer("/incomplete_details/reason")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+
+    state.terminal = true;
+    if reason == "max_output_tokens" {
+        events.push(LlmEvent::Done {
+            stop_reason: StopReason::MaxTokens,
+            usage: response.get("usage").map(parse_usage).unwrap_or_default(),
+        });
+    } else {
+        events.push(LlmEvent::Error(format!("OpenAI response incomplete: {reason}")));
+    }
+    events
+}
+
+fn failed_response(event: &Value, state: &mut StreamState) -> Vec<LlmEvent> {
+    state.terminal = true;
+    let response = event.get("response").unwrap_or(event);
+    let message = response
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .or_else(|| response.get("error").and_then(Value::as_str))
+        .unwrap_or("OpenAI response failed");
+    vec![LlmEvent::Error(message.to_string())]
+}
+
+fn error_event(event: &Value, state: &mut StreamState) -> Vec<LlmEvent> {
+    state.terminal = true;
+    let message = event
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .or_else(|| event.get("message").and_then(Value::as_str))
+        .unwrap_or("OpenAI Responses stream error");
+    vec![LlmEvent::Error(message.to_string())]
+}
+
+fn events_for_output_item(item: &Value, state: &mut StreamState) -> Vec<LlmEvent> {
+    let identity = item
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| item.to_string());
+    if !state.seen_output_items.insert(identity) {
+        return Vec::new();
+    }
+
+    match item.get("type").and_then(Value::as_str) {
+        Some("reasoning") => vec![LlmEvent::ProviderItem {
+            provider: PROVIDER_ITEM_OWNER.to_string(),
+            item: item.clone(),
+        }],
+        Some("function_call") => function_call_event(item, state).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn function_call_event(item: &Value, state: &mut StreamState) -> Option<LlmEvent> {
+    let call_id = item.get("call_id").and_then(Value::as_str)?.to_string();
+    let name = item.get("name").and_then(Value::as_str).unwrap_or_default().to_string();
+    let arguments = item.get("arguments").and_then(Value::as_str).unwrap_or("{}");
+    let input = serde_json::from_str(arguments).unwrap_or_else(|_| Value::Object(Map::new()));
+
+    let mut provider_metadata = Map::new();
+    let mut function_call = Map::new();
+    function_call.insert("function_call".to_string(), item.clone());
+    provider_metadata.insert(PROVIDER_ITEM_OWNER.to_string(), Value::Object(function_call));
+
+    state.saw_tool_call = true;
+    Some(LlmEvent::ToolUse {
+        id: call_id,
+        name,
+        input,
+        extra: Some(Value::Object(provider_metadata)),
+    })
+}
+
+fn parse_usage(usage: &Value) -> TokenUsage {
+    TokenUsage {
+        input_tokens: usage.get("input_tokens").and_then(Value::as_u64).unwrap_or(0),
+        output_tokens: usage.get("output_tokens").and_then(Value::as_u64).unwrap_or(0),
+        cache_creation_tokens: 0,
+        cache_read_tokens: usage
+            .pointer("/input_tokens_details/cached_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+    }
+}
+
+#[cfg(test)]
+#[path = "openai_responses_test.rs"]
+mod openai_responses_test;

--- a/crates/aion-providers/src/openai_responses_projector.rs
+++ b/crates/aion-providers/src/openai_responses_projector.rs
@@ -1,0 +1,263 @@
+use std::collections::HashSet;
+
+use aion_config::compat::ProviderCompat;
+use aion_types::llm::LlmRequest;
+use aion_types::message::{ContentBlock, Message, Role};
+use serde_json::{Value, json};
+
+use crate::openai_messages::generate_call_id;
+use crate::openai_responses::PROVIDER_ITEM_OWNER;
+use crate::projector::{ProjectionError, ResolvedToolWireShape, WireProvider, preflight_projected_body, project_tools};
+
+pub(crate) struct OpenAiResponsesProjector;
+
+impl OpenAiResponsesProjector {
+    pub(crate) fn project(request: &LlmRequest, compat: &ProviderCompat) -> Result<Value, ProjectionError> {
+        let max_tokens = request
+            .max_tokens
+            .or_else(|| compat.default_max_tokens_for_model(&request.model));
+        let input = project_input(&request.messages, compat);
+
+        let mut body = json!({
+            "model": request.model,
+            "instructions": request.system,
+            "input": input,
+            "stream": true,
+            "store": false,
+            "include": ["reasoning.encrypted_content"]
+        });
+
+        if let Some(max_tokens) = max_tokens {
+            body["max_output_tokens"] = json!(max_tokens);
+        }
+
+        let mut tool_count = 0;
+        if !request.tools.is_empty() && compat.emit_tools() {
+            let tools = project_tools(&request.tools, ResolvedToolWireShape::OpenAiFunction)
+                .into_iter()
+                .filter_map(flatten_function_tool)
+                .collect::<Vec<_>>();
+            tool_count = tools.len();
+            body["tools"] = json!(tools);
+        } else if !request.tools.is_empty() {
+            tracing::warn!(
+                target: "aion_providers",
+                "OpenAI Responses outgoing tools omitted because compat.emit_tools is disabled"
+            );
+        }
+
+        if let Some(effort) = &request.reasoning_effort {
+            if compat.supports_effort() {
+                body["reasoning"] = json!({ "effort": effort });
+            } else {
+                tracing::warn!(
+                    target: "aion_providers",
+                    "OpenAI Responses reasoning effort omitted because compat.supports_effort is disabled"
+                );
+            }
+        }
+
+        preflight_projected_body(WireProvider::OpenAi, &body, tool_count, compat)?;
+        Ok(body)
+    }
+}
+
+fn flatten_function_tool(tool: Value) -> Option<Value> {
+    let function = tool.get("function")?.as_object()?;
+    let mut flattened = function.clone();
+    flattened.insert("type".to_string(), json!("function"));
+    // Chat Completions tools are non-strict by default. Preserve that contract
+    // when the same ToolDef is projected to Responses.
+    flattened.insert("strict".to_string(), json!(false));
+    Some(Value::Object(flattened))
+}
+
+fn project_input(messages: &[Message], compat: &ProviderCompat) -> Vec<Value> {
+    let tool_use_ids = messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .filter_map(|block| match block {
+            ContentBlock::ToolUse { id, .. } if !id.is_empty() => Some(id.clone()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+    let tool_result_ids = messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .filter_map(|block| match block {
+            ContentBlock::ToolResult { tool_use_id, .. } => Some(tool_use_id.clone()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+
+    let mut input = Vec::new();
+    for message in messages {
+        project_provider_items(message, &mut input);
+
+        match message.role {
+            Role::User | Role::Tool => project_user_message(message, compat, &tool_use_ids, &mut input),
+            Role::Assistant => project_assistant_message(message, compat, &tool_result_ids, &mut input),
+            Role::System => {}
+        }
+    }
+    input
+}
+
+fn project_provider_items(message: &Message, input: &mut Vec<Value>) {
+    for block in &message.content {
+        if let ContentBlock::ProviderItem { provider, item } = block
+            && provider == PROVIDER_ITEM_OWNER
+        {
+            input.push(item.clone());
+        }
+    }
+}
+
+fn project_user_message(
+    message: &Message,
+    compat: &ProviderCompat,
+    tool_use_ids: &HashSet<String>,
+    input: &mut Vec<Value>,
+) {
+    let mut content = Vec::new();
+    for block in &message.content {
+        match block {
+            ContentBlock::Text { text } => {
+                let text = strip_patterns(text, compat);
+                if !text.is_empty() {
+                    content.push(json!({ "type": "input_text", "text": text }));
+                }
+            }
+            ContentBlock::Image { image_url } => {
+                if let Err(error) = image_url.validate() {
+                    tracing::warn!(
+                        target: "aion_providers",
+                        error = %error,
+                        "skipping invalid image block in OpenAI Responses projection"
+                    );
+                    continue;
+                }
+                content.push(json!({
+                    "type": "input_image",
+                    "image_url": image_url.url
+                }));
+            }
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content: output,
+                ..
+            } => {
+                if compat.clean_orphan_tool_results() && !tool_use_ids.contains(tool_use_id) {
+                    tracing::warn!(
+                        target: "aion_providers",
+                        tool_call_id = %tool_use_id,
+                        reason = "orphan_result",
+                        "dropped orphan function_call_output in OpenAI Responses request"
+                    );
+                    continue;
+                }
+                input.push(json!({
+                    "type": "function_call_output",
+                    "call_id": tool_use_id,
+                    "output": output
+                }));
+            }
+            ContentBlock::ToolUse { .. } | ContentBlock::Thinking { .. } | ContentBlock::ProviderItem { .. } => {}
+        }
+    }
+
+    if !content.is_empty() {
+        input.push(json!({ "role": "user", "content": content }));
+    }
+}
+
+fn project_assistant_message(
+    message: &Message,
+    compat: &ProviderCompat,
+    tool_result_ids: &HashSet<String>,
+    input: &mut Vec<Value>,
+) {
+    let text = message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    let text = strip_patterns(&text, compat);
+    if !text.is_empty() {
+        input.push(json!({ "role": "assistant", "content": text }));
+    }
+
+    for block in &message.content {
+        let ContentBlock::ToolUse {
+            id,
+            name,
+            input: arguments,
+            extra,
+        } = block
+        else {
+            continue;
+        };
+
+        if compat.sanitize_malformed_tool_calls() && name.is_empty() {
+            tracing::warn!(
+                target: "aion_providers",
+                tool_call_id = %id,
+                reason = "empty_name",
+                "dropped malformed function_call in OpenAI Responses request"
+            );
+            continue;
+        }
+        if compat.clean_orphan_tool_calls() && !tool_result_ids.contains(id) {
+            tracing::warn!(
+                target: "aion_providers",
+                tool_call_id = %id,
+                reason = "orphan_call",
+                "dropped orphan function_call in OpenAI Responses request"
+            );
+            continue;
+        }
+
+        if let Some(item) = raw_function_call(extra) {
+            input.push(item.clone());
+            continue;
+        }
+
+        let call_id = if id.is_empty() && compat.auto_tool_id() {
+            generate_call_id()
+        } else {
+            id.clone()
+        };
+        input.push(json!({
+            "type": "function_call",
+            "call_id": call_id,
+            "name": name,
+            "arguments": serde_json::to_string(arguments).unwrap_or_default()
+        }));
+    }
+}
+
+fn raw_function_call(extra: &Option<Value>) -> Option<&Value> {
+    extra
+        .as_ref()?
+        .get(PROVIDER_ITEM_OWNER)?
+        .get("function_call")
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("function_call"))
+}
+
+fn strip_patterns(text: &str, compat: &ProviderCompat) -> String {
+    let mut result = text.to_string();
+    if let Some(patterns) = &compat.messages.strip_patterns {
+        for pattern in patterns {
+            result = result.replace(pattern, "");
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+#[path = "openai_responses_projector_test.rs"]
+mod openai_responses_projector_test;

--- a/crates/aion-providers/src/openai_responses_projector_test.rs
+++ b/crates/aion-providers/src/openai_responses_projector_test.rs
@@ -1,0 +1,142 @@
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use aion_types::tool::ToolDef;
+    use serde_json::json;
+
+    use super::*;
+
+    fn request(messages: Vec<Message>, tools: Vec<ToolDef>) -> LlmRequest {
+        LlmRequest {
+            model: "gpt-5.6-sol".to_string(),
+            system: "Be helpful".to_string(),
+            messages,
+            tools,
+            max_tokens: Some(4096),
+            thinking: None,
+            reasoning_effort: Some("high".to_string()),
+        }
+    }
+
+    fn tool() -> ToolDef {
+        ToolDef {
+            name: "get_weather".to_string(),
+            description: "Get weather".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            }),
+            deferred: false,
+        }
+    }
+
+    #[test]
+    fn projects_responses_request_fields_and_flat_function_tools() {
+        let messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "Weather?".to_string(),
+            }],
+        )];
+
+        let body =
+            OpenAiResponsesProjector::project(&request(messages, vec![tool()]), &ProviderCompat::openai_defaults())
+                .expect("Responses body should project");
+
+        assert_eq!(body["model"], "gpt-5.6-sol");
+        assert_eq!(body["instructions"], "Be helpful");
+        assert_eq!(body["max_output_tokens"], 4096);
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert_eq!(body["store"], false);
+        assert_eq!(body["include"], json!(["reasoning.encrypted_content"]));
+        assert_eq!(
+            body["input"][0]["content"][0],
+            json!({"type": "input_text", "text": "Weather?"})
+        );
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["name"], "get_weather");
+        assert_eq!(body["tools"][0]["strict"], false);
+        assert!(body["tools"][0].get("function").is_none());
+        assert!(body.get("messages").is_none());
+        assert!(body.get("max_tokens").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn replays_reasoning_function_call_and_function_output_items() {
+        let reasoning = json!({
+            "id": "rs_1",
+            "type": "reasoning",
+            "encrypted_content": "encrypted",
+            "summary": []
+        });
+        let function_call = json!({
+            "id": "fc_1",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_1",
+            "name": "get_weather",
+            "arguments": "{\"city\":\"Hangzhou\"}"
+        });
+        let extra = json!({
+            (PROVIDER_ITEM_OWNER): {
+                "function_call": function_call.clone()
+            }
+        });
+        let messages = vec![
+            Message::new(
+                Role::Assistant,
+                vec![
+                    ContentBlock::ProviderItem {
+                        provider: PROVIDER_ITEM_OWNER.to_string(),
+                        item: reasoning.clone(),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "call_1".to_string(),
+                        name: "get_weather".to_string(),
+                        input: json!({"city": "Hangzhou"}),
+                        extra: Some(extra),
+                    },
+                ],
+            ),
+            Message::new(
+                Role::User,
+                vec![ContentBlock::ToolResult {
+                    tool_use_id: "call_1".to_string(),
+                    content: "sunny".to_string(),
+                    is_error: false,
+                }],
+            ),
+        ];
+
+        let body =
+            OpenAiResponsesProjector::project(&request(messages, vec![tool()]), &ProviderCompat::openai_defaults())
+                .expect("Responses body should project");
+
+        assert_eq!(body["input"][0], reasoning);
+        assert_eq!(body["input"][1], function_call);
+        assert_eq!(
+            body["input"][2],
+            json!({"type": "function_call_output", "call_id": "call_1", "output": "sunny"})
+        );
+    }
+
+    #[test]
+    fn ignores_opaque_items_owned_by_other_providers() {
+        let messages = vec![Message::new(
+            Role::Assistant,
+            vec![ContentBlock::ProviderItem {
+                provider: "other".to_string(),
+                item: json!({"type": "reasoning", "id": "rs_other"}),
+            }],
+        )];
+
+        let body =
+            OpenAiResponsesProjector::project(&request(messages, Vec::new()), &ProviderCompat::openai_defaults())
+                .expect("Responses body should project");
+
+        assert_eq!(body["input"], json!([]));
+    }
+}

--- a/crates/aion-providers/src/openai_responses_test.rs
+++ b/crates/aion-providers/src/openai_responses_test.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parses_text_reasoning_and_refusal_deltas() {
+        let mut state = StreamState::new();
+
+        let text = parse_sse_chunk(r#"{"type":"response.output_text.delta","delta":"Hello"}"#, &mut state);
+        let reasoning = parse_sse_chunk(
+            r#"{"type":"response.reasoning_summary_text.delta","delta":"Thinking"}"#,
+            &mut state,
+        );
+        let refusal = parse_sse_chunk(
+            r#"{"type":"response.refusal.delta","delta":"Cannot do that"}"#,
+            &mut state,
+        );
+
+        assert!(matches!(&text[0], LlmEvent::TextDelta(delta) if delta == "Hello"));
+        assert!(matches!(&reasoning[0], LlmEvent::ThinkingDelta(delta) if delta == "Thinking"));
+        assert!(matches!(&refusal[0], LlmEvent::TextDelta(delta) if delta == "Cannot do that"));
+    }
+
+    #[test]
+    fn parses_reasoning_and_function_call_items_with_call_id() {
+        let mut state = StreamState::new();
+        let reasoning = parse_sse_chunk(
+            r#"{"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"secret","summary":[]}}"#,
+            &mut state,
+        );
+        let tool = parse_sse_chunk(
+            r#"{"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","status":"completed","call_id":"call_1","name":"read","arguments":"{\"path\":\"a.txt\"}"}}"#,
+            &mut state,
+        );
+
+        assert!(matches!(
+            &reasoning[0],
+            LlmEvent::ProviderItem { provider, item }
+                if provider == PROVIDER_ITEM_OWNER && item["encrypted_content"] == "secret"
+        ));
+        match &tool[0] {
+            LlmEvent::ToolUse { id, name, input, extra } => {
+                assert_eq!(id, "call_1");
+                assert_eq!(name, "read");
+                assert_eq!(input, &json!({"path": "a.txt"}));
+                assert_eq!(
+                    extra.as_ref().unwrap()[PROVIDER_ITEM_OWNER]["function_call"]["id"],
+                    "fc_1"
+                );
+            }
+            event => panic!("expected ToolUse, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn completed_response_deduplicates_items_and_emits_usage() {
+        let mut state = StreamState::new();
+        let item = r#"{"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"read","arguments":"{}"}}"#;
+        assert_eq!(parse_sse_chunk(item, &mut state).len(), 1);
+
+        let completed = parse_sse_chunk(
+            r#"{"type":"response.completed","response":{"status":"completed","output":[{"id":"fc_1","type":"function_call","call_id":"call_1","name":"read","arguments":"{}"}],"usage":{"input_tokens":100,"input_tokens_details":{"cached_tokens":80},"output_tokens":20}}}"#,
+            &mut state,
+        );
+
+        assert_eq!(completed.len(), 1);
+        match &completed[0] {
+            LlmEvent::Done { stop_reason, usage } => {
+                assert_eq!(*stop_reason, StopReason::ToolUse);
+                assert_eq!(usage.input_tokens, 100);
+                assert_eq!(usage.cache_read_tokens, 80);
+                assert_eq!(usage.output_tokens, 20);
+            }
+            event => panic!("expected Done, got {event:?}"),
+        }
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn incomplete_max_output_tokens_maps_to_max_tokens() {
+        let mut state = StreamState::new();
+        let events = parse_sse_chunk(
+            r#"{"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":10,"output_tokens":5}}}"#,
+            &mut state,
+        );
+
+        assert!(matches!(
+            &events[0],
+            LlmEvent::Done { stop_reason: StopReason::MaxTokens, usage }
+                if usage.input_tokens == 10 && usage.output_tokens == 5
+        ));
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn failed_and_error_events_surface_provider_messages() {
+        let mut failed_state = StreamState::new();
+        let failed = parse_sse_chunk(
+            r#"{"type":"response.failed","response":{"error":{"message":"failed message"}}}"#,
+            &mut failed_state,
+        );
+        let mut error_state = StreamState::new();
+        let error = parse_sse_chunk(
+            r#"{"type":"error","error":{"message":"stream message"}}"#,
+            &mut error_state,
+        );
+
+        assert!(matches!(&failed[0], LlmEvent::Error(message) if message == "failed message"));
+        assert!(matches!(&error[0], LlmEvent::Error(message) if message == "stream message"));
+        assert!(failed_state.is_terminal());
+        assert!(error_state.is_terminal());
+    }
+}

--- a/crates/aion-providers/src/parser.rs
+++ b/crates/aion-providers/src/parser.rs
@@ -15,6 +15,28 @@ pub(crate) struct OpenAiParser {
     pub auto_tool_id: bool,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct OpenAiResponsesParser;
+
+impl ResponseParser for OpenAiResponsesParser {
+    type State = crate::openai_responses::StreamState;
+
+    fn new_state(&self) -> Self::State {
+        crate::openai_responses::StreamState::new()
+    }
+
+    fn parse_frame(&self, frame: &Frame, state: &mut Self::State) -> Vec<LlmEvent> {
+        match frame.kind {
+            FrameKind::Data => crate::openai_responses::parse_sse_chunk(&frame.data, state),
+            FrameKind::Done => Vec::new(),
+        }
+    }
+
+    fn finish(&self, _state: &mut Self::State) -> Vec<LlmEvent> {
+        Vec::new()
+    }
+}
+
 impl ResponseParser for OpenAiParser {
     type State = crate::openai::StreamState;
 

--- a/crates/aion-providers/src/projector.rs
+++ b/crates/aion-providers/src/projector.rs
@@ -325,7 +325,7 @@ pub(crate) fn classify_tools_wire_shape_mismatch(
     ))
 }
 
-fn preflight_projected_body(
+pub(crate) fn preflight_projected_body(
     provider: WireProvider,
     body: &Value,
     tool_count: usize,

--- a/crates/aion-providers/src/stream_process.rs
+++ b/crates/aion-providers/src/stream_process.rs
@@ -5,12 +5,13 @@ use aion_types::message::{StopReason, TokenUsage};
 
 use crate::error::ProviderError;
 use crate::framing::{FrameKind, SseBlockFramer, SseLineFramer, bedrock_payload_to_frame};
-use crate::parser::{AnthropicParser, OpenAiParser, ResponseParser};
+use crate::parser::{AnthropicParser, OpenAiParser, OpenAiResponsesParser, ResponseParser};
 use crate::stream_runner::StreamOutcome;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum StreamDecoder {
     OpenAiSseLine { auto_tool_id: bool },
+    OpenAiResponsesSse,
     AnthropicSseBlock,
     BedrockAwsEventStream,
 }
@@ -19,9 +20,66 @@ impl StreamDecoder {
     pub(crate) async fn process(self, response: reqwest::Response, tx: &mpsc::Sender<LlmEvent>) -> StreamOutcome {
         match self {
             Self::OpenAiSseLine { auto_tool_id } => process_openai_sse_stream(response, tx, auto_tool_id).await,
+            Self::OpenAiResponsesSse => process_openai_responses_sse_stream(response, tx).await,
             Self::AnthropicSseBlock => process_anthropic_sse_stream(response, tx).await,
             Self::BedrockAwsEventStream => process_bedrock_aws_event_stream(response, tx).await,
         }
+    }
+}
+
+pub(crate) async fn process_openai_responses_sse_stream(
+    response: reqwest::Response,
+    tx: &mpsc::Sender<LlmEvent>,
+) -> StreamOutcome {
+    use futures::StreamExt;
+
+    let parser = OpenAiResponsesParser;
+    let mut state = parser.new_state();
+    let mut framer = SseLineFramer::default();
+    let mut stream = response.bytes_stream();
+    let mut emitted_content = false;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                let error = ProviderError::Connection(error.to_string());
+                return if emitted_content {
+                    StreamOutcome::FailedPartial(error)
+                } else {
+                    StreamOutcome::FailedEmpty(error)
+                };
+            }
+        };
+        let text = String::from_utf8_lossy(&chunk);
+        for frame in framer.push_text(&text, "[DONE]") {
+            tracing::debug!(target: "aion_providers", event_type = ?frame.event, "OpenAI Responses SSE event received");
+            let events = parser.parse_frame(&frame, &mut state);
+            for event in events {
+                if matches!(
+                    event,
+                    LlmEvent::TextDelta(_)
+                        | LlmEvent::ThinkingDelta(_)
+                        | LlmEvent::ProviderItem { .. }
+                        | LlmEvent::ToolUse { .. }
+                ) {
+                    emitted_content = true;
+                }
+                if tx.send(event).await.is_err() {
+                    return StreamOutcome::Ok;
+                }
+            }
+            if state.is_terminal() {
+                return StreamOutcome::Ok;
+            }
+        }
+    }
+
+    let error = ProviderError::Connection("OpenAI Responses stream ended without a terminal event".to_string());
+    if emitted_content {
+        StreamOutcome::FailedPartial(error)
+    } else {
+        StreamOutcome::FailedEmpty(error)
     }
 }
 

--- a/crates/aion-providers/src/stream_process_test.rs
+++ b/crates/aion-providers/src/stream_process_test.rs
@@ -122,4 +122,43 @@ mod tests {
             event => panic!("expected synthesized Done event, got {event:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn openai_responses_stream_decodes_typed_events_until_completed() {
+        let body = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"read\",\"arguments\":\"{}\"}}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":3}}}\n\n"
+        );
+        let response = mock_response(body.as_bytes().to_vec()).await;
+        let (tx, rx) = mpsc::channel(8);
+
+        let outcome = process_openai_responses_sse_stream(response, &tx).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+
+        assert!(matches!(outcome, StreamOutcome::Ok));
+        assert_eq!(events.len(), 3);
+        assert!(matches!(&events[0], LlmEvent::TextDelta(text) if text == "Hello"));
+        assert!(matches!(&events[1], LlmEvent::ToolUse { id, .. } if id == "call_1"));
+        assert!(matches!(
+            &events[2],
+            LlmEvent::Done { stop_reason: StopReason::ToolUse, usage }
+                if usage.input_tokens == 8 && usage.output_tokens == 3
+        ));
+    }
+
+    #[tokio::test]
+    async fn openai_responses_stream_without_terminal_event_fails_partial() {
+        let body = b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n".to_vec();
+        let response = mock_response(body).await;
+        let (tx, rx) = mpsc::channel(8);
+
+        let outcome = process_openai_responses_sse_stream(response, &tx).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+
+        assert!(matches!(outcome, StreamOutcome::FailedPartial(_)));
+        assert!(matches!(&events[0], LlmEvent::TextDelta(text) if text == "partial"));
+    }
 }

--- a/crates/aion-providers/src/transport.rs
+++ b/crates/aion-providers/src/transport.rs
@@ -1,10 +1,11 @@
-use aion_config::compat::ProviderCompat;
+use aion_config::compat::{OpenAiApiMode, ProviderCompat};
 use aion_types::llm::LlmRequest;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde_json::Value;
 
 use crate::bedrock::BedrockTransportState;
 use crate::error::ProviderError;
+use crate::openai_responses_projector::OpenAiResponsesProjector;
 use crate::projector::{
     AnthropicWireProjector, OpenAiProjector, ResolvedToolWireShape, WireParams, WireProvider,
     classify_tools_wire_shape_mismatch, projection_to_provider_error,
@@ -18,6 +19,7 @@ use crate::vertex::VertexTransportState;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum WireProtocol {
     OpenAiChat,
+    OpenAiResponses,
     AnthropicMessages,
 }
 
@@ -86,7 +88,7 @@ impl OpenAiTransport {
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
         Ok(ProjectedHttpRequest {
-            url: join_base_url_and_api_path(&self.base_url, compat.api_path()),
+            url: join_base_url_and_api_path(&self.base_url, compat.openai_api_path()),
             headers,
             body,
             body_bytes: None,
@@ -140,9 +142,12 @@ impl AnthropicTransport {
 
 impl ProviderTransport {
     #[cfg(test)]
-    pub(crate) fn wire_protocol(&self) -> WireProtocol {
+    pub(crate) fn wire_protocol(&self, compat: &ProviderCompat) -> WireProtocol {
         match self {
-            Self::OpenAi(_) => WireProtocol::OpenAiChat,
+            Self::OpenAi(_) => match compat.openai_api_mode() {
+                OpenAiApiMode::ChatCompletions => WireProtocol::OpenAiChat,
+                OpenAiApiMode::Responses => WireProtocol::OpenAiResponses,
+            },
             Self::Anthropic(_) | Self::Vertex(_) | Self::Bedrock(_) => WireProtocol::AnthropicMessages,
         }
     }
@@ -157,8 +162,11 @@ impl ProviderTransport {
 
     pub(crate) fn decoder(&self, compat: &ProviderCompat) -> StreamDecoder {
         match self {
-            Self::OpenAi(_) => StreamDecoder::OpenAiSseLine {
-                auto_tool_id: compat.auto_tool_id(),
+            Self::OpenAi(_) => match compat.openai_api_mode() {
+                OpenAiApiMode::ChatCompletions => StreamDecoder::OpenAiSseLine {
+                    auto_tool_id: compat.auto_tool_id(),
+                },
+                OpenAiApiMode::Responses => StreamDecoder::OpenAiResponsesSse,
             },
             Self::Anthropic(_) | Self::Vertex(_) => StreamDecoder::AnthropicSseBlock,
             Self::Bedrock(_) => StreamDecoder::BedrockAwsEventStream,
@@ -171,10 +179,17 @@ impl ProviderTransport {
         compat: &ProviderCompat,
     ) -> Result<(Value, ResolvedToolWireShape), ProviderError> {
         match self {
-            Self::OpenAi(_) => {
-                let body = OpenAiProjector::project(request, compat).map_err(projection_to_provider_error)?;
-                Ok((body, OpenAiProjector::resolved_tool_wire_shape(compat)))
-            }
+            Self::OpenAi(_) => match compat.openai_api_mode() {
+                OpenAiApiMode::ChatCompletions => {
+                    let body = OpenAiProjector::project(request, compat).map_err(projection_to_provider_error)?;
+                    Ok((body, OpenAiProjector::resolved_tool_wire_shape(compat)))
+                }
+                OpenAiApiMode::Responses => {
+                    let body =
+                        OpenAiResponsesProjector::project(request, compat).map_err(projection_to_provider_error)?;
+                    Ok((body, ResolvedToolWireShape::OpenAiFunction))
+                }
+            },
 
             Self::Anthropic(transport) => {
                 let params = WireParams {

--- a/crates/aion-providers/src/transport_test.rs
+++ b/crates/aion-providers/src/transport_test.rs
@@ -4,7 +4,7 @@ use super::*;
 mod tests {
     use super::*;
 
-    use aion_config::compat::ProviderCompat;
+    use aion_config::compat::{OpenAiApiMode, ProviderCompat};
     use aion_types::llm::LlmRequest;
     use aion_types::message::{ContentBlock, Message, Role};
     use aion_types::tool::ToolDef;
@@ -54,11 +54,21 @@ mod tests {
         let transport = ProviderTransport::OpenAi(OpenAiTransport::new("test-key", "https://example.test"));
         let compat = ProviderCompat::openai_defaults();
 
-        assert_eq!(transport.wire_protocol(), WireProtocol::OpenAiChat);
+        assert_eq!(transport.wire_protocol(&compat), WireProtocol::OpenAiChat);
         assert_eq!(
             transport.decoder(&compat),
             StreamDecoder::OpenAiSseLine { auto_tool_id: true }
         );
+    }
+
+    #[test]
+    fn openai_transport_selects_responses_wire_and_decoder_when_configured() {
+        let transport = ProviderTransport::OpenAi(OpenAiTransport::new("test-key", "https://example.test"));
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.transport.openai_api_mode = Some(OpenAiApiMode::Responses);
+
+        assert_eq!(transport.wire_protocol(&compat), WireProtocol::OpenAiResponses);
+        assert_eq!(transport.decoder(&compat), StreamDecoder::OpenAiResponsesSse);
     }
 
     #[test]
@@ -94,6 +104,23 @@ mod tests {
     }
 
     #[test]
+    fn openai_transport_uses_responses_path_when_configured() {
+        let transport = OpenAiTransport::new("test-key", "https://api.openai.com");
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.transport.openai_api_mode = Some(OpenAiApiMode::Responses);
+
+        let request = transport
+            .build_projected_request(
+                json!({ "model": "gpt-5.6-sol" }),
+                &compat,
+                ResolvedToolWireShape::OpenAiFunction,
+            )
+            .expect("request projection should succeed");
+
+        assert_eq!(request.url, "https://api.openai.com/v1/responses");
+    }
+
+    #[test]
     fn openai_transport_custom_api_path_overrides_default_chat_path() {
         let transport = OpenAiTransport::new("test-key", "https://open.bigmodel.cn/api/paas/v4/");
         let mut compat = ProviderCompat::openai_defaults();
@@ -115,7 +142,7 @@ mod tests {
         let transport = ProviderTransport::Anthropic(AnthropicTransport::new("test-key", "https://example.test", true));
         let compat = ProviderCompat::anthropic_defaults();
 
-        assert_eq!(transport.wire_protocol(), WireProtocol::AnthropicMessages);
+        assert_eq!(transport.wire_protocol(&compat), WireProtocol::AnthropicMessages);
         assert_eq!(transport.decoder(&compat), StreamDecoder::AnthropicSseBlock);
     }
 
@@ -131,7 +158,7 @@ mod tests {
             .project_body(&request, &compat)
             .expect("request body projection should succeed");
 
-        assert_eq!(transport.wire_protocol(), WireProtocol::AnthropicMessages);
+        assert_eq!(transport.wire_protocol(&compat), WireProtocol::AnthropicMessages);
         assert_eq!(tool_wire_shape, ResolvedToolWireShape::AnthropicInputSchema);
         assert_eq!(body["anthropic_version"], "vertex-2023-10-16");
         assert_eq!(body["stream"], true);
@@ -160,7 +187,7 @@ mod tests {
             .project_body(&request, &compat)
             .expect("request body projection should succeed");
 
-        assert_eq!(transport.wire_protocol(), WireProtocol::AnthropicMessages);
+        assert_eq!(transport.wire_protocol(&compat), WireProtocol::AnthropicMessages);
         assert_eq!(transport.retry_policy(), RetryPolicy::new(0, false, false, true));
         assert_eq!(tool_wire_shape, ResolvedToolWireShape::AnthropicInputSchema);
         assert_eq!(body["anthropic_version"], "bedrock-2023-05-31");
@@ -186,6 +213,26 @@ mod tests {
         assert_eq!(body["messages"][1]["role"], "user");
         assert!(body["tools"][0].get("function").is_some());
         assert!(body["tools"][0].get("input_schema").is_none());
+    }
+
+    #[test]
+    fn openai_transport_projects_responses_body_shape_when_configured() {
+        let transport = ProviderTransport::OpenAi(OpenAiTransport::new("test-key", "https://example.test"));
+        let request = test_request(vec![test_tool()]);
+        let mut compat = ProviderCompat::openai_defaults();
+        compat.transport.openai_api_mode = Some(OpenAiApiMode::Responses);
+
+        let (body, tool_wire_shape) = transport
+            .project_body(&request, &compat)
+            .expect("request body projection should succeed");
+
+        assert_eq!(tool_wire_shape, ResolvedToolWireShape::OpenAiFunction);
+        assert_eq!(body["model"], "test-model");
+        assert_eq!(body["stream"], true);
+        assert!(body.get("messages").is_none());
+        assert_eq!(body["input"][0]["role"], "user");
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert!(body["tools"][0].get("function").is_none());
     }
 
     #[tokio::test]

--- a/crates/aion-providers/tests/provider_openai_test.rs
+++ b/crates/aion-providers/tests/provider_openai_test.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use aion_config::compat::ProviderCompat;
+use aion_config::compat::{OpenAiApiMode, ProviderCompat};
 use aion_providers::LlmProvider;
 use aion_providers::openai::OpenAIProvider;
 use aion_types::llm::{LlmEvent, LlmRequest};
@@ -182,6 +182,77 @@ async fn test_openai_stream_text_response() {
         }
         e => panic!("expected Done, got: {:?}", e),
     }
+}
+
+#[tokio::test]
+async fn test_openai_responses_request_and_typed_stream() {
+    let server = MockServer::start().await;
+    let reasoning_item = json!({
+        "id": "rs_1",
+        "type": "reasoning",
+        "encrypted_content": "encrypted",
+        "summary": []
+    });
+    let function_item = json!({
+        "id": "fc_1",
+        "type": "function_call",
+        "status": "completed",
+        "call_id": "call_1",
+        "name": "read",
+        "arguments": "{\"path\":\"README.md\"}"
+    });
+    let sse_body = format!(
+        "data: {}\n\ndata: {}\n\ndata: {}\n\n",
+        json!({"type": "response.output_item.done", "item": reasoning_item.clone()}),
+        json!({"type": "response.output_item.done", "item": function_item.clone()}),
+        json!({
+            "type": "response.completed",
+            "response": {
+                "status": "completed",
+                "output": [reasoning_item, function_item],
+                "usage": {
+                    "input_tokens": 30,
+                    "input_tokens_details": {"cached_tokens": 20},
+                    "output_tokens": 12
+                }
+            }
+        })
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .and(header("authorization", "Bearer test-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(sse_body, "text/event-stream"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut compat = ProviderCompat::openai_defaults();
+    compat.transport.openai_api_mode = Some(OpenAiApiMode::Responses);
+    let provider = OpenAIProvider::new("test-key", &server.uri(), compat);
+    let mut request = make_request_with_tool();
+    request.model = "gpt-5.6-sol".to_string();
+    request.reasoning_effort = Some("high".to_string());
+    let rx = provider.stream(&request).await.unwrap();
+    let events = collect_events(rx).await;
+
+    assert_eq!(events.len(), 3, "expected provider item, tool use and done: {events:?}");
+    assert!(matches!(&events[0], LlmEvent::ProviderItem { item, .. } if item["id"] == "rs_1"));
+    assert!(matches!(&events[1], LlmEvent::ToolUse { id, name, .. } if id == "call_1" && name == "read"));
+    assert!(matches!(
+        &events[2],
+        LlmEvent::Done { stop_reason: StopReason::ToolUse, usage }
+            if usage.input_tokens == 30 && usage.cache_read_tokens == 20 && usage.output_tokens == 12
+    ));
+
+    let received = server.received_requests().await.unwrap();
+    let body: Value = received[0].body_json().unwrap();
+    assert_eq!(body["model"], "gpt-5.6-sol");
+    assert_eq!(body["reasoning"]["effort"], "high");
+    assert_eq!(body["input"][0]["content"][0]["type"], "input_text");
+    assert_eq!(body["tools"][0]["type"], "function");
+    assert_eq!(body["tools"][0]["name"], "read");
+    assert!(body.get("messages").is_none());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aion-types/src/llm.rs
+++ b/crates/aion-types/src/llm.rs
@@ -40,6 +40,8 @@ pub enum LlmEvent {
     ThinkingDelta(String),
     /// Opaque provider signature for the current thinking block.
     ThinkingSignature(String),
+    /// Opaque provider output item that must be persisted and replayed.
+    ProviderItem { provider: String, item: Value },
     /// Response complete
     Done { stop_reason: StopReason, usage: TokenUsage },
     /// Error from the API

--- a/crates/aion-types/src/message.rs
+++ b/crates/aion-types/src/message.rs
@@ -50,6 +50,11 @@ pub enum ContentBlock {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         signature: Option<String>,
     },
+
+    /// Opaque provider output item that must be replayed on later requests.
+    /// Providers other than the named owner must ignore this block.
+    #[serde(rename = "provider_item")]
+    ProviderItem { provider: String, item: Value },
 }
 
 /// Image URL for content blocks

--- a/crates/aion-types/src/message_test.rs
+++ b/crates/aion-types/src/message_test.rs
@@ -195,6 +195,30 @@ mod tests {
         assert_eq!(value["signature"], "sig-123");
     }
 
+    #[test]
+    fn provider_item_round_trips_opaque_json() {
+        let block = ContentBlock::ProviderItem {
+            provider: "openai_responses".to_string(),
+            item: json!({
+                "id": "rs_1",
+                "type": "reasoning",
+                "encrypted_content": "encrypted"
+            }),
+        };
+
+        let value = serde_json::to_value(&block).unwrap();
+        let round_trip = serde_json::from_value::<ContentBlock>(value.clone()).unwrap();
+
+        assert_eq!(value["type"], "provider_item");
+        assert_eq!(value["provider"], "openai_responses");
+        assert_eq!(value["item"]["encrypted_content"], "encrypted");
+        assert!(matches!(
+            round_trip,
+            ContentBlock::ProviderItem { provider, item }
+                if provider == "openai_responses" && item["id"] == "rs_1"
+        ));
+    }
+
     // --- StopReason variants ---
 
     #[test]

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -90,6 +90,29 @@ aionrs --profile dev "Create a GitHub issue"
 
 ---
 
+## OpenAI Responses API
+
+OpenAI providers use Chat Completions by default so existing OpenAI-compatible
+services keep the same request and streaming format. Select Responses only for
+models or endpoints that require it:
+
+```toml
+[providers.openai]
+api_key = "sk-xxx"
+base_url = "https://api.openai.com/v1"
+
+[providers.openai.compat]
+openai_api_mode = "responses"
+```
+
+The setting changes the complete wire contract: the endpoint becomes
+`/responses`, requests use `input` items and flat function tools, and typed SSE
+events are decoded into the existing provider-neutral agent events. Tool calls
+and encrypted reasoning items are persisted and replayed for subsequent tool
+rounds. `chat_completions` remains the default when the setting is omitted.
+
+---
+
 ## OpenAI-Compatible Thinking Models
 
 Some OpenAI-compatible providers support a `thinking` request object in


### PR DESCRIPTION
## Motivation

GPT-5.6 tool-enabled requests with `reasoning_effort` are rejected by `/v1/chat/completions` and must use the OpenAI Responses API. AionCLI needs to support that protocol without changing the default behavior for existing OpenAI-compatible providers or other provider implementations.

## Summary

- add a config-driven OpenAI API mode with `chat_completions` as the backward-compatible default and `responses` as an explicit opt-in
- implement Responses API request projection, typed SSE parsing, text streaming, function calls/results, and `call_id` correlation
- preserve and replay provider-owned encrypted reasoning items across turns
- keep the provider-neutral agent loop unchanged and isolate protocol-specific behavior in the OpenAI provider transport
- retain the existing Anthropic, Gemini/Vertex, Bedrock, and default OpenAI Chat Completions paths

## Compatibility

- existing configurations continue to use Chat Completions unless `openai_api_mode = "responses"` is selected
- no user-visible protocol selector is introduced
- non-OpenAI providers are not routed through the Responses transport

## Validation

- `just push -u origin jiahe/feat/openai-responses`
- integrated with AionCore using `aionrs@3185442df3d164f4d249c4fa4d21f94d05cc4ffe`
- verified a real `gpt-5.6-sol` tool-enabled request completes through the Responses API

## Related PRs / Merge Order

1. Merge this PR and publish an aionrs release containing the Responses API support.
2. Merge [iOfficeAI/AionCore#636](https://github.com/iOfficeAI/AionCore/pull/636), which enables Responses mode for the GPT-5.6 model family.

## Follow-up

- replace AionCore's temporary commit pin with the released aionrs tag after publication
