### PR TITLE
fix(providers): handle embedded json errors in streaming responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "chrono",
  "dirs",
  "futures",
+ "http 1.4.0",
  "insta",
  "jsonwebtoken",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ futures = "0.3"
 
 # HTTP client
 # HTTP client — use rustls to avoid native OpenSSL dep during cross-compilation
+http = "1"
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"], default-features = false }
 
 # Serialization

--- a/crates/aion-providers/Cargo.toml
+++ b/crates/aion-providers/Cargo.toml
@@ -12,6 +12,7 @@ aion-config.workspace = true
 
 tokio.workspace        = true
 futures.workspace      = true
+http.workspace         = true
 reqwest.workspace      = true
 serde.workspace        = true
 serde_json.workspace   = true

--- a/crates/aion-providers/src/composed_test.rs
+++ b/crates/aion-providers/src/composed_test.rs
@@ -1,5 +1,8 @@
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
     use aion_config::compat::{ProviderCompat, TransportCompat};
     use aion_types::llm::{LlmEvent, LlmRequest};
     use aion_types::message::{ContentBlock, Message, Role};
@@ -356,5 +359,87 @@ mod tests {
             rx.recv().await,
             Some(LlmEvent::TextDelta(text)) if text == "hi"
         ));
+    }
+
+    #[tokio::test]
+    async fn composed_provider_retries_successful_json_502_then_streams() {
+        let server = MockServer::start().await;
+        let attempt = Arc::new(AtomicU32::new(0));
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with({
+                let attempt = Arc::clone(&attempt);
+                move |_request: &wiremock::Request| {
+                    if attempt.fetch_add(1, Ordering::SeqCst) == 0 {
+                        ResponseTemplate::new(200).set_body_json(json!({
+                            "error": {
+                                "message": "upstream busy",
+                                "code": 502
+                            }
+                        }))
+                    } else {
+                        ResponseTemplate::new(200).set_body_raw(
+                            concat!(
+                                "data: {\"choices\":[{\"delta\":{\"content\":\"recovered\"}}]}\n\n",
+                                "data: [DONE]\n\n"
+                            ),
+                            "text/event-stream",
+                        )
+                    }
+                }
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+        tokio::time::pause();
+
+        let provider = ComposedProvider::new(
+            ProviderTransport::OpenAi(OpenAiTransport::new("test-key", &server.uri())),
+            ProviderCompat::openai_defaults(),
+        );
+        let mut rx = provider
+            .stream(&test_request())
+            .await
+            .expect("embedded 502 should be retried");
+
+        assert!(matches!(
+            rx.recv().await,
+            Some(LlmEvent::TextDelta(text)) if text == "recovered"
+        ));
+        assert_eq!(attempt.load(Ordering::SeqCst), 2);
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn composed_provider_returns_typed_502_after_retry_exhaustion() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "error": {
+                    "message": "upstream busy",
+                    "code": 502
+                }
+            })))
+            .expect(6)
+            .mount(&server)
+            .await;
+        tokio::time::pause();
+
+        let provider = ComposedProvider::new(
+            ProviderTransport::OpenAi(OpenAiTransport::new("test-key", &server.uri())),
+            ProviderCompat::openai_defaults(),
+        );
+
+        let error = provider
+            .stream(&test_request())
+            .await
+            .expect_err("exhausted retries should return a typed provider error");
+
+        assert!(matches!(
+            error,
+            ProviderError::Api { status: 502, message } if message == "upstream busy"
+        ));
+        server.verify().await;
     }
 }

--- a/crates/aion-providers/src/transport.rs
+++ b/crates/aion-providers/src/transport.rs
@@ -1,5 +1,7 @@
 use aion_config::compat::{OpenAiApiMode, ProviderCompat};
 use aion_types::llm::LlmRequest;
+use futures::StreamExt;
+use reqwest::ResponseBuilderExt;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde_json::Value;
 
@@ -15,7 +17,7 @@ use crate::stream_process::StreamDecoder;
 use crate::stream_runner::RetryPolicy;
 use crate::vertex::VertexTransportState;
 
