### PR TITLE
fix(compact): correct context token accounting

### DIFF
--- a/crates/aion-agent/src/compact/auto.rs
+++ b/crates/aion-agent/src/compact/auto.rs
@@ -1,6 +1,6 @@
-//! Autocompact: watermark-triggered LLM summarization.
+//! Autocompact: context-threshold-triggered LLM summarization.
 //!
-//! When the token watermark exceeds the configured threshold, this module
+//! When the best-known context size exceeds the configured threshold, this module
 //! calls the LLM to produce a structured summary of the conversation,
 //! then replaces the full history with a compact boundary marker and the
 //! summary.  A circuit breaker prevents runaway retries.
@@ -34,7 +34,7 @@ pub struct CompactResult {
     pub messages: Vec<Message>,
     /// How many original messages were summarized.
     pub messages_summarized: usize,
-    /// Input token count before compaction (from the last API call).
+    /// Best-known context token count before compaction.
     pub pre_compact_tokens: u64,
 }
 
@@ -55,11 +55,11 @@ pub enum CompactError {
 
 // ── Trigger check ───────────────────────────────────────────────────────────
 
-/// Check if autocompact should trigger based on the token watermark.
+/// Check if autocompact should trigger based on the best-known context size.
 ///
 /// When `autocompact_threshold_pct` is set, threshold = context_window * pct / 100.
 /// Otherwise falls back to: `threshold = context_window - output_reserve - autocompact_buffer`
-pub fn should_autocompact(last_input_tokens: u64, config: &CompactConfig) -> bool {
+pub fn should_autocompact(context_tokens: u64, config: &CompactConfig) -> bool {
     if !config.enabled {
         return false;
     }
@@ -69,7 +69,7 @@ pub fn should_autocompact(last_input_tokens: u64, config: &CompactConfig) -> boo
         let effective_window = config.context_window.saturating_sub(config.output_reserve);
         effective_window.saturating_sub(config.autocompact_buffer)
     };
-    last_input_tokens as usize >= threshold
+    context_tokens as usize >= threshold
 }
 
 // ── Core autocompact ────────────────────────────────────────────────────────

--- a/crates/aion-agent/src/compact/emergency.rs
+++ b/crates/aion-agent/src/compact/emergency.rs
@@ -1,6 +1,6 @@
 //! Emergency truncation: the last safety net before a context overflow.
 //!
-//! When `last_input_tokens` is within `emergency_buffer` of the full
+//! When the best-known context size is within `emergency_buffer` of the full
 //! `context_window`, the engine should block the next API call and ask
 //! the user to compact or start a new conversation.
 //!
@@ -12,19 +12,19 @@ use aion_config::compact::CompactConfig;
 /// User-facing message shown when the emergency limit is hit.
 pub const EMERGENCY_USER_MESSAGE: &str = "Context window nearly full. Please use /compact or start a new conversation.";
 
-/// Check whether the last observed input token count has reached the
+/// Check whether the best-known context token count has reached the
 /// emergency blocking limit.
 ///
 /// The limit is `context_window - emergency_buffer`.  When
-/// `last_input_tokens >= limit`, the engine must not send another API
+/// `context_tokens >= limit`, the engine must not send another API
 /// request — doing so would almost certainly fail with a prompt-too-long
 /// error from the provider.
 ///
 /// This check is independent of `CompactConfig.enabled`; the emergency
 /// safety net is always active.
-pub fn is_at_emergency_limit(last_input_tokens: u64, config: &CompactConfig) -> bool {
+pub fn is_at_emergency_limit(context_tokens: u64, config: &CompactConfig) -> bool {
     let limit = config.context_window.saturating_sub(config.emergency_buffer);
-    last_input_tokens as usize >= limit
+    context_tokens as usize >= limit
 }
 
 #[cfg(test)]

--- a/crates/aion-agent/src/compact/estimate.rs
+++ b/crates/aion-agent/src/compact/estimate.rs
@@ -1,48 +1,6 @@
-use aion_types::message::{ContentBlock, ImageUrl, Message};
+use aion_types::message::{ContentBlock, ImageUrl};
 
 const CHARS_PER_TOKEN_TEXT: usize = 4;
-
-const CHARS_PER_TOKEN_JSON: usize = 3;
-
-/// Estimate the total token count for a slice of messages.
-///
-/// Intentionally conservative (slightly over-estimates) to ensure
-/// compaction triggers rather than being skipped.
-pub fn estimate_tokens_from_messages(messages: &[Message]) -> u64 {
-    let mut total_chars: usize = 0;
-    let mut json_chars: usize = 0;
-
-    for msg in messages {
-        for block in &msg.content {
-            match block {
-                ContentBlock::Text { text } => {
-                    total_chars += text.len();
-                }
-                ContentBlock::Thinking { thinking, .. } => {
-                    total_chars += thinking.len();
-                }
-                ContentBlock::ToolUse { name, input, .. } => {
-                    let input_str = input.to_string();
-                    json_chars += name.len() + input_str.len();
-                }
-                ContentBlock::ToolResult { content, .. } => {
-                    total_chars += content.len();
-                }
-                ContentBlock::Image { image_url } => {
-                    total_chars += estimate_image_tokens(image_url) as usize * CHARS_PER_TOKEN_TEXT;
-                }
-                ContentBlock::ProviderItem { item, .. } => {
-                    json_chars += item.to_string().len();
-                }
-            }
-        }
-    }
-
-    let text_tokens = total_chars / CHARS_PER_TOKEN_TEXT;
-    let json_tokens = json_chars / CHARS_PER_TOKEN_JSON;
-
-    (text_tokens + json_tokens) as u64
-}
 
 /// Estimate one final tool result that will be added after the provider's
 /// exact usage measurement.

--- a/crates/aion-agent/src/compact/estimate.rs
+++ b/crates/aion-agent/src/compact/estimate.rs
@@ -1,4 +1,4 @@
-use aion_types::message::{ContentBlock, Message};
+use aion_types::message::{ContentBlock, ImageUrl, Message};
 
 const CHARS_PER_TOKEN_TEXT: usize = 4;
 
@@ -29,15 +29,7 @@ pub fn estimate_tokens_from_messages(messages: &[Message]) -> u64 {
                     total_chars += content.len();
                 }
                 ContentBlock::Image { image_url } => {
-                    // Image token cost is not proportional to base64 string length.
-                    // Use a provider-agnostic heuristic based on decoded byte size,
-                    // clamped to reasonable per-image bounds.
-                    const BYTES_PER_TOKEN: usize = 750;
-                    const MIN_IMAGE_TOKENS: usize = 85;
-                    const MAX_IMAGE_TOKENS: usize = 2048;
-                    let bytes = image_url.decoded_byte_size().unwrap_or(0);
-                    let tokens = (bytes / BYTES_PER_TOKEN).clamp(MIN_IMAGE_TOKENS, MAX_IMAGE_TOKENS);
-                    total_chars += tokens * CHARS_PER_TOKEN_TEXT;
+                    total_chars += estimate_image_tokens(image_url) as usize * CHARS_PER_TOKEN_TEXT;
                 }
                 ContentBlock::ProviderItem { item, .. } => {
                     json_chars += item.to_string().len();
@@ -50,6 +42,35 @@ pub fn estimate_tokens_from_messages(messages: &[Message]) -> u64 {
     let json_tokens = json_chars / CHARS_PER_TOKEN_JSON;
 
     (text_tokens + json_tokens) as u64
+}
+
+/// Estimate one final tool result that will be added after the provider's
+/// exact usage measurement.
+pub(crate) fn estimate_tokens_from_tool_result(block: &ContentBlock) -> u64 {
+    match block {
+        ContentBlock::ToolResult { content, .. } => (content.len() / CHARS_PER_TOKEN_TEXT) as u64,
+        _ => 0,
+    }
+}
+
+/// Estimate an image block emitted by a tool for the next provider request.
+pub(crate) fn estimate_tokens_from_tool_image(block: &ContentBlock) -> u64 {
+    match block {
+        ContentBlock::Image { image_url } => estimate_image_tokens(image_url),
+        _ => 0,
+    }
+}
+
+fn estimate_image_tokens(image_url: &ImageUrl) -> u64 {
+    // Image token cost is not proportional to base64 string length. Use a
+    // provider-agnostic heuristic based on decoded byte size and clamp it to
+    // reasonable per-image bounds.
+    const BYTES_PER_TOKEN: usize = 750;
+    const MIN_IMAGE_TOKENS: usize = 85;
+    const MAX_IMAGE_TOKENS: usize = 2048;
+
+    let bytes = image_url.decoded_byte_size().unwrap_or(0);
+    (bytes / BYTES_PER_TOKEN).clamp(MIN_IMAGE_TOKENS, MAX_IMAGE_TOKENS) as u64
 }
 
 #[cfg(test)]

--- a/crates/aion-agent/src/compact/estimate_test.rs
+++ b/crates/aion-agent/src/compact/estimate_test.rs
@@ -112,21 +112,21 @@ mod tests {
     }
 
     #[test]
-    fn effective_watermark_uses_max() {
-        let provider_reported: u64 = 500;
-        let messages = vec![Message::new(
-            Role::User,
-            vec![ContentBlock::ToolResult {
-                tool_use_id: "c1".into(),
-                content: "x".repeat(400_000),
-                is_error: false,
-            }],
-        )];
-        let local_estimate = estimate_tokens_from_messages(&messages);
-        let effective = provider_reported.max(local_estimate);
+    fn final_tool_result_is_estimated_directly() {
+        let result = ContentBlock::ToolResult {
+            tool_use_id: "c1".into(),
+            content: "x".repeat(400_000),
+            is_error: false,
+        };
 
-        assert_eq!(effective, 100_000);
-        assert!(effective > provider_reported);
+        assert_eq!(estimate_tokens_from_tool_result(&result), 100_000);
+    }
+
+    #[test]
+    fn non_tool_result_is_not_counted_as_tool_output() {
+        let text = ContentBlock::Text { text: "x".repeat(400) };
+
+        assert_eq!(estimate_tokens_from_tool_result(&text), 0);
     }
 
     #[test]
@@ -168,5 +168,17 @@ mod tests {
         let estimate = estimate_tokens_from_messages(&[msg]);
         // Maximum 2048 tokens * 4 chars/token.
         assert_eq!(estimate, 2048);
+    }
+
+    #[test]
+    fn tool_image_is_estimated_directly() {
+        let data = STANDARD.encode(vec![0u8; 10_000]);
+        let image = ContentBlock::Image {
+            image_url: ImageUrl {
+                url: format!("data:image/png;base64,{}", data),
+            },
+        };
+
+        assert_eq!(estimate_tokens_from_tool_image(&image), 85);
     }
 }

--- a/crates/aion-agent/src/compact/estimate_test.rs
+++ b/crates/aion-agent/src/compact/estimate_test.rs
@@ -3,113 +3,9 @@ use super::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aion_types::message::{ImageUrl, Message, Role};
+    use aion_types::message::ImageUrl;
     use base64::Engine;
     use base64::engine::general_purpose::STANDARD;
-    use serde_json::json;
-
-    #[test]
-    fn empty_messages_returns_zero() {
-        assert_eq!(estimate_tokens_from_messages(&[]), 0);
-    }
-
-    #[test]
-    fn text_only_message() {
-        let text = "a".repeat(400);
-        let msg = Message::new(Role::User, vec![ContentBlock::Text { text }]);
-        assert_eq!(estimate_tokens_from_messages(&[msg]), 100);
-    }
-
-    #[test]
-    fn tool_use_message_uses_json_ratio() {
-        let input = json!({"cmd": "ls -la"});
-        let input_len = "ExecCommand".len() + input.to_string().len();
-        let msg = Message::new(
-            Role::Assistant,
-            vec![ContentBlock::ToolUse {
-                id: "call_1".into(),
-                name: "ExecCommand".into(),
-                input,
-                extra: None,
-            }],
-        );
-        let result = estimate_tokens_from_messages(&[msg]);
-        assert_eq!(result, (input_len / CHARS_PER_TOKEN_JSON) as u64);
-    }
-
-    #[test]
-    fn tool_result_uses_text_ratio() {
-        let content = "x".repeat(800);
-        let msg = Message::new(
-            Role::User,
-            vec![ContentBlock::ToolResult {
-                tool_use_id: "call_1".into(),
-                content,
-                is_error: false,
-            }],
-        );
-        assert_eq!(estimate_tokens_from_messages(&[msg]), 200);
-    }
-
-    #[test]
-    fn mixed_conversation_accumulates() {
-        let messages = vec![
-            Message::new(Role::User, vec![ContentBlock::Text { text: "a".repeat(400) }]),
-            Message::new(
-                Role::Assistant,
-                vec![
-                    ContentBlock::Text { text: "b".repeat(200) },
-                    ContentBlock::ToolUse {
-                        id: "c1".into(),
-                        name: "Read".into(),
-                        input: json!({"path": "/foo/bar.rs"}),
-                        extra: None,
-                    },
-                ],
-            ),
-            Message::new(
-                Role::User,
-                vec![ContentBlock::ToolResult {
-                    tool_use_id: "c1".into(),
-                    content: "c".repeat(1200),
-                    is_error: false,
-                }],
-            ),
-        ];
-        let estimate = estimate_tokens_from_messages(&messages);
-        // text_tokens = (400 + 200 + 1200) / 4 = 450
-        // json_tokens = ("Read".len() + json_string.len()) / 3
-        assert!(estimate > 450);
-        assert!(estimate < 600);
-    }
-
-    #[test]
-    fn thinking_block_counted() {
-        let thinking = "t".repeat(4000);
-        let msg = Message::new(
-            Role::Assistant,
-            vec![ContentBlock::Thinking {
-                thinking,
-                signature: None,
-            }],
-        );
-        assert_eq!(estimate_tokens_from_messages(&[msg]), 1000);
-    }
-
-    #[test]
-    fn large_conversation_realistic_estimate() {
-        let big_result = "x".repeat(400_000);
-        let messages = vec![Message::new(
-            Role::User,
-            vec![ContentBlock::ToolResult {
-                tool_use_id: "c1".into(),
-                content: big_result,
-                is_error: false,
-            }],
-        )];
-        let estimate = estimate_tokens_from_messages(&messages);
-        assert_eq!(estimate, 100_000);
-    }
 
     #[test]
     fn final_tool_result_is_estimated_directly() {
@@ -130,20 +26,17 @@ mod tests {
     }
 
     #[test]
-    fn image_block_uses_decoded_size_not_base64_length() {
+    fn tool_image_uses_decoded_size_not_base64_length() {
         // 10_000 decoded bytes -> 10_000 / 750 = 13 tokens, clamped to minimum 85.
         let image_bytes = vec![0u8; 10_000];
         let data = STANDARD.encode(&image_bytes);
-        let msg = Message::new(
-            Role::User,
-            vec![ContentBlock::Image {
-                image_url: ImageUrl {
-                    url: format!("data:image/png;base64,{}", data),
-                },
-            }],
-        );
-        let estimate = estimate_tokens_from_messages(&[msg]);
-        // 85 tokens * 4 chars/token = 340 chars counted as text.
+        let image = ContentBlock::Image {
+            image_url: ImageUrl {
+                url: format!("data:image/png;base64,{}", data),
+            },
+        };
+        let estimate = estimate_tokens_from_tool_image(&image);
+
         assert_eq!(estimate, 85);
         // The old base64-length heuristic would have counted ~13_333 chars -> ~3_333 tokens.
         assert!(
@@ -153,32 +46,16 @@ mod tests {
     }
 
     #[test]
-    fn image_block_estimate_respects_maximum() {
+    fn tool_image_estimate_respects_maximum() {
         // A huge image should be capped, not grow with base64 length.
         let image_bytes = vec![0u8; 10_000_000];
         let data = STANDARD.encode(&image_bytes);
-        let msg = Message::new(
-            Role::User,
-            vec![ContentBlock::Image {
-                image_url: ImageUrl {
-                    url: format!("data:image/png;base64,{}", data),
-                },
-            }],
-        );
-        let estimate = estimate_tokens_from_messages(&[msg]);
-        // Maximum 2048 tokens * 4 chars/token.
-        assert_eq!(estimate, 2048);
-    }
-
-    #[test]
-    fn tool_image_is_estimated_directly() {
-        let data = STANDARD.encode(vec![0u8; 10_000]);
         let image = ContentBlock::Image {
             image_url: ImageUrl {
                 url: format!("data:image/png;base64,{}", data),
             },
         };
 
-        assert_eq!(estimate_tokens_from_tool_image(&image), 85);
+        assert_eq!(estimate_tokens_from_tool_image(&image), 2048);
     }
 }

--- a/crates/aion-agent/src/compact/mod.rs
+++ b/crates/aion-agent/src/compact/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Three levels, from lightest to heaviest:
 //! - **Microcompact**: clears old tool result content (no LLM call)
-//! - **Autocompact**: watermark-triggered LLM summarization
+//! - **Autocompact**: context-threshold-triggered LLM summarization
 //! - **Emergency**: blocks API calls when near the context window limit
 
 pub mod auto;

--- a/crates/aion-agent/src/compact/state.rs
+++ b/crates/aion-agent/src/compact/state.rs
@@ -8,7 +8,12 @@ use aion_config::compact::CompactConfig;
 pub struct CompactState {
     /// Number of consecutive autocompact failures.
     pub consecutive_failures: u32,
-    /// Input token count from the last API call (used as the watermark).
+    /// Best-known size of the context for the next provider request.
+    ///
+    /// A completed provider turn replaces this value with its exact
+    /// `input_tokens + output_tokens`. Content appended after that response,
+    /// such as tool results, is added using a local estimate.
+    /// The historical field name is retained for source compatibility.
     pub last_input_tokens: u64,
 }
 

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -7,7 +7,7 @@ use crate::cache_diagnostics::{CacheBreakDetector, CacheDiagnostic, CacheStats};
 use crate::commands::{CommandContext, CommandRegistry, CommandResult, SlashCommand, default_registry};
 use crate::compact::auto::{CompactError, autocompact, should_autocompact};
 use crate::compact::emergency::is_at_emergency_limit;
-use crate::compact::estimate::estimate_tokens_from_messages;
+use crate::compact::estimate::{estimate_tokens_from_tool_image, estimate_tokens_from_tool_result};
 use crate::compact::micro::{microcompact, should_microcompact};
 use crate::compact::state::CompactState;
 use crate::confirm::ToolConfirmer;
@@ -113,7 +113,7 @@ pub struct AgentEngine {
     // Compaction and plan-mode state.
     /// Static compaction thresholds, flags, and sizing configuration.
     compact_config: CompactConfig,
-    /// Runtime compaction watermark and circuit-breaker state.
+    /// Runtime context-size and compaction circuit-breaker state.
     compact_state: CompactState,
     /// Active compaction strategy level.
     compact_level: CompactLevel,
@@ -487,6 +487,7 @@ impl AgentEngine {
             self.apply_context_modifiers(&tool_modifiers);
 
             self.emit_tool_results(&tool_calls, &tool_results);
+            self.record_tool_context_estimate(&tool_results, &follow_up_blocks);
 
             self.messages.push(Message::now(Role::User, tool_results));
             if !follow_up_blocks.is_empty() {
@@ -746,7 +747,7 @@ impl AgentEngine {
         );
         async {
             // Run multi-level compaction before each API call.
-            // On the first model turn last_input_tokens is 0 so neither
+            // On the first model turn context_tokens is 0 so neither
             // autocompact nor emergency will fire.
             self.run_compaction().await?;
             let request = self.build_request(kind);
@@ -889,29 +890,15 @@ impl AgentEngine {
         })
     }
 
-    /// Fold one turn's token usage into the running totals and update the
-    /// compaction watermark and cache-break diagnostics.
+    /// Fold one turn's token usage into the running totals and replace the
+    /// best-known context size with the provider's exact turn total.
     fn record_turn_usage(&mut self, turn_usage: &TokenUsage) {
         self.total_usage.input_tokens += turn_usage.input_tokens;
         self.total_usage.output_tokens += turn_usage.output_tokens;
         self.total_usage.cache_creation_tokens += turn_usage.cache_creation_tokens;
         self.total_usage.cache_read_tokens += turn_usage.cache_read_tokens;
 
-        // Track per-turn input tokens for compaction watermark.
-        // Use max(provider_reported, local_estimate) as a safety net:
-        // some providers (e.g. DeepSeek with prefix caching) underreport
-        // prompt_tokens, causing compaction to never trigger.
-        let local_estimate = estimate_tokens_from_messages(&self.messages);
-        let effective_watermark = turn_usage.input_tokens.max(local_estimate);
-
-        if local_estimate > turn_usage.input_tokens && local_estimate.saturating_sub(turn_usage.input_tokens) > 10_000 {
-            self.output.emit_info(&format!(
-                "Token watermark override: provider={}, local_estimate={}, using={}",
-                turn_usage.input_tokens, local_estimate, effective_watermark
-            ));
-        }
-
-        self.compact_state.last_input_tokens = effective_watermark;
+        self.compact_state.last_input_tokens = turn_usage.input_tokens.saturating_add(turn_usage.output_tokens);
 
         // Cache break detection
         let cache_stats = CacheStats {
@@ -940,6 +927,28 @@ impl AgentEngine {
         }
     }
 
+    /// Add content produced after the provider usage snapshot. Every final
+    /// tool result is estimated once; tool-emitted images are counted because
+    /// they are also sent in the next provider request.
+    fn record_tool_context_estimate(&mut self, tool_results: &[ContentBlock], tool_images: &[ContentBlock]) {
+        let tool_result_tokens = tool_results.iter().fold(0_u64, |total, result| {
+            total.saturating_add(estimate_tokens_from_tool_result(result))
+        });
+        let tool_image_tokens = tool_images.iter().fold(0_u64, |total, image| {
+            total.saturating_add(estimate_tokens_from_tool_image(image))
+        });
+        let added_tokens = tool_result_tokens.saturating_add(tool_image_tokens);
+
+        self.compact_state.last_input_tokens = self.compact_state.last_input_tokens.saturating_add(added_tokens);
+        debug!(
+            target: "aion_agent",
+            tool_result_tokens,
+            tool_image_tokens,
+            context_tokens = self.compact_state.last_input_tokens,
+            "tool results added to context token estimate"
+        );
+    }
+
     /// Run the multi-level compaction pipeline before each API call.
     ///
     /// Execution order: microcompact → autocompact → emergency check.
@@ -961,7 +970,7 @@ impl AgentEngine {
         let mut compacted = false;
         let should_compact = should_autocompact(self.compact_state.last_input_tokens, &self.compact_config);
         if should_compact {
-            info!(target: "aion_agent", last_input_tokens = self.compact_state.last_input_tokens, "context compaction triggered");
+            info!(target: "aion_agent", context_tokens = self.compact_state.last_input_tokens, "context compaction triggered");
             let threshold = if let Some(pct) = self.compact_config.autocompact_threshold_pct {
                 let t = self.compact_config.context_window * pct as usize / 100;
                 self.output.emit_info(&format!(
@@ -1008,7 +1017,7 @@ impl AgentEngine {
         } else if should_compact {
             self.output.emit_info(&format!(
                 "Autocompact: skipped (circuit breaker tripped after {} consecutive failures, \
-                 last_input_tokens={})",
+                 context_tokens={})",
                 self.compact_state.consecutive_failures, self.compact_state.last_input_tokens
             ));
         } else if !self.compact_config.enabled {
@@ -1023,7 +1032,7 @@ impl AgentEngine {
             if self.compact_state.last_input_tokens as usize >= threshold {
                 self.output.emit_info(&format!(
                     "Autocompact: disabled (compact.enabled=false, \
-                     last_input_tokens={}, threshold={})",
+                     context_tokens={}, threshold={})",
                     self.compact_state.last_input_tokens, threshold
                 ));
             }
@@ -1334,7 +1343,7 @@ impl AgentEngine {
             return;
         }
 
-        let result_blocks = pending_results
+        let result_blocks: Vec<ContentBlock> = pending_results
             .into_iter()
             .map(|(tool_use_id, name)| {
                 info!(
@@ -1352,6 +1361,7 @@ impl AgentEngine {
             })
             .collect();
 
+        self.record_tool_context_estimate(&result_blocks, &[]);
         self.messages.push(Message::now(Role::User, result_blocks));
         self.save_session();
     }

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -589,6 +589,7 @@ mod tests_compact {
     use serde_json::json;
 
     use super::{CompactLevel, ProviderCompat};
+    use crate::compact::auto::should_autocompact;
     use crate::compact::state::CompactState;
     use crate::confirm::ToolConfirmer;
     use crate::output::OutputSink;
@@ -781,6 +782,7 @@ mod tests_compact {
             matches!(&last.content[1], ContentBlock::ToolResult { tool_use_id, content, is_error }
                 if tool_use_id == "call_bash" && content == "Tool execution canceled by user" && *is_error)
         );
+        assert_eq!(engine.compact_state.last_input_tokens, 14);
 
         let emitted = output.tool_results.lock().unwrap();
         assert_eq!(emitted.len(), 2);
@@ -839,6 +841,61 @@ mod tests_compact {
                 .any(|msg| msg == "Cache full miss: TtlExpiry"),
             "full cache misses should remain visible as diagnostics"
         );
+    }
+
+    #[test]
+    fn provider_turn_total_replaces_previous_context_estimate() {
+        let mut state = CompactState::new();
+        state.last_input_tokens = 100_000;
+        let mut engine = make_compact_engine(CompactConfig::default(), state, vec![]);
+
+        engine.record_turn_usage(&TokenUsage {
+            input_tokens: 693,
+            output_tokens: 102,
+            cache_read_tokens: 512,
+            ..Default::default()
+        });
+
+        assert_eq!(engine.compact_state.last_input_tokens, 795);
+    }
+
+    #[test]
+    fn all_tool_results_are_added_before_the_next_threshold_check() {
+        let config = CompactConfig {
+            context_window: 1_000,
+            autocompact_threshold_pct: Some(60),
+            ..Default::default()
+        };
+        let mut engine = make_compact_engine(config, CompactState::new(), vec![]);
+        engine.record_turn_usage(&TokenUsage {
+            input_tokens: 500,
+            output_tokens: 50,
+            ..Default::default()
+        });
+        assert!(!should_autocompact(
+            engine.compact_state.last_input_tokens,
+            &engine.compact_config
+        ));
+
+        let tool_results = vec![
+            ContentBlock::ToolResult {
+                tool_use_id: "call-1".into(),
+                content: "a".repeat(200),
+                is_error: false,
+            },
+            ContentBlock::ToolResult {
+                tool_use_id: "call-2".into(),
+                content: "b".repeat(200),
+                is_error: false,
+            },
+        ];
+        engine.record_tool_context_estimate(&tool_results, &[]);
+
+        assert_eq!(engine.compact_state.last_input_tokens, 650);
+        assert!(should_autocompact(
+            engine.compact_state.last_input_tokens,
+            &engine.compact_config
+        ));
     }
 
     // -- Emergency check fires when at limit --
@@ -966,7 +1023,7 @@ mod tests_compact {
     #[tokio::test]
     async fn first_turn_zero_tokens_no_compaction() {
         let config = CompactConfig::default();
-        let state = CompactState::new(); // last_input_tokens = 0
+        let state = CompactState::new(); // context_tokens = 0
 
         let mut engine = make_compact_engine(config, state, vec![]);
         assert!(engine.run_compaction().await.is_ok());

--- a/crates/aion-agent/tests/engine_compact_test.rs
+++ b/crates/aion-agent/tests/engine_compact_test.rs
@@ -107,7 +107,7 @@ fn summary_turn(summary_text: &str) -> Vec<LlmEvent> {
 
 #[tokio::test]
 async fn tc_2_6_01_first_turn_no_compaction() {
-    // On the first turn last_input_tokens is 0, so neither autocompact
+    // On the first turn context_tokens is 0, so neither autocompact
     // nor emergency should fire.
     let provider = Arc::new(CompactMockProvider::new(vec![text_turn("Hello", 50_000)]));
 
@@ -130,9 +130,9 @@ async fn tc_2_6_01_first_turn_no_compaction() {
 async fn tc_2_6_03_emergency_returns_error() {
     // Emergency is the last safety net — it fires when autocompact is
     // disabled or circuit-broken.  We disable compact so only emergency
-    // is active, then push input_tokens above the emergency limit.
+    // is active, then push the provider turn total above the emergency limit.
     //
-    // Turn 1: tool use, returns input_tokens above emergency threshold
+    // Turn 1: tool use, returns a turn total above the emergency threshold
     // Turn 2: emergency fires before the API call → ContextTooLong
     let turn1 = vec![
         LlmEvent::ToolUse {
@@ -168,7 +168,8 @@ async fn tc_2_6_03_emergency_returns_error() {
 
     match err {
         AgentError::ContextTooLong { input_tokens, limit } => {
-            assert_eq!(input_tokens, 198_000);
+            // 198_000 input + 100 output + one token estimated from "result".
+            assert_eq!(input_tokens, 198_101);
             assert_eq!(limit, 197_000);
         }
         other => panic!("expected ContextTooLong, got: {:?}", other),
@@ -457,7 +458,7 @@ async fn tc_2_6_02_micro_before_auto_execution_order() {
             //
             // micro_keep_recent = 3 → count threshold = 6.
             // After 7 tool-use turns: 7 > 6 → micro fires.
-            // After turn 6: last_input_tokens = 170k > 167k → auto fires.
+            // After turn 6: context_tokens = 170k > 167k → auto fires.
             let events = if count < 7 {
                 let input_tokens = if count == 6 { 170_000 } else { 10_000 };
                 vec![
@@ -556,8 +557,8 @@ async fn tc_2_6_02_micro_before_auto_execution_order() {
 async fn tc_2_6_e2e_02_micro_and_auto_cooperative() {
     // Verify that microcompact and autocompact cooperate in the same
     // compaction cycle.  Microcompact frees some tokens from old tool
-    // results, and autocompact still fires because the input token
-    // watermark (which is not reduced by micro) remains above threshold.
+    // results, and autocompact still fires because the context estimate
+    // (which is not reduced by micro) remains above threshold.
 
     let compact_call_count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
     let counter_ref = compact_call_count.clone();
@@ -605,7 +606,7 @@ async fn tc_2_6_e2e_02_micro_and_auto_cooperative() {
             // 7 tool-use turns (count 0-6).  Turn 6 returns high tokens.
             // micro_keep_recent = 3 → count threshold = 6.
             // After 7 tool results: 7 > 6 → micro fires.
-            // After turn 6: last_input_tokens = 170k > 167k → auto fires.
+            // After turn 6: context_tokens = 170k > 167k → auto fires.
             let events = if count < 7 {
                 let input_tokens = if count == 6 { 170_000 } else { 10_000 };
                 vec![
@@ -673,7 +674,7 @@ async fn tc_2_6_e2e_02_micro_and_auto_cooperative() {
     assert_eq!(result.text, "After cooperative compact");
 
     // Autocompact was called exactly once (micro freed tokens but
-    // did not reduce last_input_tokens, so auto still fired).
+    // did not reduce context_tokens, so auto still fired).
     let calls = *compact_call_count.lock().unwrap();
     assert_eq!(
         calls, 1,

--- a/crates/aion-providers/src/anthropic_shared.rs
+++ b/crates/aion-providers/src/anthropic_shared.rs
@@ -306,9 +306,13 @@ pub fn parse_sse_data(event_type: &str, data: &str, state: &mut StreamState) -> 
     match event_type {
         "message_start" => {
             if let Some(usage) = json.get("message").and_then(|m| m.get("usage")) {
-                state.input_tokens = usage["input_tokens"].as_u64().unwrap_or(0);
                 state.cache_creation_tokens = usage["cache_creation_input_tokens"].as_u64().unwrap_or(0);
                 state.cache_read_tokens = usage["cache_read_input_tokens"].as_u64().unwrap_or(0);
+                state.input_tokens = usage["input_tokens"]
+                    .as_u64()
+                    .unwrap_or(0)
+                    .saturating_add(state.cache_creation_tokens)
+                    .saturating_add(state.cache_read_tokens);
             }
         }
 

--- a/crates/aion-providers/src/anthropic_shared_test.rs
+++ b/crates/aion-providers/src/anthropic_shared_test.rs
@@ -942,6 +942,20 @@ mod tests {
         assert!(events.is_empty());
     }
 
+    #[test]
+    fn test_message_start_includes_cache_tokens_in_total_input() {
+        let mut state = StreamState::new();
+        let data =
+            r#"{"message":{"usage":{"input_tokens":12,"cache_creation_input_tokens":3,"cache_read_input_tokens":4}}}"#;
+
+        let events = parse_sse_data("message_start", data, &mut state);
+
+        assert!(events.is_empty());
+        assert_eq!(state.input_tokens, 19);
+        assert_eq!(state.cache_creation_tokens, 3);
+        assert_eq!(state.cache_read_tokens, 4);
+    }
+
     // --- Image block projection ---
 
     #[test]

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -46,6 +46,7 @@ pub(crate) struct StreamState {
     tool_calls: Vec<ToolCallAccumulator>,
     input_tokens: u64,
     output_tokens: u64,
+    cache_read_tokens: u64,
     diagnostics: OpenAiStreamDiagnostics,
     /// Deferred Done event: populated when finish_reason arrives, emitted on
     /// [DONE] so the final usage-only chunk has a chance to update token counts.
@@ -58,6 +59,7 @@ impl StreamState {
             tool_calls: Vec::new(),
             input_tokens: 0,
             output_tokens: 0,
+            cache_read_tokens: 0,
             diagnostics: OpenAiStreamDiagnostics::default(),
             pending_done: None,
         }
@@ -77,7 +79,7 @@ impl StreamState {
                     input_tokens: self.input_tokens,
                     output_tokens: self.output_tokens,
                     cache_creation_tokens: 0,
-                    cache_read_tokens: 0,
+                    cache_read_tokens: self.cache_read_tokens,
                 },
             },
             other => other,
@@ -120,15 +122,14 @@ pub(crate) fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id:
 
     // Extract usage if present
     if let Some(usage) = json.get("usage") {
-        let base_prompt = usage["prompt_tokens"].as_u64().unwrap_or(state.input_tokens);
-
-        // DeepSeek-style: prompt_cache_hit_tokens is reported separately and
-        // prompt_tokens only contains the cache-miss portion.
-        // Add it to get the true total prompt size.
-        let cache_hit = usage["prompt_cache_hit_tokens"].as_u64().unwrap_or(0);
-
-        state.input_tokens = base_prompt + cache_hit;
+        state.input_tokens = usage["prompt_tokens"].as_u64().unwrap_or(state.input_tokens);
         state.output_tokens = usage["completion_tokens"].as_u64().unwrap_or(state.output_tokens);
+        state.cache_read_tokens = usage
+            .pointer("/prompt_tokens_details/cached_tokens")
+            .and_then(Value::as_u64)
+            .or_else(|| usage["cached_tokens"].as_u64())
+            .or_else(|| usage["prompt_cache_hit_tokens"].as_u64())
+            .unwrap_or(state.cache_read_tokens);
     }
 
     let Some(choice) = json["choices"].as_array().and_then(|c| c.first()) else {

--- a/crates/aion-providers/src/openai_test.rs
+++ b/crates/aion-providers/src/openai_test.rs
@@ -67,16 +67,37 @@ mod tests {
     }
 
     #[test]
-    fn usage_includes_prompt_cache_hit_tokens() {
-        // DeepSeek reports prompt_cache_hit_tokens separately;
-        // input_tokens should be the sum of prompt_tokens + prompt_cache_hit_tokens
+    fn deepseek_cache_hit_tokens_are_an_input_subset() {
         let mut state = StreamState::new();
 
-        let chunk = r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":500,"completion_tokens":100,"prompt_cache_hit_tokens":999500}}"#;
+        let chunk = r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":693,"completion_tokens":102,"total_tokens":795,"prompt_tokens_details":{"cached_tokens":512},"completion_tokens_details":{"reasoning_tokens":44},"prompt_cache_hit_tokens":512,"prompt_cache_miss_tokens":181}}"#;
         let _ = parse_sse_chunk(chunk, &mut state, false);
 
-        assert_eq!(state.input_tokens, 1_000_000);
-        assert_eq!(state.output_tokens, 100);
+        assert_eq!(state.input_tokens, 693);
+        assert_eq!(state.output_tokens, 102);
+        assert_eq!(state.cache_read_tokens, 512);
+
+        let done = state.flush_done().unwrap();
+        match done {
+            LlmEvent::Done { usage, .. } => {
+                assert_eq!(usage.input_tokens, 693);
+                assert_eq!(usage.output_tokens, 102);
+                assert_eq!(usage.cache_read_tokens, 512);
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kimi_top_level_cached_tokens_are_an_input_subset() {
+        let mut state = StreamState::new();
+
+        let chunk = r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":19,"completion_tokens":21,"total_tokens":40,"cached_tokens":10}}"#;
+        let _ = parse_sse_chunk(chunk, &mut state, false);
+
+        assert_eq!(state.input_tokens, 19);
+        assert_eq!(state.output_tokens, 21);
+        assert_eq!(state.cache_read_tokens, 10);
     }
 
     #[test]
@@ -91,6 +112,7 @@ mod tests {
         // prompt_tokens is already the full total for OpenAI
         assert_eq!(state.input_tokens, 1_000_000);
         assert_eq!(state.output_tokens, 100);
+        assert_eq!(state.cache_read_tokens, 999_000);
     }
 
     #[test]

--- a/crates/aion-types/src/compact.rs
+++ b/crates/aion-types/src/compact.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CompactTrigger {
-    /// Triggered automatically when token usage exceeded the watermark.
+    /// Triggered automatically when token usage exceeded the context threshold.
     Auto,
     /// Triggered manually by the user (e.g. `/compact` command).
     Manual,

--- a/crates/aion-types/src/message.rs
+++ b/crates/aion-types/src/message.rs
@@ -210,10 +210,15 @@ pub enum StopReason {
 /// Token usage statistics
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TokenUsage {
+    /// Full provider input, including cache-read and cache-creation tokens.
     pub input_tokens: u64,
+    /// Full provider output, including reasoning tokens when reported as part
+    /// of the completion total.
     pub output_tokens: u64,
+    /// Subset of `input_tokens` used to create a provider-side prompt cache.
     #[serde(default)]
     pub cache_creation_tokens: u64,
+    /// Subset of `input_tokens` read from a provider-side prompt cache.
     #[serde(default)]
     pub cache_read_tokens: u64,
 }


### PR DESCRIPTION
## Why

Compaction decisions need one consistent measure of how much prior context will be carried toward the next provider request. The previous implementation mixed two incompatible sources:

- Provider adapters did not expose the same `TokenUsage::input_tokens` semantics. OpenAI-compatible cache hits could be added on top of an already complete `prompt_tokens` value, while Anthropic cache creation and cache read tokens were not included in `input_tokens`.
- The engine used `max(provider_input_tokens, local_message_estimate)` as a watermark. This mixed provider-reported usage with a heuristic full-history estimate, did not directly account for the current model output, and could drift differently for each provider.
- Tool results are produced after the provider usage snapshot, so they need a bounded local estimate before the following request.

The result was provider-dependent compaction pressure: the same logical context could trigger compaction too early or too late depending on cache reporting and message representation.

## What

- Define `TokenUsage::input_tokens` as the full provider input and keep cache creation/read values as subsets of that input.
- Normalize OpenAI-compatible and Anthropic usage parsing to follow that contract.
- Replace the compaction watermark after every completed provider turn with the provider-reported turn total:
  ```text
  context_tokens = input_tokens + output_tokens
  ```
- Add estimates for tool text results and tool-emitted images that are appended after the provider response.
- Use context-oriented naming in compaction checks and diagnostics while retaining the existing `last_input_tokens` field name for source compatibility.
- Add regression tests for cached-token parsing, turn-total replacement, tool-result accumulation, and image estimation.

## How

### Provider usage normalization

- OpenAI-compatible responses:
  - `input_tokens = prompt_tokens`
  - cached input is recorded separately in `cache_read_tokens`
  - cached-token lookup supports `prompt_tokens_details.cached_tokens`, top-level `cached_tokens`, and `prompt_cache_hit_tokens`
  - cached tokens are not added to `prompt_tokens` again
- Anthropic responses:
  - `input_tokens = input_tokens + cache_creation_input_tokens + cache_read_input_tokens`
  - cache creation/read fields remain available separately as subsets
- `output_tokens` remains the provider's full completion total, including reasoning tokens when the provider includes them in that total.

### Compaction state updates

1. After a provider turn completes, the previous context estimate is replaced with `input_tokens + output_tokens` using saturating arithmetic.
2. After tool execution, each final tool result is estimated once and added to that value.
3. Tool text uses the existing provider-neutral text heuristic; tool images use decoded byte size with bounded per-image estimates.
4. Before the next provider call, the existing `microcompact -> autocompact -> emergency` pipeline evaluates this best-known context value.

For example, a provider turn reporting 150k input tokens and 10k output tokens establishes a 160k context value. If tools then append an estimated 2k tokens, the next compaction check uses 162k.

## Behavior and compatibility

- Cache token fields are subsets of `input_tokens`; callers must not add them again when calculating context or the existing `input + output` total.
- Session usage accumulation is unchanged: input, output, cache creation, and cache read fields continue to accumulate independently.
- The public `CompactState::last_input_tokens` field is retained to avoid a source-breaking rename.
- No AionCore or AionUi change is required for this PR.

## Boundaries and non-goals

- Provider usage is treated as the source of truth. This PR does not add a fallback for providers that omit or return invalid usage data.
- Newly appended user input is intentionally not folded into the automatic compaction trigger before it is sent. A very large new user message is not automatically summarized by this change; request-size validation and provider hard limits remain separate concerns.
- The tracked value is not an exact serialization of the next request. Provider-specific wrappers, system/tool-schema overhead, and content projection can differ. In particular, reasoning counted in `output_tokens` may not all be replayed, so the completed-turn value can be conservative.
- This PR does not change how thinking/reasoning content is stored, projected, or replayed.
- This PR does not change context-window configuration, compaction thresholds, the `microcompact -> autocompact -> emergency` ordering, or the summarization/truncation algorithms.
- This PR does not introduce provider-specific compatibility for non-standard token semantics; providers are expected to satisfy the normalized `TokenUsage` contract.
- Billing calculations and UI token presentation are outside the scope of this PR.

## Validation

- `just push -u origin jiahe/fix/context-compaction-usage`
  - workspace Clippy passed with warnings denied
  - formatting passed
  - 2204 tests passed, 2 skipped
  - Hakari dependency verification passed
