### PR TITLE
fix(agent): finalize repeated tool failures without tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ aionrs --help
 so runs have no broad model-turn limit unless you configure one. Set it to
 `0` to explicitly disable the broad limit. `max_tool_call_malformed_turns`
 stops repeated same tool-call-malformed rounds earlier; it defaults to `3`.
-`max_tool_call_failure_turns` stops zero-text turns where every executable
-tool result failed; it also defaults to `3`. Set either guard to `0` to
-disable that breaker and rely on `max_turns` if a broad turn limit is
-configured.
+`max_tool_call_failure_turns` finalizes repeated failed tool-call patterns
+based on failed tool names and inputs, regardless of assistant text or
+successful sibling calls in the same round; it also defaults to `3`. The
+failure guard additionally detects consecutive all-error rounds and short
+repeating call cycles. Set either guard to `0` to disable that breaker and
+rely on `max_turns` if a broad turn limit is configured.
 
 See [Core Concepts](docs/core-concepts.md) for the distinction between runs,
 turns, tool rounds, and tool calls.

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -24,7 +24,7 @@ use crate::tool_call::{
     tool_call_malformed_reason,
 };
 use crate::tool_policy::ToolPolicy;
-use crate::turn::{FinalizationReason, TurnGuardAction, TurnGuards, TurnKind, TurnOutcome};
+use crate::turn::{FinalizationReason, ToolLoopWarning, TurnGuardAction, TurnGuards, TurnKind, TurnOutcome};
 use aion_compact::CompactLevel;
 use aion_config::compact::CompactConfig;
 use aion_config::compat::ProviderCompat;