-const MAX_JSON_RESPONSE_BYTES: usize = 64 * 1024;
+const MAX_JSON_ERROR_INSPECTION_BYTES: usize = 64 * 1024;
 
 #[cfg(test)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -295,15 +297,7 @@ async fn send_projected_json_request(
 
     if is_json_response(&response) {
         let http_status = status.as_u16();
-        let body_text = read_json_response_body(response).await?;
-        let error = map_success_json_response(&body_text);
-        let provider_status = provider_error_status(&error);
-        tracing::warn!(
-            http_status,
-            provider_status,
-            "provider returned JSON instead of a stream with a successful HTTP status"
-        );
-        return Err(error);
+        return inspect_success_json_response(response, http_status).await;
     }
 
     Ok(response)
@@ -321,31 +315,52 @@ fn is_json_response(response: &reqwest::Response) -> bool {
         })
 }
 
-async fn read_json_response_body(mut response: reqwest::Response) -> Result<String, ProviderError> {
-    let mut body = Vec::new();
-    while let Some(chunk) = response.chunk().await? {
-        if body.len().saturating_add(chunk.len()) > MAX_JSON_RESPONSE_BYTES {
-            return Err(ProviderError::Parse(format!(
-                "JSON response exceeded the {MAX_JSON_RESPONSE_BYTES}-byte limit"
-            )));
+async fn inspect_success_json_response(
+    response: reqwest::Response,
+    http_status: u16,
+) -> Result<reqwest::Response, ProviderError> {
+    let status = response.status();
+    let version = response.version();
+    let headers = response.headers().clone();
+    let url = response.url().clone();
+    let mut stream = response.bytes_stream();
+    let mut buffered_chunks = Vec::new();
+    let mut buffered_bytes = 0usize;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        buffered_bytes = buffered_bytes.saturating_add(chunk.len());
+        buffered_chunks.push(chunk);
+
+        if buffered_bytes > MAX_JSON_ERROR_INSPECTION_BYTES {
+            let prefix = futures::stream::iter(buffered_chunks.into_iter().map(Ok::<_, reqwest::Error>));
+            let body = reqwest::Body::wrap_stream(prefix.chain(stream));
+            return rebuild_response(status, version, headers, url, body);
         }
-        body.extend_from_slice(&chunk);
     }
 
-    String::from_utf8(body).map_err(|error| ProviderError::Parse(format!("JSON response was not valid UTF-8: {error}")))
+    let mut body_bytes = Vec::with_capacity(buffered_bytes);
+    for chunk in buffered_chunks {
+        body_bytes.extend_from_slice(&chunk);
+    }
+
+    if let Ok(body) = serde_json::from_slice::<Value>(&body_bytes)
+        && let Some(error) = map_success_json_error(&body, &body_bytes)
+    {
+        let provider_status = provider_error_status(&error);
+        tracing::warn!(
+            http_status,
+            provider_status,
+            "provider returned a JSON error with a successful HTTP status"
+        );
+        return Err(error);
+    }
+
+    rebuild_response(status, version, headers, url, body_bytes)
 }
 
-fn map_success_json_response(body_text: &str) -> ProviderError {
-    let body = match serde_json::from_str::<Value>(body_text) {
-        Ok(body) => body,
-        Err(error) => {
-            return ProviderError::Parse(format!(
-                "Expected a streaming response but received invalid JSON: {error}"
-            ));
-        }
-    };
-
-    let error = body.get("error").unwrap_or(&body);
+fn map_success_json_error(body: &Value, body_bytes: &[u8]) -> Option<ProviderError> {
+    let error = body.get("error").unwrap_or(body);
     let status = [
         error.get("code"),
         error.get("status"),
@@ -366,13 +381,36 @@ fn map_success_json_response(body_text: &str) -> ProviderError {
         .to_string();
 
     match status {
-        Some(429) => ProviderError::RateLimited {
+        Some(429) => Some(ProviderError::RateLimited {
             retry_after_ms: 5000,
-            body: (!body_text.is_empty()).then(|| body_text.to_string()),
-        },
-        Some(status @ 400..=599) => ProviderError::Api { status, message },
-        _ => ProviderError::Parse(format!("Provider returned an unexpected JSON response: {message}")),
+            body: (!body_bytes.is_empty()).then(|| String::from_utf8_lossy(body_bytes).into_owned()),
+        }),
+        Some(status) => Some(ProviderError::Api { status, message }),
+        None if body.get("error").is_some() => Some(ProviderError::Parse(format!(
+            "Provider returned a JSON error response without an HTTP status: {message}"
+        ))),
+        None => None,
     }
+}
+
+fn rebuild_response<B>(
+    status: http::StatusCode,
+    version: http::Version,
+    headers: HeaderMap,
+    url: url::Url,
+    body: B,
+) -> Result<reqwest::Response, ProviderError>
+where
+    B: Into<reqwest::Body>,
+{
+    let mut response = http::Response::builder()
+        .status(status)
+        .version(version)
+        .url(url)
+        .body(body)
+        .map_err(|error| ProviderError::Connection(format!("Failed to preserve provider response: {error}")))?;
+    *response.headers_mut() = headers;
+    Ok(reqwest::Response::from(response))
 }
 
 fn json_http_status_code(value: &Value) -> Option<u16> {

--- a/crates/aion-providers/src/transport.rs
+++ b/crates/aion-providers/src/transport.rs
@@ -15,6 +15,8 @@ use crate::stream_process::StreamDecoder;
 use crate::stream_runner::RetryPolicy;
 use crate::vertex::VertexTransportState;
 
+const MAX_JSON_RESPONSE_BYTES: usize = 64 * 1024;
+
 #[cfg(test)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum WireProtocol {
@@ -291,7 +293,102 @@ async fn send_projected_json_request(
         return Err(map_common_status(status.as_u16(), body_text, tool_wire_shape));
     }
 
+    if is_json_response(&response) {
+        let http_status = status.as_u16();
+        let body_text = read_json_response_body(response).await?;
+        let error = map_success_json_response(&body_text);
+        let provider_status = provider_error_status(&error);
+        tracing::warn!(
+            http_status,
+            provider_status,
+            "provider returned JSON instead of a stream with a successful HTTP status"
+        );
+        return Err(error);
+    }
+
     Ok(response)
+}
+
+fn is_json_response(response: &reqwest::Response) -> bool {
+    response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .is_some_and(|media_type| {
+            media_type.eq_ignore_ascii_case("application/json") || media_type.to_ascii_lowercase().ends_with("+json")
+        })
+}
+
+async fn read_json_response_body(mut response: reqwest::Response) -> Result<String, ProviderError> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        if body.len().saturating_add(chunk.len()) > MAX_JSON_RESPONSE_BYTES {
+            return Err(ProviderError::Parse(format!(
+                "JSON response exceeded the {MAX_JSON_RESPONSE_BYTES}-byte limit"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    String::from_utf8(body).map_err(|error| ProviderError::Parse(format!("JSON response was not valid UTF-8: {error}")))
+}
+
+fn map_success_json_response(body_text: &str) -> ProviderError {
+    let body = match serde_json::from_str::<Value>(body_text) {
+        Ok(body) => body,
+        Err(error) => {
+            return ProviderError::Parse(format!(
+                "Expected a streaming response but received invalid JSON: {error}"
+            ));
+        }
+    };
+
+    let error = body.get("error").unwrap_or(&body);
+    let status = [
+        error.get("code"),
+        error.get("status"),
+        body.get("code"),
+        body.get("status"),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(json_http_status_code);
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .or_else(|| error.as_str())
+        .or_else(|| body.get("message").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .unwrap_or("Provider returned a JSON error response without a message")
+        .to_string();
+
+    match status {
+        Some(429) => ProviderError::RateLimited {
+            retry_after_ms: 5000,
+            body: (!body_text.is_empty()).then(|| body_text.to_string()),
+        },
+        Some(status @ 400..=599) => ProviderError::Api { status, message },
+        _ => ProviderError::Parse(format!("Provider returned an unexpected JSON response: {message}")),
+    }
+}
+
+fn json_http_status_code(value: &Value) -> Option<u16> {
+    value
+        .as_u64()
+        .and_then(|status| u16::try_from(status).ok())
+        .or_else(|| value.as_str().and_then(|status| status.parse().ok()))
+        .filter(|status| (400..=599).contains(status))
+}
+
+fn provider_error_status(error: &ProviderError) -> Option<u16> {
+    match error {
+        ProviderError::Api { status, .. } => Some(*status),
+        ProviderError::RateLimited { .. } => Some(429),
+        _ => None,
+    }
 }
 
 fn map_common_status(status: u16, body_text: String, tool_wire_shape: ResolvedToolWireShape) -> ProviderError {

--- a/crates/aion-providers/src/transport_test.rs
+++ b/crates/aion-providers/src/transport_test.rs
@@ -267,6 +267,108 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn openai_transport_maps_successful_json_502_to_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "error": {
+                    "message": "Upstream error from Nvidia: ResourceExhausted: Worker local total request limit reached (33/32)",
+                    "code": 502
+                }
+            })))
+            .mount(&server)
+            .await;
+        let transport = ProviderTransport::OpenAi(OpenAiTransport::new("test-key", &server.uri()));
+        let compat = ProviderCompat::openai_defaults();
+        let (body, tool_wire_shape) = transport
+            .project_body(&test_request(vec![]), &compat)
+            .expect("request body projection should succeed");
+        let request = transport
+            .build_projected_request("test-model", body, &compat, tool_wire_shape)
+            .expect("projected request should build");
+
+        let error = transport
+            .send(request)
+            .await
+            .expect_err("embedded 502 should map to an API error");
+
+        assert!(matches!(
+            error,
+            ProviderError::Api { status: 502, message }
+                if message == "Upstream error from Nvidia: ResourceExhausted: Worker local total request limit reached (33/32)"
+        ));
+    }
+
+    #[tokio::test]
+    async fn openai_transport_maps_successful_json_429_to_rate_limited() {
+        let server = MockServer::start().await;
+        let response_body = json!({
+            "error": {
+                "message": "Too many requests",
+                "code": "429"
+            }
+        });
+        let response_body_text = response_body.to_string();
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&server)
+            .await;
+        let transport = ProviderTransport::OpenAi(OpenAiTransport::new("test-key", &server.uri()));
+        let compat = ProviderCompat::openai_defaults();
+        let (body, tool_wire_shape) = transport
+            .project_body(&test_request(vec![]), &compat)
+            .expect("request body projection should succeed");
+        let request = transport
+            .build_projected_request("test-model", body, &compat, tool_wire_shape)
+            .expect("projected request should build");
+
+        let error = transport
+            .send(request)
+            .await
+            .expect_err("embedded 429 should map to rate limited");
+
+        match error {
+            ProviderError::RateLimited { retry_after_ms, body } => {
+                assert_eq!(retry_after_ms, 5000);
+                assert_eq!(body.as_deref(), Some(response_body_text.as_str()));
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn successful_json_top_level_error_shape_is_normalized() {
+        let error = map_success_json_response(r#"{"code":"503","message":"upstream busy"}"#);
+
+        assert!(matches!(
+            error,
+            ProviderError::Api { status: 503, message } if message == "upstream busy"
+        ));
+    }
+
+    #[test]
+    fn successful_json_uses_http_status_when_provider_code_is_not_http() {
+        let error = map_success_json_response(r#"{"error":{"code":1001,"message":"upstream busy"},"status":503}"#);
+
+        assert!(matches!(
+            error,
+            ProviderError::Api { status: 503, message } if message == "upstream busy"
+        ));
+    }
+
+    #[test]
+    fn successful_json_without_error_status_is_a_parse_error() {
+        let error = map_success_json_response(r#"{"choices":[]}"#);
+
+        assert!(matches!(
+            error,
+            ProviderError::Parse(message) if message.contains("unexpected JSON response")
+        ));
+    }
+
+    #[tokio::test]
     async fn openai_transport_preserves_429_body_as_none_when_empty() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))

--- a/crates/aion-providers/src/transport_test.rs
+++ b/crates/aion-providers/src/transport_test.rs
@@ -338,9 +338,91 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn openai_transport_preserves_successful_json_response() {
+        let server = MockServer::start().await;
+        let response_body = json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "hello"
+                },
+                "finish_reason": "stop"
+            }]
+        });
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&server)
+            .await;
+        let transport = ProviderTransport::OpenAi(OpenAiTransport::new("test-key", &server.uri()));
+        let compat = ProviderCompat::openai_defaults();
+        let (body, tool_wire_shape) = transport
+            .project_body(&test_request(vec![]), &compat)
+            .expect("request body projection should succeed");
+        let request = transport
+            .build_projected_request("test-model", body, &compat, tool_wire_shape)
+            .expect("projected request should build");
+
+        let response = transport
+            .send(request)
+            .await
+            .expect("successful JSON should remain a successful response");
+
+        assert_eq!(
+            response
+                .json::<Value>()
+                .await
+                .expect("preserved response should remain valid JSON"),
+            response_body
+        );
+    }
+
+    #[tokio::test]
+    async fn openai_transport_preserves_large_successful_json_response() {
+        let server = MockServer::start().await;
+        let response_body = json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "x".repeat(MAX_JSON_ERROR_INSPECTION_BYTES + 1)
+                },
+                "finish_reason": "stop"
+            }]
+        });
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&server)
+            .await;
+        let transport = ProviderTransport::OpenAi(OpenAiTransport::new("test-key", &server.uri()));
+        let compat = ProviderCompat::openai_defaults();
+        let (body, tool_wire_shape) = transport
+            .project_body(&test_request(vec![]), &compat)
+            .expect("request body projection should succeed");
+        let request = transport
+            .build_projected_request("test-model", body, &compat, tool_wire_shape)
+            .expect("projected request should build");
+
+        let response = transport
+            .send(request)
+            .await
+            .expect("large successful JSON should remain a successful response");
+
+        assert_eq!(
+            response
+                .json::<Value>()
+                .await
+                .expect("preserved response should remain valid JSON"),
+            response_body
+        );
+    }
+
     #[test]
     fn successful_json_top_level_error_shape_is_normalized() {
-        let error = map_success_json_response(r#"{"code":"503","message":"upstream busy"}"#);
+        let body_text = r#"{"code":"503","message":"upstream busy"}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+        let error = map_success_json_error(&body, body_text.as_bytes()).expect("status 503 should map to an error");
 
         assert!(matches!(
             error,
@@ -350,7 +432,9 @@ mod tests {
 
     #[test]
     fn successful_json_uses_http_status_when_provider_code_is_not_http() {
-        let error = map_success_json_response(r#"{"error":{"code":1001,"message":"upstream busy"},"status":503}"#);
+        let body_text = r#"{"error":{"code":1001,"message":"upstream busy"},"status":503}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+        let error = map_success_json_error(&body, body_text.as_bytes()).expect("status 503 should map to an error");
 
         assert!(matches!(
             error,
@@ -359,12 +443,22 @@ mod tests {
     }
 
     #[test]
-    fn successful_json_without_error_status_is_a_parse_error() {
-        let error = map_success_json_response(r#"{"choices":[]}"#);
+    fn successful_json_without_error_shape_is_not_mapped_to_an_error() {
+        let body_text = r#"{"choices":[]}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+
+        assert!(map_success_json_error(&body, body_text.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn successful_json_error_without_http_status_is_a_parse_error() {
+        let body_text = r#"{"error":{"code":"resource_exhausted","message":"upstream busy"}}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+        let error = map_success_json_error(&body, body_text.as_bytes()).expect("explicit error should be surfaced");
 
         assert!(matches!(
             error,
-            ProviderError::Parse(message) if message.contains("unexpected JSON response")
+            ProviderError::Parse(message) if message.contains("without an HTTP status")
         ));
     }
 


### PR DESCRIPTION
## Why

Some OpenAI-compatible gateways return `200 OK` with an `application/json` error body for requests that asked for an SSE stream. The transport previously passed that response to the SSE decoder, which emitted no events and caused the failure to be misclassified as an empty model answer instead of a typed, potentially retryable provider error.

## Summary

- inspect successful JSON responses for embedded error envelopes without gateway-specific URL checks
- normalize nested and top-level `code`, `status`, and `message` fields
- map embedded `429` errors to `ProviderError::RateLimited`, embedded HTTP-style `4xx/5xx` errors to `ProviderError::Api`, and explicit `error` objects without a recognizable HTTP status to `ProviderError::Parse`
- preserve typed `5xx` errors before stream creation so the existing initial-request retry policy handles them
- treat 64 KiB as an error-inspection window, not a response-size limit
- rebuild non-error JSON responses with their status, HTTP version, headers, final URL, and body before continuing through the existing downstream path
- stop inspection after the window is exceeded and pass the buffered prefix plus the remaining stream through in byte order, without truncation or a size-based parse error
- add the direct `http` dependency used to reconstruct `reqwest::Response`
- add regression coverage for retry recovery and exhaustion, alternate error envelopes, rate limits, successful JSON preservation, large-response passthrough, and normal SSE responses

No AionCore or AionUi API changes are required.

## Non-goals

- This change does not convert a non-streaming successful JSON completion into `LlmEvent` values; such responses continue through the existing decoder behavior.
- JSON error envelopes larger than the 64 KiB inspection window are not classified by this transport check and continue downstream unchanged.

## Validation

- `cargo test -p aion-providers transport_test --no-fail-fast` (28 passed)
- `just push origin jiahe/fix/openai-json-error-response`
  - workspace fmt and Clippy passed
  - 2,221 nextest tests passed; 2 skipped
  - Hakari verification passed
- GitHub Actions CI, E2E, and cross-platform build checks passed
