### PR TITLE
fix(providers): buffer partial UTF-8 across SSE chunk boundaries

### DIFF
--- a/crates/aion-providers/src/framing.rs
+++ b/crates/aion-providers/src/framing.rs
@@ -14,6 +14,61 @@ pub(crate) struct Frame {
     pub kind: FrameKind,
 }
 
+/// Decodes a byte stream into UTF-8 text incrementally, carrying an incomplete
+/// trailing multibyte sequence over to the next chunk.
+///
+/// `bytes_stream()` can split a multibyte UTF-8 character (e.g. a 3-byte CJK
+/// char) across two network chunks. Lossy-decoding each chunk on its own would
+/// turn both halves into U+FFFD and drop the character. This decoder only emits
+/// complete UTF-8 sequences and retains the incomplete tail until more bytes
+/// arrive.
+#[derive(Default)]
+pub(crate) struct Utf8StreamDecoder {
+    pending: Vec<u8>,
+}
+
+impl Utf8StreamDecoder {
+    /// Append `chunk` to the pending bytes and return the longest valid UTF-8
+    /// prefix as an owned `String`, retaining any incomplete trailing sequence
+    /// for the next call. The returned string may be empty.
+    pub(crate) fn push(&mut self, chunk: &[u8]) -> String {
+        self.pending.extend_from_slice(chunk);
+
+        let valid_up_to = match std::str::from_utf8(&self.pending) {
+            Ok(_) => self.pending.len(),
+            Err(error) => error.valid_up_to(),
+        };
+
+        // A truly invalid leading byte (valid_up_to == 0) would stick forever.
+        // The retained tail of an incomplete sequence is at most 3 bytes, so
+        // once pending grows past that, drop one leading byte lossily to make
+        // progress instead of buffering unboundedly.
+        if valid_up_to == 0 {
+            if self.pending.len() > 3 {
+                let dropped = self.pending.remove(0);
+                return String::from_utf8_lossy(&[dropped]).into_owned();
+            }
+            return String::new();
+        }
+
+        let decoded = String::from_utf8_lossy(&self.pending[..valid_up_to]).into_owned();
+        self.pending.drain(..valid_up_to);
+        decoded
+    }
+
+    /// Decode any remaining pending bytes at the true end of the stream. A
+    /// genuinely-truncated trailing sequence is decoded lossily (yielding
+    /// U+FFFD) since no further bytes will arrive.
+    pub(crate) fn flush(&mut self) -> String {
+        if self.pending.is_empty() {
+            return String::new();
+        }
+        let decoded = String::from_utf8_lossy(&self.pending).into_owned();
+        self.pending.clear();
+        decoded
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct SseLineFramer {
     buffer: String,

--- a/crates/aion-providers/src/framing_test.rs
+++ b/crates/aion-providers/src/framing_test.rs
@@ -2,8 +2,54 @@ use super::*;
 
 #[cfg(test)]
 mod tests {
-    use super::{Frame, FrameKind, SseBlockFramer, SseLineFramer, bedrock_payload_to_frame};
+    use super::{Frame, FrameKind, SseBlockFramer, SseLineFramer, Utf8StreamDecoder, bedrock_payload_to_frame};
     use base64::Engine as _;
+
+    #[test]
+    fn test_utf8_decoder_reassembles_cjk_split_across_chunks() {
+        let original = "权限管理服务器";
+        let bytes = original.as_bytes();
+
+        // Split at byte offsets that fall in the MIDDLE of multibyte (3-byte
+        // CJK) characters, across three push() calls.
+        let split_a = 4; // inside the 2nd char (chars start at 0, 3, 6, ...)
+        let split_b = 13; // inside the 5th char
+        assert!(!original.is_char_boundary(split_a));
+        assert!(!original.is_char_boundary(split_b));
+
+        let mut decoder = Utf8StreamDecoder::default();
+        let mut out = String::new();
+        out.push_str(&decoder.push(&bytes[..split_a]));
+        out.push_str(&decoder.push(&bytes[split_a..split_b]));
+        out.push_str(&decoder.push(&bytes[split_b..]));
+        out.push_str(&decoder.flush());
+
+        assert_eq!(out, original);
+        assert!(!out.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn test_utf8_decoder_flush_handles_truncated_tail_without_panic() {
+        let mut decoder = Utf8StreamDecoder::default();
+
+        // A single leading byte of a 3-byte sequence with no continuation.
+        let head = &"权".as_bytes()[..1];
+        assert_eq!(decoder.push(head), "");
+
+        // Genuinely truncated stream end: flush decodes lossily, no panic.
+        let flushed = decoder.flush();
+        assert!(flushed.contains('\u{FFFD}'));
+
+        // Decoder is drained after flush.
+        assert_eq!(decoder.flush(), "");
+    }
+
+    #[test]
+    fn test_utf8_decoder_passes_through_complete_ascii() {
+        let mut decoder = Utf8StreamDecoder::default();
+        assert_eq!(decoder.push(b"data: hello\n"), "data: hello\n");
+        assert_eq!(decoder.flush(), "");
+    }
 
     #[test]
     fn test_sse_line_framer_extracts_data_and_done() {

--- a/crates/aion-providers/src/stream_process.rs
+++ b/crates/aion-providers/src/stream_process.rs
@@ -6,7 +6,7 @@ use aion_types::llm::LlmEvent;
 use aion_types::message::{StopReason, TokenUsage};
 
 use crate::error::ProviderError;
-use crate::framing::{FrameKind, SseBlockFramer, SseLineFramer, bedrock_payload_to_frame};
+use crate::framing::{FrameKind, SseBlockFramer, SseLineFramer, Utf8StreamDecoder, bedrock_payload_to_frame};
 use crate::parser::{AnthropicParser, OpenAiParser, OpenAiResponsesParser, ResponseParser};
 use crate::stream_diagnostics::StreamTermination;
 use crate::stream_runner::StreamOutcome;
@@ -39,6 +39,7 @@ pub(crate) async fn process_openai_responses_sse_stream(
     let parser = OpenAiResponsesParser;
     let mut state = parser.new_state();
     let mut framer = SseLineFramer::default();
+    let mut decoder = Utf8StreamDecoder::default();
     let mut stream = response.bytes_stream();
     let mut emitted_content = false;
 
@@ -54,7 +55,7 @@ pub(crate) async fn process_openai_responses_sse_stream(
                 };
             }
         };
-        let text = String::from_utf8_lossy(&chunk);
+        let text = decoder.push(&chunk);
         for frame in framer.push_text(&text, "[DONE]") {
             tracing::debug!(target: "aion_providers", event_type = ?frame.event, "OpenAI Responses SSE event received");
             let events = parser.parse_frame(&frame, &mut state);
@@ -75,6 +76,30 @@ pub(crate) async fn process_openai_responses_sse_stream(
             if state.is_terminal() {
                 return StreamOutcome::Ok;
             }
+        }
+    }
+
+    // Flush any bytes left over at the true end of the stream.
+    let text = decoder.flush();
+    for frame in framer.push_text(&text, "[DONE]") {
+        tracing::debug!(target: "aion_providers", event_type = ?frame.event, "OpenAI Responses SSE event received");
+        let events = parser.parse_frame(&frame, &mut state);
+        for event in events {
+            if matches!(
+                event,
+                LlmEvent::TextDelta(_)
+                    | LlmEvent::ThinkingDelta(_)
+                    | LlmEvent::ProviderItem { .. }
+                    | LlmEvent::ToolUse { .. }
+            ) {
+                emitted_content = true;
+            }
+            if tx.send(event).await.is_err() {
+                return StreamOutcome::Ok;
+            }
+        }
+        if state.is_terminal() {
+            return StreamOutcome::Ok;
         }
     }
 
@@ -100,6 +125,7 @@ pub(crate) async fn process_openai_sse_stream(
         .observe_response(response.status().as_u16(), response.headers());
     let started_at = Instant::now();
     let mut framer = SseLineFramer::default();
+    let mut decoder = Utf8StreamDecoder::default();
     let mut stream = response.bytes_stream();
     let mut emitted_content = false;
 
@@ -118,7 +144,7 @@ pub(crate) async fn process_openai_sse_stream(
             }
         };
         state.diagnostics_mut().observe_network_chunk(chunk.len());
-        let text = String::from_utf8_lossy(&chunk);
+        let text = decoder.push(&chunk);
         for frame in framer.push_text(&text, "[DONE]") {
             state.diagnostics_mut().observe_frame(&frame);
             let is_done = frame.kind == FrameKind::Done;
@@ -143,6 +169,25 @@ pub(crate) async fn process_openai_sse_stream(
         }
     }
 
+    // Flush any bytes left over at the true end of the stream.
+    let text = decoder.flush();
+    for frame in framer.push_text(&text, "[DONE]") {
+        state.diagnostics_mut().observe_frame(&frame);
+        let is_done = frame.kind == FrameKind::Done;
+        let events = parser.parse_frame(&frame, &mut state);
+        for event in events {
+            state.diagnostics_mut().observe_event(&event);
+            if tx.send(event).await.is_err() {
+                state.emit_diagnostics(StreamTermination::ConsumerDropped, started_at.elapsed());
+                return StreamOutcome::Ok;
+            }
+        }
+        if is_done {
+            state.emit_diagnostics(StreamTermination::Done, started_at.elapsed());
+            return StreamOutcome::Ok;
+        }
+    }
+
     for event in parser.finish(&mut state) {
         state.diagnostics_mut().observe_event(&event);
         if tx.send(event).await.is_err() {
@@ -164,6 +209,7 @@ pub(crate) async fn process_anthropic_sse_stream(
     let parser = AnthropicParser;
     let mut state = parser.new_state();
     let mut framer = SseBlockFramer::default();
+    let mut decoder = Utf8StreamDecoder::default();
     let mut stream = response.bytes_stream();
     let mut emitted_content = false;
 
@@ -179,7 +225,7 @@ pub(crate) async fn process_anthropic_sse_stream(
                 };
             }
         };
-        let text = String::from_utf8_lossy(&chunk);
+        let text = decoder.push(&chunk);
         for frame in framer.push_text(&text) {
             let events = parser.parse_frame(&frame, &mut state);
             for event in events {
@@ -195,6 +241,17 @@ pub(crate) async fn process_anthropic_sse_stream(
                 if tx.send(event).await.is_err() {
                     return StreamOutcome::Ok;
                 }
+            }
+        }
+    }
+
+    // Flush any bytes left over at the true end of the stream.
+    let text = decoder.flush();
+    for frame in framer.push_text(&text) {
+        let events = parser.parse_frame(&frame, &mut state);
+        for event in events {
+            if tx.send(event).await.is_err() {
+                return StreamOutcome::Ok;
             }
         }
     }


### PR DESCRIPTION
## Problem

Streaming CJK (Chinese/Japanese/Korean) model output intermittently dropped characters, replacing them with `�` (U+FFFD). Reported via Sentry **ELECTRON-3NH** / **ELECTRON-3P5** (OpenCode Zen `deepseek-v4-flash-free`), but the defect affects **all** streaming providers on the OpenAI-compatible / Anthropic paths.

## Root cause

`crates/aion-providers/src/stream_process.rs` decoded each raw `bytes_stream()` chunk independently with `String::from_utf8_lossy(&chunk)` before handing the text to the `&str`-accumulating framers. When a multibyte UTF-8 character (a 3-byte CJK char) is split across two network chunks, each half is lossy-decoded separately and each incomplete fragment becomes `U+FFFD` — so the character is lost. The signature (isolated `�` exactly at CJK character boundaries, surrounded by byte-perfect text) is a textbook split-multibyte-across-chunk-boundary bug.

## Fix

- Add a byte-level `Utf8StreamDecoder` carry buffer in `framing.rs` that only emits complete UTF-8 sequences per chunk and retains the incomplete trailing bytes until the next chunk.
- Use it in the OpenAI, OpenAI-Responses and Anthropic SSE paths; flush any remainder at the true end of the stream.
- The Bedrock path already buffers raw bytes and is untouched.

## Tests

- `cargo test -p aion-providers` green (222 + 4 + 9 + 11 passed).
- New `framing_test` cases: a CJK string (`权限管理服务器`) split mid-character across chunks reassembles with **zero U+FFFD**; a legitimately-truncated final byte is handled by `flush()` without panic; ASCII pass-through unchanged.