@@ -425,11 +425,11 @@ impl AgentEngine {
             let outcome = self.run_turn(TurnKind::Normal).await?;
             guards.record_counted_turn();
 
-            let (assistant_text, tool_calls) = match TurnOutcome::from_stream(outcome) {
+            let tool_calls = match TurnOutcome::from_stream(outcome) {
                 TurnOutcome::ToolRound(outcome) => {
                     let assistant_content = build_assistant_content(&outcome);
                     self.messages.push(Message::now(Role::Assistant, assistant_content));
-                    (outcome.assistant_text, outcome.tool_calls)
+                    outcome.tool_calls
                 }
                 TurnOutcome::Final(outcome) => {
                     let assistant_content = build_assistant_content(&outcome);
@@ -476,15 +476,25 @@ impl AgentEngine {
 
             // need to execute tool calls before the next turn
             let ToolRoundOutput {
-                tool_results,
+                mut tool_results,
                 tool_modifiers,
                 follow_up_blocks,
                 tool_call_malformed_fingerprint,
                 tool_call_failure_fingerprint,
-            } = self.execute_tool_round(&tool_calls, &assistant_text).await?;
+                all_tool_results_error,
+            } = self.execute_tool_round(&tool_calls).await?;
 
             // Apply any context modifiers from skill executions before the next turn.
             self.apply_context_modifiers(&tool_modifiers);
+
+            let guard_action = guards.after_tool_round(
+                tool_call_malformed_fingerprint,
+                tool_call_failure_fingerprint,
+                all_tool_results_error,
+            );
+            if let TurnGuardAction::Warn(warning) = guard_action {
+                append_tool_loop_warning(&mut tool_results, warning);
+            }
 
             self.emit_tool_results(&tool_calls, &tool_results);
             self.record_tool_context_estimate(&tool_results, &follow_up_blocks);
@@ -497,16 +507,11 @@ impl AgentEngine {
             // Save session after each tool round.
             self.save_session();
 
-            match guards.after_tool_round(tool_call_malformed_fingerprint, tool_call_failure_fingerprint) {
-                TurnGuardAction::Continue => {}
-                TurnGuardAction::Finalize => {
+            match guard_action {
+                TurnGuardAction::Continue | TurnGuardAction::Warn(_) => {}
+                TurnGuardAction::Finalize(reason) => {
                     return self
-                        .finalize_once(
-                            FinalizationReason::TurnBudget,
-                            String::new(),
-                            guards.counted_turns(),
-                            StopReason::MaxTurns,
-                        )
+                        .finalize_once(reason, String::new(), guards.counted_turns(), StopReason::MaxTurns)
                         .await;
                 }
                 TurnGuardAction::Stop(err) => return Err(err),
@@ -575,16 +580,10 @@ impl AgentEngine {
     /// Malformed calls get synthetic error results; the rest are executed via
     /// the approval (JSON stream) or interactive (terminal) path. Results and
     /// skill modifiers are interleaved back into the original call order.
-    /// `assistant_text` is the visible text from the same turn, used only to
-    /// classify an all-error round for the consecutive-failure breaker.
     ///
     /// A `Quit` from tool execution is surfaced as `AgentError::UserAborted`
     /// after saving the session.
-    async fn execute_tool_round(
-        &mut self,
-        tool_calls: &[ContentBlock],
-        assistant_text: &str,
-    ) -> Result<ToolRoundOutput, AgentError> {
+    async fn execute_tool_round(&mut self, tool_calls: &[ContentBlock]) -> Result<ToolRoundOutput, AgentError> {
         let tool_call_malformed_reasons: Vec<_> = tool_calls
             .iter()
             .map(|call| {
@@ -677,14 +676,14 @@ impl AgentEngine {
             executable_modifiers,
         );
 
-        let tool_call_failure_fingerprint = (tool_call_malformed_fingerprint.is_none()
-            && assistant_text.trim().is_empty()
+        let all_tool_results_error = tool_call_malformed_fingerprint.is_none()
             && !tool_results.is_empty()
             && tool_results
                 .iter()
-                .all(|result| matches!(result, ContentBlock::ToolResult { is_error: true, .. })))
-        .then(|| tool_call_failure_fingerprint(tool_calls))
-        .flatten();
+                .all(|result| matches!(result, ContentBlock::ToolResult { is_error: true, .. }));
+        let tool_call_failure_fingerprint = all_tool_results_error
+            .then(|| tool_call_failure_fingerprint(tool_calls))
+            .flatten();
 
         Ok(ToolRoundOutput {
             tool_results,
@@ -692,6 +691,7 @@ impl AgentEngine {
             follow_up_blocks,
             tool_call_malformed_fingerprint,
             tool_call_failure_fingerprint,
+            all_tool_results_error,
         })
     }
 
@@ -1388,9 +1388,30 @@ struct ToolRoundOutput {
     /// tool-call-malformed breaker.
     tool_call_malformed_fingerprint: Option<ToolCallMalformedFingerprint>,
     /// `Some` when this round produced executable (non-malformed) tool calls
-    /// with the same name+input pattern, all errored, and the model emitted no
-    /// visible text; feeds the consecutive-tool-call-failure breaker.
+    /// with the same name+input pattern and all errored; feeds the exact-call
+    /// and cycle breakers.
     tool_call_failure_fingerprint: Option<ToolCallFailureFingerprint>,
+    /// Whether the round had a non-malformed call and every result was an error.
+    all_tool_results_error: bool,
+}
+
+fn append_tool_loop_warning(tool_results: &mut [ContentBlock], warning: ToolLoopWarning) {
+    let Some(content) = tool_results.iter_mut().rev().find_map(|result| {
+        let ContentBlock::ToolResult {
+            content,
+            is_error: true,
+            ..
+        } = result
+        else {
+            return None;
+        };
+        Some(content)
+    }) else {
+        return;
+    };
+
+    content.push_str("\n\n");
+    content.push_str(&warning.guidance());
 }
 
 /// Assemble the assistant message content blocks (thinking, text, tool calls)

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -676,14 +676,20 @@ impl AgentEngine {
             executable_modifiers,
         );
 
-        let all_tool_results_error = tool_call_malformed_fingerprint.is_none()
-            && !tool_results.is_empty()
+        let failed_tool_calls: Vec<_> = tool_calls
+            .iter()
+            .zip(&tool_call_malformed_reasons)
+            .zip(&tool_results)
+            .filter(|((_, malformed_reason), result)| {
+                malformed_reason.is_none() && matches!(result, ContentBlock::ToolResult { is_error: true, .. })
+            })
+            .map(|((call, _), _)| call.clone())
+            .collect();
+        let tool_call_failure_fingerprint = tool_call_failure_fingerprint(&failed_tool_calls);
+        let all_tool_results_error = tool_call_failure_fingerprint.is_some()
             && tool_results
                 .iter()
                 .all(|result| matches!(result, ContentBlock::ToolResult { is_error: true, .. }));
-        let tool_call_failure_fingerprint = all_tool_results_error
-            .then(|| tool_call_failure_fingerprint(tool_calls))
-            .flatten();
 
         Ok(ToolRoundOutput {
             tool_results,
@@ -1387,9 +1393,9 @@ struct ToolRoundOutput {
     /// `Some` only when every tool call in the round was malformed; feeds the
     /// tool-call-malformed breaker.
     tool_call_malformed_fingerprint: Option<ToolCallMalformedFingerprint>,
-    /// `Some` when this round produced executable (non-malformed) tool calls
-    /// with the same name+input pattern and all errored; feeds the exact-call
-    /// and cycle breakers.
+    /// `Some` when at least one non-malformed tool call failed. The fingerprint
+    /// contains only failed calls, so successful sibling calls do not reset the
+    /// exact-call or cycle breakers.
     tool_call_failure_fingerprint: Option<ToolCallFailureFingerprint>,
     /// Whether the round had a non-malformed call and every result was an error.
     all_tool_results_error: bool,

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -1316,14 +1316,20 @@ mod tests_plan_mode {
 
 #[cfg(test)]
 mod tests_handle_command {
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use aion_config::compact::CompactConfig;
+    use aion_protocol::events::ToolCategory;
     use aion_providers::error::ProviderError;
     use aion_providers::provider::LlmProvider;
+    use aion_tools::Tool;
     use aion_tools::registry::ToolRegistry;
     use aion_types::llm::{LlmEvent, LlmRequest};
     use aion_types::message::{ContentBlock, ImageInputCapability, ImageUrl, Message, Role, StopReason, TokenUsage};
+    use aion_types::tool::ToolResult;
+    use async_trait::async_trait;
+    use serde_json::{Value, json};
     use tokio::sync::mpsc::{Receiver, channel};
 
     use super::{AgentEngine, AgentError, CacheBreakDetector, CompactLevel, ProviderCompat};
@@ -1477,7 +1483,7 @@ mod tests_handle_command {
     // --- run() text-only behavior ---
 
     struct SingleResponseProvider;
-    #[async_trait::async_trait]
+    #[async_trait]
     impl LlmProvider for SingleResponseProvider {
         async fn stream(&self, _: &LlmRequest) -> Result<Receiver<LlmEvent>, ProviderError> {
             let (tx, rx) = channel(2);
@@ -1489,6 +1495,91 @@ mod tests_handle_command {
                 })
                 .await;
             Ok(rx)
+        }
+    }
+
+    #[derive(Default)]
+    struct RetryingToolProvider {
+        requests: Mutex<Vec<LlmRequest>>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for RetryingToolProvider {
+        async fn stream(&self, request: &LlmRequest) -> Result<Receiver<LlmEvent>, ProviderError> {
+            let request_index = {
+                let mut requests = self.requests.lock().unwrap();
+                let request_index = requests.len();
+                requests.push(request.clone());
+                request_index
+            };
+            let (tx, rx) = channel(4);
+
+            if request_index < 3 {
+                let _ = tx.send(LlmEvent::TextDelta("I will retry".to_string())).await;
+                let _ = tx
+                    .send(LlmEvent::ToolUse {
+                        id: format!("call-{request_index}"),
+                        name: "FailingTool".to_string(),
+                        input: json!({ "resource": "same" }),
+                        extra: None,
+                    })
+                    .await;
+                let _ = tx
+                    .send(LlmEvent::Done {
+                        stop_reason: StopReason::ToolUse,
+                        usage: TokenUsage::default(),
+                    })
+                    .await;
+            } else {
+                let _ = tx
+                    .send(LlmEvent::TextDelta(
+                        "The tool is blocked; please resolve its error before retrying.".to_string(),
+                    ))
+                    .await;
+                let _ = tx
+                    .send(LlmEvent::Done {
+                        stop_reason: StopReason::EndTurn,
+                        usage: TokenUsage::default(),
+                    })
+                    .await;
+            }
+
+            Ok(rx)
+        }
+    }
+
+    struct FailingTool {
+        executions: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for FailingTool {
+        fn name(&self) -> &str {
+            "FailingTool"
+        }
+
+        fn description(&self) -> &str {
+            "always fails for loop-guard testing"
+        }
+
+        fn input_schema(&self) -> Value {
+            json!({ "type": "object" })
+        }
+
+        fn is_concurrency_safe(&self, _: &Value) -> bool {
+            true
+        }
+
+        async fn execute(&self, _: Value) -> ToolResult {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            ToolResult {
+                content: "resource remains unavailable".to_string(),
+                is_error: true,
+            }
+        }
+
+        fn category(&self) -> ToolCategory {
+            ToolCategory::Info
         }
     }
 
@@ -1515,6 +1606,47 @@ mod tests_handle_command {
             ContentBlock::Text { text } => assert_eq!(text, input),
             _ => panic!("expected plain text block, got {:?}", user_msg.content[0]),
         }
+    }
+
+    #[tokio::test]
+    async fn visible_retry_text_does_not_reset_tool_failure_finalization() {
+        let provider = Arc::new(RetryingToolProvider::default());
+        let executions = Arc::new(AtomicUsize::new(0));
+        let mut engine = make_engine_with_provider(provider.clone());
+        engine.max_turns_per_run = Some(10);
+        engine.tools.register(Box::new(FailingTool {
+            executions: executions.clone(),
+        }));
+
+        let result = engine.run("finish the task", "msg-tool-loop").await.unwrap();
+
+        assert_eq!(executions.load(Ordering::SeqCst), 3);
+        assert_eq!(result.stop_reason, StopReason::EndTurn);
+        assert_eq!(result.turns, 3);
+        assert!(result.text.contains("tool is blocked"));
+
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 4);
+        assert!(requests[..3].iter().all(|request| !request.tools.is_empty()));
+        assert!(requests[3].tools.is_empty());
+        assert!(requests[2].messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::ToolResult { content, is_error: true, .. }
+                        if content.contains("same tool call has failed 2/3 times")
+                )
+            })
+        }));
+        assert!(requests[3].messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::ToolResult { content, is_error: true, .. }
+                        if content.contains("resource remains unavailable")
+                )
+            })
+        }));
     }
 
     #[tokio::test]
@@ -1663,10 +1795,10 @@ mod tests_loop_helpers {
     use super::{AgentError, build_assistant_content, merge_tool_results, tool_call_malformed_fingerprint};
     use crate::stream::StreamOutcome;
     use crate::tool_call::{
-        DEFAULT_MAX_TOOL_CALL_FAILURE, ToolCallFailureFingerprint, ToolCallMalformedReason,
-        tool_call_failure_fingerprint,
+        DEFAULT_MAX_ALL_ERROR_TOOL_ROUNDS, DEFAULT_MAX_TOOL_CALL_FAILURE, ToolCallFailureFingerprint,
+        ToolCallMalformedReason, tool_call_failure_fingerprint,
     };
-    use crate::turn::{FinalizationReason, TurnGuardAction, TurnGuards, TurnKind, TurnOutcome};
+    use crate::turn::{FinalizationReason, ToolLoopWarning, TurnGuardAction, TurnGuards, TurnKind, TurnOutcome};
 
     fn tool_use(id: &str, name: &str) -> ContentBlock {
         tool_use_with_input(id, name, json!({}))
@@ -1785,19 +1917,19 @@ mod tests_loop_helpers {
     }
 
     #[test]
-    fn after_tool_round_trips_consecutive_tool_call_failure_breaker() {
+    fn after_tool_round_warns_then_finalizes_repeated_exact_failure() {
         let mut guards = TurnGuards::new(Some(100), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
-        // First N-1 tool-call-failure rounds: no stop yet.
-        for _ in 0..DEFAULT_MAX_TOOL_CALL_FAILURE - 1 {
-            assert!(matches!(
-                guards.after_tool_round(None, failed_exec_fingerprint()),
-                TurnGuardAction::Continue
-            ));
-        }
-        // The Nth consecutive tool-call-failure round trips the breaker.
         assert!(matches!(
-            guards.after_tool_round(None, failed_exec_fingerprint()),
-            TurnGuardAction::Stop(AgentError::ToolCallFailures { .. })
+            guards.after_tool_round(None, failed_exec_fingerprint(), true),
+            TurnGuardAction::Continue
+        ));
+        assert!(matches!(
+            guards.after_tool_round(None, failed_exec_fingerprint(), true),
+            TurnGuardAction::Warn(ToolLoopWarning::ExactFailure { count: 2, limit: 3 })
+        ));
+        assert!(matches!(
+            guards.after_tool_round(None, failed_exec_fingerprint(), true),
+            TurnGuardAction::Finalize(FinalizationReason::ToolFailure)
         ));
     }
 
@@ -1805,24 +1937,28 @@ mod tests_loop_helpers {
     fn after_tool_round_resets_tool_call_failure_streak_on_success() {
         let mut guards = TurnGuards::new(Some(100), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
         assert!(matches!(
-            guards.after_tool_round(None, failed_exec_fingerprint()),
+            guards.after_tool_round(None, failed_exec_fingerprint(), true),
             TurnGuardAction::Continue
         ));
         // A non-error tool round resets the streak.
-        assert!(matches!(guards.after_tool_round(None, None), TurnGuardAction::Continue));
+        assert!(matches!(
+            guards.after_tool_round(None, None, false),
+            TurnGuardAction::Continue
+        ));
         assert_eq!(guards.tool_call_failure_count(), 0);
+        assert_eq!(guards.all_error_tool_round_count(), 0);
         // So a single subsequent tool-call-failure round must not trip the breaker.
         assert!(matches!(
-            guards.after_tool_round(None, failed_exec_fingerprint()),
+            guards.after_tool_round(None, failed_exec_fingerprint(), true),
             TurnGuardAction::Continue
         ));
     }
 
     #[test]
-    fn after_tool_round_does_not_trip_failure_breaker_for_different_tool_inputs() {
+    fn after_tool_round_does_not_trip_exact_breaker_for_different_tool_inputs() {
         let mut guards = TurnGuards::new(Some(100), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
 
-        for index in 0..DEFAULT_MAX_TOOL_CALL_FAILURE {
+        for index in 0..2 {
             let fingerprint = tool_call_failure_fingerprint(&[tool_use_with_input(
                 &format!("call-{index}"),
                 "ExecCommand",
@@ -1830,7 +1966,7 @@ mod tests_loop_helpers {
             )]);
 
             assert!(matches!(
-                guards.after_tool_round(None, fingerprint),
+                guards.after_tool_round(None, fingerprint, true),
                 TurnGuardAction::Continue
             ));
             assert_eq!(guards.tool_call_failure_count(), 1);
@@ -1838,10 +1974,86 @@ mod tests_loop_helpers {
     }
 
     #[test]
+    fn after_tool_round_warns_then_finalizes_variable_all_error_rounds() {
+        let mut guards = TurnGuards::new(Some(100), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
+
+        for index in 1..=DEFAULT_MAX_ALL_ERROR_TOOL_ROUNDS {
+            let fingerprint = tool_call_failure_fingerprint(&[tool_use_with_input(
+                &format!("call-{index}"),
+                "ExecCommand",
+                json!({ "cmd": format!("unique-command-{index}") }),
+            )]);
+            let action = guards.after_tool_round(None, fingerprint, true);
+
+            match index {
+                3 => assert!(matches!(
+                    action,
+                    TurnGuardAction::Warn(ToolLoopWarning::AllErrorRounds { count: 3, limit: 8 })
+                )),
+                DEFAULT_MAX_ALL_ERROR_TOOL_ROUNDS => assert!(matches!(
+                    action,
+                    TurnGuardAction::Finalize(FinalizationReason::ToolFailure)
+                )),
+                _ => assert!(matches!(action, TurnGuardAction::Continue)),
+            }
+        }
+    }
+
+    #[test]
+    fn after_tool_round_warns_then_finalizes_alternating_cycle() {
+        let mut guards = TurnGuards::new(Some(100), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
+
+        for index in 0..6 {
+            let variant = index % 2;
+            let fingerprint = tool_call_failure_fingerprint(&[tool_use_with_input(
+                &format!("call-{index}"),
+                "ExecCommand",
+                json!({ "cmd": format!("command-{variant}") }),
+            )]);
+            let action = guards.after_tool_round(None, fingerprint, true);
+
+            match index {
+                2 => assert!(matches!(
+                    action,
+                    TurnGuardAction::Warn(ToolLoopWarning::AllErrorRounds { .. })
+                )),
+                3 => assert!(matches!(
+                    action,
+                    TurnGuardAction::Warn(ToolLoopWarning::Cycle {
+                        period: 2,
+                        repetitions: 2,
+                        limit: 3,
+                    })
+                )),
+                5 => assert!(matches!(
+                    action,
+                    TurnGuardAction::Finalize(FinalizationReason::ToolFailure)
+                )),
+                _ => assert!(matches!(action, TurnGuardAction::Continue)),
+            }
+        }
+    }
+
+    #[test]
+    fn zero_failure_limit_disables_all_tool_failure_guards() {
+        let mut guards = TurnGuards::new(Some(100), 3, 0);
+
+        for _ in 0..20 {
+            assert!(matches!(
+                guards.after_tool_round(None, failed_exec_fingerprint(), true),
+                TurnGuardAction::Continue
+            ));
+        }
+    }
+
+    #[test]
     fn after_tool_round_requests_finalize_when_budget_is_exhausted() {
         let mut guards = TurnGuards::new(Some(1), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
         guards.record_counted_turn();
-        assert!(matches!(guards.after_tool_round(None, None), TurnGuardAction::Finalize));
+        assert!(matches!(
+            guards.after_tool_round(None, None, false),
+            TurnGuardAction::Finalize(FinalizationReason::TurnBudget)
+        ));
     }
 
     #[test]
@@ -1854,7 +2066,7 @@ mod tests_loop_helpers {
         let fingerprint = tool_call_malformed_fingerprint(&calls, &reasons);
 
         assert!(matches!(
-            guards.after_tool_round(fingerprint, None),
+            guards.after_tool_round(fingerprint, None, false),
             TurnGuardAction::Stop(AgentError::ToolCallMalformed { count: 1, limit: 1 })
         ));
     }
@@ -1885,6 +2097,20 @@ mod tests_loop_helpers {
         assert_eq!(kind.diagnostic_phase(), "max_tokens_finalization");
         assert!(prompt.contains("previous response was cut off"));
         assert!(prompt.contains("Finish the answer"));
+    }
+
+    #[test]
+    fn turn_kind_tool_failure_prompt_explains_blocker_and_disables_tools() {
+        let kind = TurnKind::Finalization(FinalizationReason::ToolFailure);
+        let prompt = kind
+            .control_prompt()
+            .expect("tool failure finalization must have a prompt");
+
+        assert!(kind.disable_tools());
+        assert_eq!(kind.diagnostic_phase(), "tool_failure_finalization");
+        assert!(prompt.contains("Do not call any more tools"));
+        assert!(prompt.contains("concrete blocker"));
+        assert!(prompt.contains("Do not mention internal retry counters"));
     }
 
     #[test]
@@ -2138,7 +2364,7 @@ mod tests_tool_policy_enforcement {
         let mut engine = make_engine(Arc::clone(&read_executions), Arc::clone(&exec_executions));
         let calls = vec![tool_use("denied", "ExecCommand"), tool_use("allowed", "Read")];
 
-        let output = engine.execute_tool_round(&calls, "").await.unwrap();
+        let output = engine.execute_tool_round(&calls).await.unwrap();
 
         assert_eq!(exec_executions.load(Ordering::SeqCst), 0);
         assert_eq!(read_executions.load(Ordering::SeqCst), 1);
@@ -2150,5 +2376,6 @@ mod tests_tool_policy_enforcement {
             &output.tool_results[1],
             ContentBlock::ToolResult { is_error: false, .. }
         ));
+        assert!(!output.all_tool_results_error);
     }
 }

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -1512,15 +1512,23 @@ mod tests_handle_command {
                 requests.push(request.clone());
                 request_index
             };
-            let (tx, rx) = channel(4);
+            let (tx, rx) = channel(5);
 
             if request_index < 3 {
                 let _ = tx.send(LlmEvent::TextDelta("I will retry".to_string())).await;
                 let _ = tx
                     .send(LlmEvent::ToolUse {
-                        id: format!("call-{request_index}"),
+                        id: format!("failed-call-{request_index}"),
                         name: "FailingTool".to_string(),
                         input: json!({ "resource": "same" }),
+                        extra: None,
+                    })
+                    .await;
+                let _ = tx
+                    .send(LlmEvent::ToolUse {
+                        id: format!("successful-call-{request_index}"),
+                        name: "SuccessfulTool".to_string(),
+                        input: json!({ "resource": request_index }),
                         extra: None,
                     })
                     .await;
@@ -1583,6 +1591,41 @@ mod tests_handle_command {
         }
     }
 
+    struct SuccessfulTool {
+        executions: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for SuccessfulTool {
+        fn name(&self) -> &str {
+            "SuccessfulTool"
+        }
+
+        fn description(&self) -> &str {
+            "always succeeds for loop-guard testing"
+        }
+
+        fn input_schema(&self) -> Value {
+            json!({ "type": "object" })
+        }
+
+        fn is_concurrency_safe(&self, _: &Value) -> bool {
+            true
+        }
+
+        async fn execute(&self, _: Value) -> ToolResult {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            ToolResult {
+                content: "progress recorded".to_string(),
+                is_error: false,
+            }
+        }
+
+        fn category(&self) -> ToolCategory {
+            ToolCategory::Info
+        }
+    }
+
     fn make_engine_with_provider(provider: Arc<dyn LlmProvider>) -> AgentEngine {
         let mut engine = make_engine();
         engine.provider = provider;
@@ -1609,18 +1652,23 @@ mod tests_handle_command {
     }
 
     #[tokio::test]
-    async fn visible_retry_text_does_not_reset_tool_failure_finalization() {
+    async fn visible_retry_text_and_successful_tools_do_not_reset_repeated_failure() {
         let provider = Arc::new(RetryingToolProvider::default());
-        let executions = Arc::new(AtomicUsize::new(0));
+        let failed_executions = Arc::new(AtomicUsize::new(0));
+        let successful_executions = Arc::new(AtomicUsize::new(0));
         let mut engine = make_engine_with_provider(provider.clone());
         engine.max_turns_per_run = Some(10);
         engine.tools.register(Box::new(FailingTool {
-            executions: executions.clone(),
+            executions: failed_executions.clone(),
+        }));
+        engine.tools.register(Box::new(SuccessfulTool {
+            executions: successful_executions.clone(),
         }));
 
         let result = engine.run("finish the task", "msg-tool-loop").await.unwrap();
 
-        assert_eq!(executions.load(Ordering::SeqCst), 3);
+        assert_eq!(failed_executions.load(Ordering::SeqCst), 3);
+        assert_eq!(successful_executions.load(Ordering::SeqCst), 3);
         assert_eq!(result.stop_reason, StopReason::EndTurn);
         assert_eq!(result.turns, 3);
         assert!(result.text.contains("tool is blocked"));
@@ -1951,6 +1999,24 @@ mod tests_loop_helpers {
         assert!(matches!(
             guards.after_tool_round(None, failed_exec_fingerprint(), true),
             TurnGuardAction::Continue
+        ));
+    }
+
+    #[test]
+    fn after_tool_round_tracks_repeated_failure_across_mixed_success_rounds() {
+        let mut guards = TurnGuards::new(Some(100), 3, DEFAULT_MAX_TOOL_CALL_FAILURE);
+
+        assert!(matches!(
+            guards.after_tool_round(None, failed_exec_fingerprint(), false),
+            TurnGuardAction::Continue
+        ));
+        assert!(matches!(
+            guards.after_tool_round(None, failed_exec_fingerprint(), false),
+            TurnGuardAction::Warn(ToolLoopWarning::ExactFailure { count: 2, limit: 3 })
+        ));
+        assert!(matches!(
+            guards.after_tool_round(None, failed_exec_fingerprint(), false),
+            TurnGuardAction::Finalize(FinalizationReason::ToolFailure)
         ));
     }
 
@@ -2377,5 +2443,6 @@ mod tests_tool_policy_enforcement {
             ContentBlock::ToolResult { is_error: false, .. }
         ));
         assert!(!output.all_tool_results_error);
+        assert!(output.tool_call_failure_fingerprint.is_some());
     }
 }

--- a/crates/aion-agent/src/tool_call.rs
+++ b/crates/aion-agent/src/tool_call.rs
@@ -2,6 +2,9 @@ use aion_types::{message::ContentBlock, skill_types::ContextModifier};
 
 pub(crate) const DEFAULT_MAX_TOOL_CALL_MALFORMED: usize = 3;
 pub(crate) const DEFAULT_MAX_TOOL_CALL_FAILURE: usize = 3;
+pub(crate) const DEFAULT_MAX_ALL_ERROR_TOOL_ROUNDS: usize = 8;
+pub(crate) const DEFAULT_MAX_TOOL_CALL_CYCLE_REPETITIONS: usize = 3;
+const MAX_TOOL_CALL_CYCLE_PERIOD: usize = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ToolCallMalformedReason {
@@ -282,6 +285,113 @@ impl ToolCallFailureTracker {
     #[cfg(test)]
     pub(crate) fn count(&self) -> usize {
         self.count
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ToolCallAllErrorRoundTracker {
+    count: usize,
+    limit: usize,
+}
+
+impl ToolCallAllErrorRoundTracker {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self { count: 0, limit }
+    }
+
+    pub(crate) fn observe(&mut self, all_error: bool) -> usize {
+        if all_error {
+            self.count += 1;
+        } else {
+            self.count = 0;
+        }
+        self.count
+    }
+
+    pub(crate) fn is_limit_exceeded(&self) -> bool {
+        self.limit > 0 && self.count >= self.limit
+    }
+
+    pub(crate) fn limit(&self) -> usize {
+        self.limit
+    }
+
+    #[cfg(test)]
+    pub(crate) fn count(&self) -> usize {
+        self.count
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ToolCallCycle {
+    pub(crate) period: usize,
+    pub(crate) repetitions: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct ToolCallCycleTracker {
+    enabled: bool,
+    history: Vec<ToolCallFailureFingerprint>,
+}
+
+impl ToolCallCycleTracker {
+    pub(crate) fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            history: Vec::new(),
+        }
+    }
+
+    pub(crate) fn observe(&mut self, current: Option<ToolCallFailureFingerprint>) -> Option<ToolCallCycle> {
+        if !self.enabled {
+            self.history.clear();
+            return None;
+        }
+
+        let Some(current) = current else {
+            self.history.clear();
+            return None;
+        };
+
+        self.history.push(current);
+        let max_history = MAX_TOOL_CALL_CYCLE_PERIOD * DEFAULT_MAX_TOOL_CALL_CYCLE_REPETITIONS;
+        if self.history.len() > max_history {
+            self.history.remove(0);
+        }
+
+        self.detect_cycle()
+    }
+
+    fn detect_cycle(&self) -> Option<ToolCallCycle> {
+        let history_len = self.history.len();
+        let max_period = MAX_TOOL_CALL_CYCLE_PERIOD.min(history_len / 2);
+        let mut best: Option<ToolCallCycle> = None;
+
+        for period in 2..=max_period {
+            let pattern_start = history_len - period;
+            let pattern = &self.history[pattern_start..];
+            let mut repetitions = 1;
+            let mut previous_end = pattern_start;
+
+            while previous_end >= period && self.history[previous_end - period..previous_end] == *pattern {
+                repetitions += 1;
+                previous_end -= period;
+            }
+
+            if repetitions < 2 {
+                continue;
+            }
+
+            let cycle = ToolCallCycle { period, repetitions };
+            if best.is_none_or(|current| {
+                cycle.repetitions > current.repetitions
+                    || (cycle.repetitions == current.repetitions && cycle.period < current.period)
+            }) {
+                best = Some(cycle);
+            }
+        }
+
+        best
     }
 }
 

--- a/crates/aion-agent/src/tool_call_test.rs
+++ b/crates/aion-agent/src/tool_call_test.rs
@@ -6,6 +6,15 @@ mod tests {
 
     use super::*;
 
+    fn failure_fingerprint(command: &str) -> Option<ToolCallFailureFingerprint> {
+        tool_call_failure_fingerprint(&[ContentBlock::ToolUse {
+            id: format!("call-{command}"),
+            name: "ExecCommand".into(),
+            input: json!({ "cmd": command }),
+            extra: None,
+        }])
+    }
+
     #[test]
     fn reason_detects_blank_name_before_blank_id() {
         assert_eq!(
@@ -112,5 +121,77 @@ mod tests {
         assert!(!tracker.is_limit_exceeded());
         assert_eq!(tracker.observe(fingerprint), 2);
         assert!(!tracker.is_limit_exceeded());
+    }
+
+    #[test]
+    fn all_error_round_tracker_counts_consecutive_rounds_and_resets_on_progress() {
+        let mut tracker = ToolCallAllErrorRoundTracker::new(3);
+
+        assert_eq!(tracker.observe(true), 1);
+        assert_eq!(tracker.observe(true), 2);
+        assert!(!tracker.is_limit_exceeded());
+        assert_eq!(tracker.observe(false), 0);
+        assert_eq!(tracker.observe(true), 1);
+        assert_eq!(tracker.observe(true), 2);
+        assert_eq!(tracker.observe(true), 3);
+        assert!(tracker.is_limit_exceeded());
+        assert_eq!(tracker.limit(), 3);
+    }
+
+    #[test]
+    fn cycle_tracker_detects_two_and_three_repetitions() {
+        let mut tracker = ToolCallCycleTracker::new(true);
+        let a = failure_fingerprint("command-a");
+        let b = failure_fingerprint("command-b");
+
+        assert_eq!(tracker.observe(a.clone()), None);
+        assert_eq!(tracker.observe(b.clone()), None);
+        assert_eq!(tracker.observe(a.clone()), None);
+        assert_eq!(
+            tracker.observe(b.clone()),
+            Some(ToolCallCycle {
+                period: 2,
+                repetitions: 2,
+            })
+        );
+        assert_eq!(
+            tracker.observe(a),
+            Some(ToolCallCycle {
+                period: 2,
+                repetitions: 2,
+            })
+        );
+        assert_eq!(
+            tracker.observe(b),
+            Some(ToolCallCycle {
+                period: 2,
+                repetitions: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn cycle_tracker_resets_on_non_failure_round() {
+        let mut tracker = ToolCallCycleTracker::new(true);
+        let a = failure_fingerprint("command-a");
+        let b = failure_fingerprint("command-b");
+
+        tracker.observe(a.clone());
+        tracker.observe(b.clone());
+        tracker.observe(a.clone());
+        assert_eq!(tracker.observe(None), None);
+        assert_eq!(tracker.observe(b), None);
+        assert_eq!(tracker.observe(a), None);
+    }
+
+    #[test]
+    fn disabled_cycle_tracker_never_accumulates_history() {
+        let mut tracker = ToolCallCycleTracker::new(false);
+        let a = failure_fingerprint("command-a");
+        let b = failure_fingerprint("command-b");
+
+        for fingerprint in [a.clone(), b.clone(), a, b] {
+            assert_eq!(tracker.observe(fingerprint), None);
+        }
     }
 }

--- a/crates/aion-agent/src/turn.rs
+++ b/crates/aion-agent/src/turn.rs
@@ -1,9 +1,15 @@
 use crate::error::AgentError;
 use crate::stream::StreamOutcome;
 use crate::tool_call::{
-    ToolCallFailureFingerprint, ToolCallFailureTracker, ToolCallMalformedFingerprint, ToolCallMalformedTracker,
+    DEFAULT_MAX_ALL_ERROR_TOOL_ROUNDS, DEFAULT_MAX_TOOL_CALL_CYCLE_REPETITIONS, ToolCallAllErrorRoundTracker,
+    ToolCallCycle, ToolCallCycleTracker, ToolCallFailureFingerprint, ToolCallFailureTracker,
+    ToolCallMalformedFingerprint, ToolCallMalformedTracker,
 };
 use aion_types::message::StopReason;
+
+const EXACT_FAILURE_WARNING_COUNT: usize = 2;
+const ALL_ERROR_ROUND_WARNING_COUNT: usize = 3;
+const TOOL_CALL_CYCLE_WARNING_REPETITIONS: usize = 2;
 
 pub(crate) enum TurnOutcome {
     ToolRound(StreamOutcome),
@@ -29,6 +35,7 @@ impl TurnOutcome {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FinalizationReason {
     TurnBudget,
+    ToolFailure,
     MaxTokens,
     EmptyFinal,
 }
@@ -38,6 +45,9 @@ impl FinalizationReason {
         match self {
             FinalizationReason::TurnBudget => {
                 "Stopped after reaching the turn budget before the model produced a final answer."
+            }
+            FinalizationReason::ToolFailure => {
+                "Tool execution repeatedly failed without making progress. Review the latest tool errors and try again after resolving the blocker."
             }
             FinalizationReason::MaxTokens => {
                 "The response was cut off by the token limit and could not be completed automatically."
@@ -64,6 +74,9 @@ impl TurnKind {
             Self::Finalization(FinalizationReason::TurnBudget) => {
                 Some("Do not call any more tools. Use the tool results already provided and give the final answer now.")
             }
+            Self::Finalization(FinalizationReason::ToolFailure) => Some(
+                "Tool execution repeatedly failed without making progress. Do not call any more tools. Summarize what was completed, explain the concrete blocker using the latest tool results, and state what the user should change or provide next. Do not mention internal retry counters.",
+            ),
             Self::Finalization(FinalizationReason::MaxTokens) => Some(
                 "The previous response was cut off by the token limit. Finish the answer now. Do not call any tools.",
             ),
@@ -77,6 +90,7 @@ impl TurnKind {
         match self {
             Self::Normal => "normal",
             Self::Finalization(FinalizationReason::TurnBudget) => "turn_budget_finalization",
+            Self::Finalization(FinalizationReason::ToolFailure) => "tool_failure_finalization",
             Self::Finalization(FinalizationReason::MaxTokens) => "max_tokens_finalization",
             Self::Finalization(FinalizationReason::EmptyFinal) => "empty_final_retry",
         }
@@ -117,11 +131,52 @@ pub(crate) struct TurnGuards {
     turns: TurnTracker,
     tool_call_malformed: ToolCallMalformedTracker,
     tool_call_failures: ToolCallFailureTracker,
+    all_error_tool_rounds: ToolCallAllErrorRoundTracker,
+    tool_call_cycles: ToolCallCycleTracker,
+    tool_call_cycle_warning_emitted: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolLoopWarning {
+    ExactFailure {
+        count: usize,
+        limit: usize,
+    },
+    AllErrorRounds {
+        count: usize,
+        limit: usize,
+    },
+    Cycle {
+        period: usize,
+        repetitions: usize,
+        limit: usize,
+    },
+}
+
+impl ToolLoopWarning {
+    pub(crate) fn guidance(self) -> String {
+        match self {
+            Self::ExactFailure { count, limit } => format!(
+                "[Tool recovery required: the same tool call has failed {count}/{limit} times. Do not repeat it unchanged. Inspect the latest error, change arguments or strategy, use another tool, or explain the blocker in the final answer.]"
+            ),
+            Self::AllErrorRounds { count, limit } => format!(
+                "[Tool recovery required: every tool call has failed for {count}/{limit} consecutive rounds. Stop retrying reflexively. Diagnose the latest errors, choose a materially different approach, or explain the blocker in the final answer.]"
+            ),
+            Self::Cycle {
+                period,
+                repetitions,
+                limit,
+            } => format!(
+                "[Tool recovery required: a {period}-round tool-call cycle has repeated {repetitions}/{limit} times without progress. Break the cycle by changing strategy or explain the blocker in the final answer.]"
+            ),
+        }
+    }
 }
 
 pub(crate) enum TurnGuardAction {
     Continue,
-    Finalize,
+    Warn(ToolLoopWarning),
+    Finalize(FinalizationReason),
     Stop(AgentError),
 }
 
@@ -131,10 +186,18 @@ impl TurnGuards {
         max_tool_call_malformed_turns: usize,
         max_tool_call_failure_turns: usize,
     ) -> Self {
+        let tool_failure_guards_enabled = max_tool_call_failure_turns > 0;
         Self {
             turns: TurnTracker::new(max_turns_per_run),
             tool_call_malformed: ToolCallMalformedTracker::new(max_tool_call_malformed_turns),
             tool_call_failures: ToolCallFailureTracker::new(max_tool_call_failure_turns),
+            all_error_tool_rounds: ToolCallAllErrorRoundTracker::new(if tool_failure_guards_enabled {
+                DEFAULT_MAX_ALL_ERROR_TOOL_ROUNDS
+            } else {
+                0
+            }),
+            tool_call_cycles: ToolCallCycleTracker::new(tool_failure_guards_enabled),
+            tool_call_cycle_warning_emitted: false,
         }
     }
 
@@ -157,6 +220,7 @@ impl TurnGuards {
         &mut self,
         tool_call_malformed_fingerprint: Option<ToolCallMalformedFingerprint>,
         tool_call_failure_fingerprint: Option<ToolCallFailureFingerprint>,
+        all_tool_results_error: bool,
     ) -> TurnGuardAction {
         let malformed_count = self.tool_call_malformed.observe(tool_call_malformed_fingerprint);
         if self.tool_call_malformed.is_limit_exceeded() {
@@ -172,29 +236,93 @@ impl TurnGuards {
             });
         }
 
-        let tool_call_failure_count = self.tool_call_failures.observe(tool_call_failure_fingerprint);
+        let tool_call_failure_count = self.tool_call_failures.observe(tool_call_failure_fingerprint.clone());
+        let all_error_round_count = self.all_error_tool_rounds.observe(all_tool_results_error);
+        let cycle = self.tool_call_cycles.observe(tool_call_failure_fingerprint);
+        if cycle.is_none() {
+            self.tool_call_cycle_warning_emitted = false;
+        }
+
         if self.tool_call_failures.is_limit_exceeded() {
             tracing::warn!(
                 target: "aion_agent",
                 count = tool_call_failure_count,
                 limit = self.tool_call_failures.limit(),
-                "stopping tool-call failure loop"
+                loop_kind = "exact_failure",
+                "finalizing after repeated tool-call failures"
             );
-            return TurnGuardAction::Stop(AgentError::ToolCallFailures {
+            return TurnGuardAction::Finalize(FinalizationReason::ToolFailure);
+        }
+
+        if let Some(ToolCallCycle { period, repetitions }) = cycle
+            && repetitions >= DEFAULT_MAX_TOOL_CALL_CYCLE_REPETITIONS
+        {
+            tracing::warn!(
+                target: "aion_agent",
+                period,
+                repetitions,
+                limit = DEFAULT_MAX_TOOL_CALL_CYCLE_REPETITIONS,
+                loop_kind = "cycle",
+                "finalizing after repeated tool-call cycle"
+            );
+            return TurnGuardAction::Finalize(FinalizationReason::ToolFailure);
+        }
+
+        if self.all_error_tool_rounds.is_limit_exceeded() {
+            tracing::warn!(
+                target: "aion_agent",
+                count = all_error_round_count,
+                limit = self.all_error_tool_rounds.limit(),
+                loop_kind = "all_error_rounds",
+                "finalizing after consecutive all-error tool rounds"
+            );
+            return TurnGuardAction::Finalize(FinalizationReason::ToolFailure);
+        }
+
+        if self.turn_budget_reached().is_some() {
+            return TurnGuardAction::Finalize(FinalizationReason::TurnBudget);
+        }
+
+        if self.tool_call_failures.limit() > EXACT_FAILURE_WARNING_COUNT
+            && tool_call_failure_count == EXACT_FAILURE_WARNING_COUNT
+        {
+            return TurnGuardAction::Warn(ToolLoopWarning::ExactFailure {
                 count: tool_call_failure_count,
                 limit: self.tool_call_failures.limit(),
             });
         }
 
-        if self.turn_budget_reached().is_some() {
-            TurnGuardAction::Finalize
-        } else {
-            TurnGuardAction::Continue
+        if let Some(ToolCallCycle { period, repetitions }) = cycle
+            && repetitions == TOOL_CALL_CYCLE_WARNING_REPETITIONS
+            && !self.tool_call_cycle_warning_emitted
+        {
+            self.tool_call_cycle_warning_emitted = true;
+            return TurnGuardAction::Warn(ToolLoopWarning::Cycle {
+                period,
+                repetitions,
+                limit: DEFAULT_MAX_TOOL_CALL_CYCLE_REPETITIONS,
+            });
         }
+
+        if self.all_error_tool_rounds.limit() > ALL_ERROR_ROUND_WARNING_COUNT
+            && all_error_round_count == ALL_ERROR_ROUND_WARNING_COUNT
+        {
+            return TurnGuardAction::Warn(ToolLoopWarning::AllErrorRounds {
+                count: all_error_round_count,
+                limit: self.all_error_tool_rounds.limit(),
+            });
+        }
+
+        TurnGuardAction::Continue
     }
 
     #[cfg(test)]
     pub(crate) fn tool_call_failure_count(&self) -> usize {
         self.tool_call_failures.count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn all_error_tool_round_count(&self) -> usize {
+        self.all_error_tool_rounds.count()
     }
 }

--- a/crates/aion-agent/tests/engine_test.rs
+++ b/crates/aion-agent/tests/engine_test.rs
@@ -926,13 +926,13 @@ async fn finalization_requests_can_be_asserted_without_tools() {
 }
 
 #[tokio::test]
-async fn repeated_tool_call_failure_turns_stop_before_another_provider_request() {
-    let provider = Arc::new(RecordingRequestProvider::new(vec![
+async fn repeated_tool_call_failure_turns_finalize_without_more_tools() {
+    let provider = Arc::new(FullRecordingRequestProvider::new(vec![
         tool_call_failure_turn("tool-1"),
         tool_call_failure_turn("tool-2"),
         tool_call_failure_turn("tool-3"),
         vec![
-            LlmEvent::TextDelta("should not be requested".to_string()),
+            LlmEvent::TextDelta("The tool is blocked by permission settings.".to_string()),
             LlmEvent::Done {
                 stop_reason: StopReason::EndTurn,
                 usage: TokenUsage::default(),
@@ -948,27 +948,41 @@ async fn repeated_tool_call_failure_turns_stop_before_another_provider_request()
     registry.register(Box::new(MockTool::new("mock_tool", "permission denied", true)));
 
     let mut engine = AgentEngine::new_with_provider(provider, config, registry, silent_output(), std::env::temp_dir());
-    let err = engine
+    let result = engine
         .run("keep retrying a failing tool", "")
         .await
-        .expect_err("engine should stop repeated tool-call-failure loops");
+        .expect("engine should finalize repeated tool-call-failure loops");
 
-    assert!(
-        err.to_string().contains("consecutive tool-call failures"),
-        "unexpected error: {err}"
-    );
-    assert_eq!(
-        requests.lock().unwrap().len(),
-        3,
-        "fourth provider request must not be sent"
-    );
+    assert_eq!(result.stop_reason, StopReason::EndTurn);
+    assert_eq!(result.text, "The tool is blocked by permission settings.");
+    assert_eq!(result.turns, 3);
+
+    let recorded = requests.lock().unwrap();
+    assert_eq!(recorded.len(), 4);
+    assert!(recorded[..3].iter().all(|request| request.tool_count > 0));
+    assert_eq!(recorded[3].tool_count, 0);
+    assert!(recorded[3].messages.iter().any(|message| {
+        message.content.iter().any(|block| {
+            matches!(
+                block,
+                ContentBlock::ToolResult { content, is_error: true, .. }
+                    if content.contains("permission denied")
+            )
+        })
+    }));
 }
 
 #[tokio::test]
-async fn repeated_tool_call_failure_threshold_one_stops_immediately() {
-    let provider = Arc::new(RecordingRequestProvider::new(vec![
+async fn repeated_tool_call_failure_threshold_one_finalizes_immediately() {
+    let provider = Arc::new(FullRecordingRequestProvider::new(vec![
         tool_call_failure_turn("tool-1"),
-        tool_call_failure_turn("tool-2"),
+        vec![
+            LlmEvent::TextDelta("The tool failed because permission was denied.".to_string()),
+            LlmEvent::Done {
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+            },
+        ],
     ]));
     let requests = provider.requests();
 
@@ -980,13 +994,19 @@ async fn repeated_tool_call_failure_threshold_one_stops_immediately() {
     registry.register(Box::new(MockTool::new("mock_tool", "permission denied", true)));
 
     let mut engine = AgentEngine::new_with_provider(provider, config, registry, silent_output(), std::env::temp_dir());
-    let err = engine
+    let result = engine
         .run("keep retrying a failing tool", "")
         .await
-        .expect_err("engine should stop repeated tool-call-failure loops");
+        .expect("engine should finalize repeated tool-call-failure loops");
 
-    assert!(matches!(err, AgentError::ToolCallFailures { count: 1, limit: 1 }));
-    assert_eq!(requests.lock().unwrap().len(), 1);
+    assert_eq!(result.stop_reason, StopReason::EndTurn);
+    assert_eq!(result.text, "The tool failed because permission was denied.");
+    assert_eq!(result.turns, 1);
+
+    let recorded = requests.lock().unwrap();
+    assert_eq!(recorded.len(), 2);
+    assert!(recorded[0].tool_count > 0);
+    assert_eq!(recorded[1].tool_count, 0);
 }
 
 #[tokio::test]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -173,9 +173,17 @@ the distinction between runs, turns, tool rounds, and tool calls.
 rounds from a provider. The default is `3`; `0` disables this breaker
 and leaves stopping to `max_turns` if a broad turn limit is configured.
 
-`max_tool_call_failure_turns` limits consecutive zero-text turns where every
-executable tool result failed. The default is `3`; `0` disables this breaker
-and leaves stopping to `max_turns` if a broad turn limit is configured.
+`max_tool_call_failure_turns` limits consecutive repeats of the same failed
+tool name and input pattern. Assistant explanation text does not reset the
+count, and successful sibling calls in a mixed round do not erase failures
+that are still repeating. A failure-free tool round resets the exact-call and
+cycle history. The default is `3`.
+
+The same guard also warns after 3 consecutive all-error rounds and finalizes
+after 8, and detects repeating 2-4 round call cycles after 2 repetitions before
+finalizing after 3. Setting `max_tool_call_failure_turns` to `0` disables all
+of these tool-failure guards and leaves stopping to `max_turns` if a broad turn
+limit is configured.
 
 Precedence is `CLI > profile > project config > global config > built-in default 3`. Use `--max-tool-call-malformed-turns <n>` or `--max-tool-call-failure-turns <n>` for a one-off CLI override.
 


### PR DESCRIPTION
## Summary

- Track repeated failed tool calls independently of assistant filler text, so messages such as `I will retry` cannot reset failure detection.
- Keep failed-call fingerprints across mixed rounds: a successful sibling tool no longer erases a concurrently repeating failed call; a failure-free tool round still resets exact-call and cycle history.
- Warn the model before escalation and detect exact retries, consecutive all-error rounds with changing arguments, and short repeating tool-call cycles.
- Persist and emit the latest failed `ToolResult`, then run one tools-disabled `ToolFailure` finalization turn instead of returning `AgentError::ToolCallFailures` to the user.
- Preserve long-running tasks by avoiding global tool-call totals; `max_tool_call_failure_turns = 0` still disables the tool-failure guards.

## Why

Weak models can evade the previous exact-call breaker by emitting harmless visible text, alternating calls, mutating arguments without making progress, or pairing a repeated failed call with an unrelated successful call. When the breaker did fire, users received a generic `stopped after 3/3 consecutive tool call failure` error instead of a useful explanation of the blocker.

## Behavior

- Exact same failed tool name and input: warn on the second failure and finalize at the configured limit (default: 3).
- Consecutive all-error rounds: warn at 3 and finalize at 8.
- Repeating cycles of 2-4 failed-call rounds: warn after 2 repetitions and finalize after 3.
- Assistant text and successful sibling calls do not reset a still-repeating failure.
- A failure-free tool round resets exact-call and cycle tracking.
- Malformed calls remain governed separately by `max_tool_call_malformed_turns`.

## Non-goals

- This version does not add structured `retryable` or `error_kind` metadata.
- The tool call that reaches a threshold is executed before the tools-disabled finalization turn.
- Successful tool calls are not classified by semantic progress; this change only prevents them from masking failed siblings in the same round.

## Validation

- `cargo test -p aion-agent`
- `cargo clippy -p aion-agent --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Mixed-round regression: repeated failed tool + successful sibling tool finalizes on the third failed round.
- `just push` (workspace Clippy, formatting, full workspace nextest, and Hakari checks passed)
