### PR TITLE
fix(tools): handle line ending differences in edit

### DIFF
--- a/crates/aion-tools/src/edit.rs
+++ b/crates/aion-tools/src/edit.rs
@@ -17,12 +17,81 @@ enum LineEnding {
     Crlf,
 }
 
+struct OldStringMatch<'a> {
+    old_string: Cow<'a, str>,
+    line_ending: LineEnding,
+    match_count: usize,
+}
+
+enum MatchSelectionError {
+    NotFound,
+    AmbiguousLineEndings,
+}
+
 fn detect_line_ending(content: &str) -> LineEnding {
     if content.contains("\r\n") {
         LineEnding::Crlf
     } else {
         LineEnding::Lf
     }
+}
+
+fn line_ending_in(text: &str) -> Option<LineEnding> {
+    if text.contains("\r\n") {
+        Some(LineEnding::Crlf)
+    } else if text.contains('\n') {
+        Some(LineEnding::Lf)
+    } else {
+        None
+    }
+}
+
+fn select_old_string<'a>(content: &str, old_string: &'a str) -> Result<OldStringMatch<'a>, MatchSelectionError> {
+    let exact_match_count = content.matches(old_string).count();
+    let normalized_candidates = [
+        (LineEnding::Lf, convert_line_endings(old_string, LineEnding::Lf)),
+        (LineEnding::Crlf, convert_line_endings(old_string, LineEnding::Crlf)),
+    ];
+
+    if exact_match_count > 0 {
+        // Exact bytes take priority. Other EOL forms are checked only to avoid
+        // silently choosing one of multiple visually identical regions.
+        let has_alternative_match = normalized_candidates
+            .iter()
+            .any(|(_, candidate)| candidate.as_ref() != old_string && content.contains(candidate.as_ref()));
+        if has_alternative_match {
+            return Err(MatchSelectionError::AmbiguousLineEndings);
+        }
+
+        return Ok(OldStringMatch {
+            old_string: Cow::Borrowed(old_string),
+            line_ending: line_ending_in(old_string).unwrap_or_else(|| detect_line_ending(content)),
+            match_count: exact_match_count,
+        });
+    }
+
+    let mut fallback_match = None;
+    for (line_ending, candidate) in normalized_candidates {
+        if candidate.as_ref() == old_string {
+            continue;
+        }
+
+        let match_count = content.matches(candidate.as_ref()).count();
+        if match_count == 0 {
+            continue;
+        }
+        if fallback_match.is_some() {
+            return Err(MatchSelectionError::AmbiguousLineEndings);
+        }
+
+        fallback_match = Some(OldStringMatch {
+            old_string: candidate,
+            line_ending,
+            match_count,
+        });
+    }
+
+    fallback_match.ok_or(MatchSelectionError::NotFound)
 }
 
 fn convert_line_endings(text: &str, line_ending: LineEnding) -> Cow<'_, str> {
@@ -175,20 +244,27 @@ impl Tool for EditTool {
             }
         };
 
-        // Tool arguments usually use LF even when the file uses CRLF. Adapt both
-        // strings to the file's actual line ending before exact matching so the
-        // replacement preserves the surrounding bytes and does not create mixed EOLs.
-        let line_ending = detect_line_ending(&content);
-        let old_string = convert_line_endings(old_string, line_ending);
-        let new_string = convert_line_endings(new_string, line_ending);
-        let match_count = content.matches(old_string.as_ref()).count();
-
-        if match_count == 0 {
-            return ToolResult {
-                content: "old_string not found in file".to_string(),
-                is_error: true,
-            };
-        }
+        // Prefer the exact bytes supplied by the caller. Only fall back to an
+        // EOL-adapted old_string when the exact form is absent.
+        let selected = match select_old_string(&content, old_string) {
+            Ok(selected) => selected,
+            Err(MatchSelectionError::NotFound) => {
+                return ToolResult {
+                    content: "old_string not found in file".to_string(),
+                    is_error: true,
+                };
+            }
+            Err(MatchSelectionError::AmbiguousLineEndings) => {
+                return ToolResult {
+                    content: "Ambiguous line-ending match: old_string matches both LF and CRLF text. \
+                              Provide more surrounding context."
+                        .to_string(),
+                    is_error: true,
+                };
+            }
+        };
+        let match_count = selected.match_count;
+        let new_string = convert_line_endings(new_string, selected.line_ending);
 
         if match_count > 1 && !replace_all {
             return ToolResult {
@@ -201,9 +277,9 @@ impl Tool for EditTool {
         }
 
         let new_content = if replace_all {
-            content.replace(old_string.as_ref(), new_string.as_ref())
+            content.replace(selected.old_string.as_ref(), new_string.as_ref())
         } else {
-            content.replacen(old_string.as_ref(), new_string.as_ref(), 1)
+            content.replacen(selected.old_string.as_ref(), new_string.as_ref(), 1)
         };
 
         if let Err(e) = std::fs::write(file_path, &new_content) {

--- a/crates/aion-tools/src/edit.rs
+++ b/crates/aion-tools/src/edit.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
@@ -9,6 +10,40 @@ use aion_types::tool::{JsonSchema, ToolResult};
 
 use crate::Tool;
 use crate::file_cache::{FileStateCache, file_mtime_ms, update_cache_after_write};
+
+#[derive(Clone, Copy)]
+enum LineEnding {
+    Lf,
+    Crlf,
+}
+
+fn detect_line_ending(content: &str) -> LineEnding {
+    if content.contains("\r\n") {
+        LineEnding::Crlf
+    } else {
+        LineEnding::Lf
+    }
+}
+
+fn convert_line_endings(text: &str, line_ending: LineEnding) -> Cow<'_, str> {
+    match line_ending {
+        LineEnding::Lf => {
+            if text.contains("\r\n") {
+                Cow::Owned(text.replace("\r\n", "\n"))
+            } else {
+                Cow::Borrowed(text)
+            }
+        }
+        LineEnding::Crlf => {
+            if text.contains('\n') {
+                let normalized = text.replace("\r\n", "\n");
+                Cow::Owned(normalized.replace('\n', "\r\n"))
+            } else {
+                Cow::Borrowed(text)
+            }
+        }
+    }
+}
 
 pub struct EditTool {
     file_cache: Option<Arc<RwLock<FileStateCache>>>,
@@ -140,7 +175,13 @@ impl Tool for EditTool {
             }
         };
 
-        let match_count = content.matches(old_string).count();
+        // Tool arguments usually use LF even when the file uses CRLF. Adapt both
+        // strings to the file's actual line ending before exact matching so the
+        // replacement preserves the surrounding bytes and does not create mixed EOLs.
+        let line_ending = detect_line_ending(&content);
+        let old_string = convert_line_endings(old_string, line_ending);
+        let new_string = convert_line_endings(new_string, line_ending);
+        let match_count = content.matches(old_string.as_ref()).count();
 
         if match_count == 0 {
             return ToolResult {
@@ -160,9 +201,9 @@ impl Tool for EditTool {
         }
 
         let new_content = if replace_all {
-            content.replace(old_string, new_string)
+            content.replace(old_string.as_ref(), new_string.as_ref())
         } else {
-            content.replacen(old_string, new_string, 1)
+            content.replacen(old_string.as_ref(), new_string.as_ref(), 1)
         };
 
         if let Err(e) = std::fs::write(file_path, &new_content) {

--- a/crates/aion-tools/src/edit_test.rs
+++ b/crates/aion-tools/src/edit_test.rs
@@ -90,6 +90,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn edit_lf_multiline_strings_preserve_crlf_file_endings() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("crlf.txt");
+        std::fs::write(&file_path, b"alpha\r\nbeta\r\ngamma\r\n").unwrap();
+
+        let cache = make_cache();
+        simulate_read(&cache, &file_path);
+        let tool = EditTool::new(Some(cache));
+        let input = json!({
+            "file_path": file_path.to_str().unwrap(),
+            "old_string": "alpha\nbeta",
+            "new_string": "alpha\nbeta updated\ninserted"
+        });
+
+        let result = tool.execute(input).await;
+
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert_eq!(
+            std::fs::read(&file_path).unwrap(),
+            b"alpha\r\nbeta updated\r\ninserted\r\ngamma\r\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_crlf_multiline_strings_preserve_lf_file_endings() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("lf.txt");
+        std::fs::write(&file_path, b"alpha\nbeta\ngamma\n").unwrap();
+
+        let tool = EditTool::new(None);
+        let input = json!({
+            "file_path": file_path.to_str().unwrap(),
+            "old_string": "alpha\r\nbeta",
+            "new_string": "alpha\r\nbeta updated\r\ninserted"
+        });
+
+        let result = tool.execute(input).await;
+
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert_eq!(
+            std::fs::read(&file_path).unwrap(),
+            b"alpha\nbeta updated\ninserted\ngamma\n"
+        );
+    }
+
+    #[test]
+    fn line_ending_conversion_preserves_lone_carriage_returns() {
+        assert_eq!(
+            convert_line_endings("alpha\r\r\nbeta", LineEnding::Crlf),
+            "alpha\r\r\nbeta"
+        );
+        assert_eq!(convert_line_endings("alpha\r\r\nbeta", LineEnding::Lf), "alpha\r\nbeta");
+    }
+
+    #[tokio::test]
     async fn test_edit_nonexistent_file() {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("does_not_exist.txt");

--- a/crates/aion-tools/src/edit_test.rs
+++ b/crates/aion-tools/src/edit_test.rs
@@ -135,6 +135,53 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn edit_exact_lf_match_in_mixed_line_endings_file() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("mixed.txt");
+        std::fs::write(&file_path, b"header\r\nalpha\nbeta\ngamma\r\n").unwrap();
+
+        let tool = EditTool::new(None);
+        let input = json!({
+            "file_path": file_path.to_str().unwrap(),
+            "old_string": "alpha\nbeta",
+            "new_string": "alpha\nbeta updated\ninserted"
+        });
+
+        let result = tool.execute(input).await;
+
+        assert!(!result.is_error, "unexpected error: {}", result.content);
+        assert_eq!(
+            std::fs::read(&file_path).unwrap(),
+            b"header\r\nalpha\nbeta updated\ninserted\ngamma\r\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_rejects_ambiguous_lf_and_crlf_matches() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("ambiguous.txt");
+        let original = b"alpha\nbeta\nseparator\r\nalpha\r\nbeta\r\n";
+        std::fs::write(&file_path, original).unwrap();
+
+        let tool = EditTool::new(None);
+        let input = json!({
+            "file_path": file_path.to_str().unwrap(),
+            "old_string": "alpha\nbeta",
+            "new_string": "updated"
+        });
+
+        let result = tool.execute(input).await;
+
+        assert!(result.is_error);
+        assert!(
+            result.content.contains("Ambiguous line-ending match"),
+            "expected ambiguity error, got: {}",
+            result.content
+        );
+        assert_eq!(std::fs::read(&file_path).unwrap(), original);
+    }
+
     #[test]
     fn line_ending_conversion_preserves_lone_carriage_returns() {
         assert_eq!(


### PR DESCRIPTION
## Summary

- try the original `old_string` bytes before considering any line-ending adaptation
- fall back to LF or CRLF variants only when the exact form is absent
- reject ambiguous edits when visually identical LF and CRLF variants match different regions
- adapt `new_string` to the selected match's line ending while preserving untouched file bytes
- keep all helpers private; there are no public API, protocol, configuration, or AionCore compatibility changes

## Why

LLM-generated Edit tool arguments normally contain LF line endings. Windows source files commonly contain CRLF, so a byte-exact substring search can return `old_string not found` even when the visible text matches.

Choosing a file-wide EOL before matching is unsafe for mixed-line-ending files: it can miss an exact LF target or silently edit a different CRLF region. The matcher now preserves exact-byte intent and reports ambiguity instead of guessing.

The conversion only rewrites CRLF pairs. Standalone `\r` bytes are preserved and CR-only legacy files are not reinterpreted.

## Non-goals

- normalize entire files or modify untouched regions
- infer line endings from the operating system
- add special handling for legacy CR-only files

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p aion-tools`
  - 94 unit tests and all integration tests passed
- `cargo clippy -p aion-tools --all-targets -- -D warnings`
- `just push`
  - 2,201 tests passed, 2 skipped
  - Hakari verification passed
