### PR TITLE
feat(agent): persist and report context usage

### DIFF
--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -7,7 +7,7 @@ use aion_config::config::{Config, McpServerConfig};
 use aion_config::shell::{ResolvedShell, resolve_shell_config};
 use aion_mcp::manager::McpManager;
 use aion_mcp::tool_proxy::register_mcp_tools;
-use aion_memory::paths::auto_memory_dir;
+use aion_memory::paths::{ENTRYPOINT_NAME, auto_memory_dir};
 use aion_providers::{LlmProvider, create_provider};
 use aion_skills::loader::load_all_skills;
 use aion_skills::permissions::SkillPermissionChecker;
@@ -26,6 +26,7 @@ use anyhow::Result;
 use tracing::info;
 
 use crate::context::{SystemPromptCache, build_system_prompt_with_shell_and_tool_policy};
+use crate::context_usage::PromptUsage;
 use crate::engine::AgentEngine;
 use crate::output::OutputSink;
 use crate::plan::tools::{EnterPlanModeTool, ExitPlanModeTool};
@@ -157,7 +158,7 @@ impl AgentBootstrap {
         let mcp = self.connect_mcp(&mut registry, &builtin_names).await;
 
         let skills = self.load_skills(&environment.workspace, mcp.manager.as_deref()).await;
-        self.configure_system_prompt(&environment, &skills);
+        let prompt_usage = self.configure_system_prompt(&environment, &skills);
 
         self.register_agent_tools(&mut registry, &provider, &environment.workspace, skills);
         let plan_active_flag = self.register_plan_tools(&mut registry);
@@ -165,7 +166,13 @@ impl AgentBootstrap {
 
         let has_mcp = mcp.has_mcp();
         let mcp_managers = mcp.managers;
-        let engine = self.into_engine(provider.clone(), registry, plan_active_flag, environment.workspace);
+        let engine = self.into_engine(
+            provider.clone(),
+            registry,
+            plan_active_flag,
+            environment.workspace,
+            prompt_usage,
+        );
 
         Ok(BootstrapResult {
             engine,
@@ -265,7 +272,7 @@ impl AgentBootstrap {
         load_all_skills(workspace, &self.extra_skill_dirs, false, mcp_manager).await
     }
 
-    fn configure_system_prompt(&mut self, environment: &BootstrapEnvironment, skills: &[SkillMetadata]) {
+    fn configure_system_prompt(&mut self, environment: &BootstrapEnvironment, skills: &[SkillMetadata]) -> PromptUsage {
         let mut prompt_cache = SystemPromptCache::new();
         let workspace = self.workspace.to_string_lossy();
         let system_prompt = build_system_prompt_with_shell_and_tool_policy(
@@ -281,7 +288,34 @@ impl AgentBootstrap {
             self.config.compact.toon,
             &self.tool_policy,
         );
+        let memory_prompt = prompt_cache.sections.get("memory").map(String::as_str);
+        let skills_prompt = prompt_cache.sections.get("skills").map(String::as_str);
+        let memory_files = if memory_prompt.is_some() {
+            environment
+                .memory_dir
+                .as_ref()
+                .map(|directory| directory.join(ENTRYPOINT_NAME))
+                .filter(|path| path.is_file())
+                .map(|path| path.display().to_string())
+                .into_iter()
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let visible_skills = skills
+            .iter()
+            .filter(|skill| self.tool_policy.allows("Skill") && !skill.disable_model_invocation)
+            .map(|skill| skill.name.clone())
+            .collect();
+        let prompt_usage = PromptUsage::from_sections(
+            &system_prompt,
+            memory_prompt,
+            skills_prompt,
+            memory_files,
+            visible_skills,
+        );
         self.config.system_prompt = Some(system_prompt);
+        prompt_usage
     }
 
     fn register_agent_tools(
@@ -334,6 +368,7 @@ impl AgentBootstrap {
         registry: ToolRegistry,
         plan_active_flag: Arc<AtomicBool>,
         workspace: PathBuf,
+        prompt_usage: PromptUsage,
     ) -> AgentEngine {
         let runtime_env = self.runtime_env.clone();
         let mut engine = if let Some(session) = self.resume_session {
@@ -351,6 +386,7 @@ impl AgentBootstrap {
         };
         engine.set_plan_active_flag(plan_active_flag);
         engine.set_tool_policy(self.tool_policy);
+        engine.set_prompt_usage(prompt_usage);
         engine
     }
 }

--- a/crates/aion-agent/src/commands/clear.rs
+++ b/crates/aion-agent/src/commands/clear.rs
@@ -19,7 +19,7 @@ impl SlashCommand for ClearCommand {
         ctx.messages.clear();
         *ctx.compact_state = CompactState::new();
         ctx.output.emit_info("Conversation cleared");
-        Ok(CommandResult::Continue)
+        Ok(CommandResult::ContextChanged)
     }
 }
 

--- a/crates/aion-agent/src/commands/clear_test.rs
+++ b/crates/aion-agent/src/commands/clear_test.rs
@@ -10,6 +10,7 @@ mod tests {
 
     use super::*;
     use crate::commands::{CommandContext, CommandRegistry};
+    use crate::context_usage::{ContextState, PromptUsage};
     use crate::output::null_sink::NullSink;
 
     struct NullProvider;
@@ -33,6 +34,9 @@ mod tests {
         let mut state = CompactState::new();
         state.last_input_tokens = 5000;
         state.consecutive_failures = 2;
+        let mut context_state = ContextState::default();
+        let prompt_usage = PromptUsage::default();
+        let context_tools = Vec::new();
         let config = aion_config::compact::CompactConfig::default();
 
         let mut ctx = CommandContext {
@@ -43,12 +47,16 @@ mod tests {
             model: "test",
             output: &output,
             registry: &registry,
+            context_state: &mut context_state,
+            prompt_usage: &prompt_usage,
+            context_tools: &context_tools,
+            dynamic_system_tokens: 0,
         };
 
         let cmd = ClearCommand;
         let result = cmd.execute(&mut ctx, "").await.unwrap();
 
-        assert_eq!(result, CommandResult::Continue);
+        assert_eq!(result, CommandResult::ContextChanged);
         assert!(ctx.messages.is_empty());
         assert_eq!(ctx.compact_state.last_input_tokens, 0);
         assert_eq!(ctx.compact_state.consecutive_failures, 0);
@@ -61,6 +69,9 @@ mod tests {
         let output = NullSink;
         let mut messages: Vec<Message> = vec![];
         let mut state = CompactState::new();
+        let mut context_state = ContextState::default();
+        let prompt_usage = PromptUsage::default();
+        let context_tools = Vec::new();
         let config = aion_config::compact::CompactConfig::default();
 
         let mut ctx = CommandContext {
@@ -71,11 +82,15 @@ mod tests {
             model: "test",
             output: &output,
             registry: &registry,
+            context_state: &mut context_state,
+            prompt_usage: &prompt_usage,
+            context_tools: &context_tools,
+            dynamic_system_tokens: 0,
         };
 
         let cmd = ClearCommand;
         let result = cmd.execute(&mut ctx, "").await.unwrap();
-        assert_eq!(result, CommandResult::Continue);
+        assert_eq!(result, CommandResult::ContextChanged);
         assert!(ctx.messages.is_empty());
     }
 }

--- a/crates/aion-agent/src/commands/compact.rs
+++ b/crates/aion-agent/src/commands/compact.rs
@@ -2,7 +2,8 @@ use async_trait::async_trait;
 
 use super::{CommandContext, CommandResult, SlashCommand};
 use crate::compact::auto;
-use aion_types::compact::CompactTrigger;
+use aion_types::compact::{CompactMetadata, CompactTrigger};
+use aion_types::message::ContentBlock;
 
 pub struct CompactCommand;
 
@@ -42,10 +43,10 @@ impl SlashCommand for CompactCommand {
 
                 if let Some(boundary) = ctx.messages.first_mut() {
                     for block in &mut boundary.content {
-                        if let aion_types::message::ContentBlock::Text { text } = block
+                        if let ContentBlock::Text { text } = block
                             && text.starts_with(auto::BOUNDARY_PREFIX)
                         {
-                            let metadata = aion_types::compact::CompactMetadata {
+                            let metadata = CompactMetadata {
                                 trigger: CompactTrigger::Manual,
                                 pre_compact_tokens: pre_tokens,
                                 messages_summarized: msgs_summarized,
@@ -64,6 +65,8 @@ impl SlashCommand for CompactCommand {
                     pre_tokens / 1000,
                     msgs_summarized
                 ));
+                ctx.context_state.record_compact();
+                return Ok(CommandResult::ContextChanged);
             }
             Err(e) => {
                 ctx.output.emit_error(&format!("Compact failed: {}", e));

--- a/crates/aion-agent/src/commands/compact_test.rs
+++ b/crates/aion-agent/src/commands/compact_test.rs
@@ -6,11 +6,13 @@ mod tests {
 
     use aion_providers::{LlmProvider, ProviderError};
     use aion_types::llm::{LlmEvent, LlmRequest};
-    use aion_types::message::{ContentBlock, Message, Role};
+    use aion_types::message::{ContentBlock, Message, Role, StopReason, TokenUsage};
+    use tokio::sync::mpsc;
 
     use super::*;
     use crate::commands::{CommandContext, CommandRegistry};
     use crate::compact::state::CompactState;
+    use crate::context_usage::{ContextState, PromptUsage};
     use crate::output::null_sink::NullSink;
 
     struct NullProvider;
@@ -22,6 +24,25 @@ mod tests {
         }
     }
 
+    struct SuccessfulProvider;
+
+    #[async_trait::async_trait]
+    impl LlmProvider for SuccessfulProvider {
+        async fn stream(&self, _: &LlmRequest) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+            let (tx, rx) = mpsc::channel(4);
+            tx.send(LlmEvent::TextDelta("<summary>manual summary</summary>".into()))
+                .await
+                .unwrap();
+            tx.send(LlmEvent::Done {
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+            })
+            .await
+            .unwrap();
+            Ok(rx)
+        }
+    }
+
     #[tokio::test]
     async fn compact_already_compact_guard() {
         let provider: Arc<dyn LlmProvider> = Arc::new(NullProvider);
@@ -29,6 +50,9 @@ mod tests {
         let output = NullSink;
         let mut messages = vec![Message::new(Role::User, vec![ContentBlock::Text { text: "hi".into() }])];
         let mut state = CompactState::new();
+        let mut context_state = ContextState::default();
+        let prompt_usage = PromptUsage::default();
+        let context_tools = Vec::new();
         let config = aion_config::compact::CompactConfig::default();
 
         let mut ctx = CommandContext {
@@ -39,6 +63,10 @@ mod tests {
             model: "test-model",
             output: &output,
             registry: &registry,
+            context_state: &mut context_state,
+            prompt_usage: &prompt_usage,
+            context_tools: &context_tools,
+            dynamic_system_tokens: 0,
         };
 
         let cmd = CompactCommand;
@@ -65,6 +93,9 @@ mod tests {
             .collect();
         let mut state = CompactState::new();
         state.consecutive_failures = 5;
+        let mut context_state = ContextState::default();
+        let prompt_usage = PromptUsage::default();
+        let context_tools = Vec::new();
         let config = aion_config::compact::CompactConfig::default();
 
         let mut ctx = CommandContext {
@@ -75,11 +106,60 @@ mod tests {
             model: "test-model",
             output: &output,
             registry: &registry,
+            context_state: &mut context_state,
+            prompt_usage: &prompt_usage,
+            context_tools: &context_tools,
+            dynamic_system_tokens: 0,
         };
 
         let cmd = CompactCommand;
         let _ = cmd.execute(&mut ctx, "").await;
         // Circuit breaker was reset to 0 before the call, then failure increments it
         assert!(ctx.compact_state.consecutive_failures <= 1);
+    }
+
+    #[tokio::test]
+    async fn successful_manual_compact_increments_count_and_requests_persistence() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(SuccessfulProvider);
+        let registry = CommandRegistry::new();
+        let output = NullSink;
+        let mut messages: Vec<Message> = (0..6)
+            .map(|index| {
+                Message::new(
+                    if index % 2 == 0 { Role::User } else { Role::Assistant },
+                    vec![ContentBlock::Text {
+                        text: format!("message-{index}"),
+                    }],
+                )
+            })
+            .collect();
+        let mut state = CompactState::new();
+        state.last_input_tokens = 50_000;
+        let mut context_state = ContextState {
+            context_usage: 50_000,
+            ..ContextState::default()
+        };
+        let prompt_usage = PromptUsage::default();
+        let context_tools = Vec::new();
+        let config = aion_config::compact::CompactConfig::default();
+        let mut ctx = CommandContext {
+            messages: &mut messages,
+            compact_state: &mut state,
+            compact_config: &config,
+            provider,
+            model: "test-model",
+            output: &output,
+            registry: &registry,
+            context_state: &mut context_state,
+            prompt_usage: &prompt_usage,
+            context_tools: &context_tools,
+            dynamic_system_tokens: 0,
+        };
+
+        let result = CompactCommand.execute(&mut ctx, "").await.unwrap();
+
+        assert_eq!(result, CommandResult::ContextChanged);
+        assert_eq!(ctx.context_state.compact_count, 1);
+        assert_eq!(ctx.messages.len(), 2);
     }
 }

--- a/crates/aion-agent/src/commands/context.rs
+++ b/crates/aion-agent/src/commands/context.rs
@@ -1,0 +1,206 @@
+use std::cmp::Reverse;
+use std::fmt::Write;
+
+use async_trait::async_trait;
+
+use super::{CommandContext, CommandResult, SlashCommand};
+use crate::context_usage::{ContextBreakdown, ContextSnapshot, ContextUsageSource, MessageUsage, NamedUsage};
+
+const BAR_WIDTH: usize = 20;
+const DETAIL_MESSAGE_LIMIT: usize = 10;
+
+pub(super) struct ContextCommand;
+
+#[async_trait]
+impl SlashCommand for ContextCommand {
+    fn name(&self) -> &str {
+        "context"
+    }
+
+    fn description(&self) -> &str {
+        "Show current context usage"
+    }
+
+    async fn execute(&self, ctx: &mut CommandContext<'_>, args: &str) -> anyhow::Result<CommandResult> {
+        let expanded = match args.trim() {
+            "" => false,
+            "all" => true,
+            other => {
+                ctx.output.emit_error(&format!(
+                    "Unknown /context argument: {other}. Use /context or /context all."
+                ));
+                return Ok(CommandResult::Continue);
+            }
+        };
+        let snapshot = ContextSnapshot::build(
+            ctx.model,
+            ctx.compact_config.context_window,
+            ctx.context_state,
+            ctx.prompt_usage,
+            ctx.dynamic_system_tokens,
+            ctx.context_tools,
+            ctx.messages,
+        );
+        ctx.output.emit_info(&format_snapshot(&snapshot, expanded));
+        Ok(CommandResult::Continue)
+    }
+}
+
+fn format_snapshot(snapshot: &ContextSnapshot, expanded: bool) -> String {
+    let usage_pct = percent(snapshot.context_usage, snapshot.context_window);
+    let free_tokens = snapshot.context_window.saturating_sub(snapshot.context_usage);
+    let free_pct = percent(free_tokens, snapshot.context_window);
+    let source = match snapshot.source {
+        ContextUsageSource::ProviderExact => "provider exact",
+        ContextUsageSource::LocalProjected => "local projected",
+    };
+
+    let mut output = String::new();
+    writeln!(&mut output, "Context Usage").expect("writing to String cannot fail");
+    writeln!(&mut output, "  Model: {}", snapshot.model).expect("writing to String cannot fail");
+    writeln!(
+        &mut output,
+        "  [{}]",
+        usage_bar(snapshot.context_usage, snapshot.context_window)
+    )
+    .expect("writing to String cannot fail");
+    writeln!(
+        &mut output,
+        "  {}/{} tokens ({usage_pct:.1}%)",
+        format_tokens(snapshot.context_usage),
+        format_tokens(snapshot.context_window)
+    )
+    .expect("writing to String cannot fail");
+    writeln!(
+        &mut output,
+        "  Free space: {} tokens ({free_pct:.1}%)",
+        format_tokens(free_tokens)
+    )
+    .expect("writing to String cannot fail");
+    writeln!(&mut output, "  Source: {source}").expect("writing to String cannot fail");
+    writeln!(
+        &mut output,
+        "  Compactions: {} compact, {} microcompact",
+        snapshot.compact_count, snapshot.microcompact_count
+    )
+    .expect("writing to String cannot fail");
+    writeln!(&mut output, "  Updated: {}", snapshot.updated_at.to_rfc3339()).expect("writing to String cannot fail");
+    writeln!(&mut output).expect("writing to String cannot fail");
+    writeln!(&mut output, "Estimated usage by category").expect("writing to String cannot fail");
+    write_breakdown(&mut output, &snapshot.breakdown, snapshot.context_window);
+
+    if expanded {
+        write_expanded_details(&mut output, snapshot);
+    } else {
+        writeln!(&mut output).expect("writing to String cannot fail");
+        write!(&mut output, "  /context all to expand").expect("writing to String cannot fail");
+    }
+
+    output
+}
+
+fn write_breakdown(output: &mut String, breakdown: &ContextBreakdown, context_window: u64) {
+    let entries = [
+        ("System prompt", breakdown.system_prompt),
+        ("Memory", breakdown.memory),
+        ("Skills", breakdown.skills),
+        ("Tools", breakdown.tools),
+        ("Messages", breakdown.messages),
+        ("Unattributed", breakdown.unattributed),
+    ];
+    for (label, tokens) in entries {
+        writeln!(
+            output,
+            "  {label}: {} tokens ({:.1}%)",
+            format_tokens(tokens),
+            percent(tokens, context_window)
+        )
+        .expect("writing to String cannot fail");
+    }
+}
+
+fn write_expanded_details(output: &mut String, snapshot: &ContextSnapshot) {
+    write_named_usage(output, "Memory files", &snapshot.memory_files);
+
+    writeln!(output).expect("writing to String cannot fail");
+    writeln!(output, "Skills · {}", snapshot.skills.len()).expect("writing to String cannot fail");
+    if snapshot.skills.is_empty() {
+        writeln!(output, "  (none)").expect("writing to String cannot fail");
+    } else {
+        for skill in &snapshot.skills {
+            writeln!(output, "  - {skill}").expect("writing to String cannot fail");
+        }
+    }
+
+    write_named_usage(output, "Tools", &snapshot.tools);
+
+    let mut messages = snapshot.messages.clone();
+    messages.sort_by_key(|message| Reverse(message.tokens));
+    messages.truncate(DETAIL_MESSAGE_LIMIT);
+    writeln!(output).expect("writing to String cannot fail");
+    writeln!(output, "Largest messages · showing {}", messages.len()).expect("writing to String cannot fail");
+    if messages.is_empty() {
+        writeln!(output, "  (none)").expect("writing to String cannot fail");
+    } else {
+        for message in messages {
+            write_message_usage(output, &message);
+        }
+    }
+}
+
+fn write_named_usage(output: &mut String, heading: &str, items: &[NamedUsage]) {
+    writeln!(output).expect("writing to String cannot fail");
+    writeln!(output, "{heading} · {}", items.len()).expect("writing to String cannot fail");
+    if items.is_empty() {
+        writeln!(output, "  (none)").expect("writing to String cannot fail");
+    } else {
+        for item in items {
+            writeln!(output, "  - {} · {} tokens", item.name, format_tokens(item.tokens))
+                .expect("writing to String cannot fail");
+        }
+    }
+}
+
+fn write_message_usage(output: &mut String, message: &MessageUsage) {
+    writeln!(
+        output,
+        "  - #{} {:?} · {} tokens",
+        message.index + 1,
+        message.role,
+        format_tokens(message.tokens)
+    )
+    .expect("writing to String cannot fail");
+}
+
+fn usage_bar(usage: u64, context_window: u64) -> String {
+    let filled = if context_window == 0 {
+        0
+    } else {
+        ((usage.min(context_window) as u128 * BAR_WIDTH as u128) / context_window as u128) as usize
+    };
+    format!("{}{}", "█".repeat(filled), "░".repeat(BAR_WIDTH - filled))
+}
+
+fn percent(tokens: u64, context_window: u64) -> f64 {
+    if context_window == 0 {
+        0.0
+    } else {
+        tokens as f64 * 100.0 / context_window as f64
+    }
+}
+
+fn format_tokens(tokens: u64) -> String {
+    if tokens < 1_000 {
+        return tokens.to_string();
+    }
+    let thousands = tokens as f64 / 1_000.0;
+    if tokens.is_multiple_of(1_000) {
+        format!("{thousands:.0}k")
+    } else {
+        format!("{thousands:.1}k")
+    }
+}
+
+#[cfg(test)]
+#[path = "context_test.rs"]
+mod context_test;

--- a/crates/aion-agent/src/commands/context_test.rs
+++ b/crates/aion-agent/src/commands/context_test.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+    use crate::context_usage::{ContextBreakdown, ContextSnapshot, ContextUsageSource};
+
+    fn snapshot() -> ContextSnapshot {
+        ContextSnapshot {
+            model: "claude-opus-4-8".into(),
+            context_usage: 89_600,
+            context_window: 200_000,
+            source: ContextUsageSource::ProviderExact,
+            compact_count: 2,
+            microcompact_count: 5,
+            updated_at: Utc::now(),
+            breakdown: ContextBreakdown {
+                system_prompt: 1_600,
+                memory: 16_100,
+                skills: 2_000,
+                tools: 5_000,
+                messages: 64_900,
+                unattributed: 0,
+            },
+            memory_files: Vec::new(),
+            skills: vec!["review".into()],
+            tools: Vec::new(),
+            messages: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn compact_view_contains_authoritative_usage_and_counts() {
+        let output = format_snapshot(&snapshot(), false);
+
+        assert!(output.contains("89.6k/200k tokens (44.8%)"));
+        assert!(output.contains("Source: provider exact"));
+        assert!(output.contains("2 compact, 5 microcompact"));
+        assert!(output.contains("/context all to expand"));
+    }
+
+    #[test]
+    fn expanded_view_lists_categories_and_details() {
+        let output = format_snapshot(&snapshot(), true);
+
+        assert!(output.contains("Estimated usage by category"));
+        assert!(output.contains("Skills · 1"));
+        assert!(output.contains("- review"));
+        assert!(!output.contains("/context all to expand"));
+    }
+}

--- a/crates/aion-agent/src/commands/help_test.rs
+++ b/crates/aion-agent/src/commands/help_test.rs
@@ -11,6 +11,7 @@ mod tests {
     use super::*;
     use crate::commands::{CommandContext, default_registry};
     use crate::compact::state::CompactState;
+    use crate::context_usage::{ContextState, PromptUsage};
     use crate::output::OutputSink;
 
     struct CaptureSink {
@@ -58,6 +59,9 @@ mod tests {
         let output = CaptureSink::new();
         let mut messages: Vec<Message> = Vec::new();
         let mut state = CompactState::new();
+        let mut context_state = ContextState::default();
+        let prompt_usage = PromptUsage::default();
+        let context_tools = Vec::new();
         let config = aion_config::compact::CompactConfig::default();
 
         let mut ctx = CommandContext {
@@ -68,6 +72,10 @@ mod tests {
             model: "test",
             output: &output,
             registry: &registry,
+            context_state: &mut context_state,
+            prompt_usage: &prompt_usage,
+            context_tools: &context_tools,
+            dynamic_system_tokens: 0,
         };
 
         let cmd = HelpCommand;
@@ -79,6 +87,7 @@ mod tests {
         let help_text = &captured[0];
         assert!(help_text.contains("/clear"));
         assert!(help_text.contains("/compact"));
+        assert!(help_text.contains("/context"));
         assert!(help_text.contains("/help"));
         assert!(help_text.contains("/quit"));
     }
@@ -90,6 +99,9 @@ mod tests {
         let output = CaptureSink::new();
         let mut messages: Vec<Message> = Vec::new();
         let mut state = CompactState::new();
+        let mut context_state = ContextState::default();
+        let prompt_usage = PromptUsage::default();
+        let context_tools = Vec::new();
         let config = aion_config::compact::CompactConfig::default();
 
         let mut ctx = CommandContext {
@@ -100,6 +112,10 @@ mod tests {
             model: "test",
             output: &output,
             registry: &registry,
+            context_state: &mut context_state,
+            prompt_usage: &prompt_usage,
+            context_tools: &context_tools,
+            dynamic_system_tokens: 0,
         };
 
         let cmd = HelpCommand;
@@ -108,11 +124,13 @@ mod tests {
         let help_text = &output.captured()[0];
         let clear_pos = help_text.find("/clear").unwrap();
         let compact_pos = help_text.find("/compact").unwrap();
+        let context_pos = help_text.find("/context").unwrap();
         let help_pos = help_text.find("/help").unwrap();
         let quit_pos = help_text.find("/quit").unwrap();
 
         assert!(clear_pos < compact_pos);
-        assert!(compact_pos < help_pos);
+        assert!(compact_pos < context_pos);
+        assert!(context_pos < help_pos);
         assert!(help_pos < quit_pos);
     }
 }

--- a/crates/aion-agent/src/commands/mod.rs
+++ b/crates/aion-agent/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod clear;
 pub mod compact;
+mod context;
 pub mod help;
 pub mod quit;
 mod registry;

--- a/crates/aion-agent/src/commands/registry.rs
+++ b/crates/aion-agent/src/commands/registry.rs
@@ -2,18 +2,22 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use super::{clear, compact, help, quit};
+use super::{clear, compact, context, help, quit};
 use crate::compact::state::CompactState;
+use crate::context_usage::{ContextState, PromptUsage};
 use crate::output::OutputSink;
 use aion_config::compact::CompactConfig;
 use aion_providers::LlmProvider;
 use aion_types::message::Message;
+use aion_types::tool::ToolDef;
 
 /// Result of executing a slash command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandResult {
     /// Command handled, continue the REPL loop.
     Continue,
+    /// Command mutated context and the updated session must be persisted.
+    ContextChanged,
     /// Exit the REPL.
     Exit,
 }
@@ -27,6 +31,10 @@ pub struct CommandContext<'a> {
     pub model: &'a str,
     pub output: &'a dyn OutputSink,
     pub registry: &'a CommandRegistry,
+    pub(crate) context_state: &'a mut ContextState,
+    pub(crate) prompt_usage: &'a PromptUsage,
+    pub(crate) context_tools: &'a [ToolDef],
+    pub(crate) dynamic_system_tokens: u64,
 }
 
 /// A slash command that can be executed in the REPL.
@@ -79,6 +87,7 @@ impl Default for CommandRegistry {
 pub fn default_registry() -> CommandRegistry {
     let mut registry = CommandRegistry::new();
     registry.register(Box::new(compact::CompactCommand));
+    registry.register(Box::new(context::ContextCommand));
     registry.register(Box::new(clear::ClearCommand));
     registry.register(Box::new(help::HelpCommand));
     registry.register(Box::new(quit::QuitCommand));

--- a/crates/aion-agent/src/commands/registry_test.rs
+++ b/crates/aion-agent/src/commands/registry_test.rs
@@ -8,6 +8,7 @@ mod tests {
     fn registry_find_by_name() {
         let registry = default_registry();
         assert!(registry.find("compact").is_some());
+        assert!(registry.find("context").is_some());
         assert!(registry.find("clear").is_some());
         assert!(registry.find("help").is_some());
         assert!(registry.find("quit").is_some());
@@ -30,6 +31,6 @@ mod tests {
     #[test]
     fn registry_all_returns_all_commands() {
         let registry = default_registry();
-        assert_eq!(registry.all().len(), 4);
+        assert_eq!(registry.all().len(), 5);
     }
 }

--- a/crates/aion-agent/src/context_usage.rs
+++ b/crates/aion-agent/src/context_usage.rs
@@ -68,8 +68,9 @@ impl ContextState {
         self.touch();
     }
 
-    pub(crate) fn record_microcompact(&mut self, estimated_tokens_freed: u64) {
-        self.context_usage = self.context_usage.saturating_sub(estimated_tokens_freed);
+    pub(crate) fn record_microcompact(&mut self) {
+        // Local character-based savings estimates are not safe enough to lower the
+        // provider-derived watermark used by autocompact and the emergency guard.
         self.source = ContextUsageSource::LocalProjected;
         self.microcompact_count = self.microcompact_count.saturating_add(1);
         self.touch();

--- a/crates/aion-agent/src/context_usage.rs
+++ b/crates/aion-agent/src/context_usage.rs
@@ -1,0 +1,355 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use aion_types::message::{ContentBlock, Message, Role};
+use aion_types::tool::ToolDef;
+
+use crate::compact::estimate::{estimate_tokens_from_tool_image, estimate_tokens_from_tool_result};
+
+const CONTEXT_STATE_SCHEMA_VERSION: u32 = 1;
+const CHARS_PER_TOKEN: usize = 4;
+
+/// Origin of the persisted context-usage value.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextUsageSource {
+    /// Exact input plus output usage reported by the latest provider turn.
+    ProviderExact,
+    /// Provider usage adjusted or reconstructed with local estimates.
+    #[default]
+    LocalProjected,
+}
+
+/// Session-scoped context accounting persisted alongside conversation history.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ContextState {
+    /// Version of this persisted object, independent from the enclosing session format.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    /// Best-known token occupancy for the next provider request.
+    #[serde(default)]
+    pub context_usage: u64,
+    /// Whether `context_usage` is provider-reported or locally projected.
+    #[serde(default)]
+    pub source: ContextUsageSource,
+    /// Number of successful full compactions in this session.
+    #[serde(default)]
+    pub compact_count: u64,
+    /// Number of microcompact passes that actually cleared content.
+    #[serde(default)]
+    pub microcompact_count: u64,
+    /// Last time any context accounting field changed.
+    #[serde(default = "default_updated_at")]
+    pub updated_at: DateTime<Utc>,
+}
+
+impl ContextState {
+    pub(crate) fn replace_with_provider_usage(&mut self, context_usage: u64) {
+        self.context_usage = context_usage;
+        self.source = ContextUsageSource::ProviderExact;
+        self.touch();
+    }
+
+    pub(crate) fn replace_with_local_estimate(&mut self, context_usage: u64) {
+        self.context_usage = context_usage;
+        self.source = ContextUsageSource::LocalProjected;
+        self.touch();
+    }
+
+    pub(crate) fn add_local_estimate(&mut self, tokens: u64) {
+        self.context_usage = self.context_usage.saturating_add(tokens);
+        self.source = ContextUsageSource::LocalProjected;
+        self.touch();
+    }
+
+    pub(crate) fn record_compact(&mut self) {
+        self.compact_count = self.compact_count.saturating_add(1);
+        self.touch();
+    }
+
+    pub(crate) fn record_microcompact(&mut self, estimated_tokens_freed: u64) {
+        self.context_usage = self.context_usage.saturating_sub(estimated_tokens_freed);
+        self.source = ContextUsageSource::LocalProjected;
+        self.microcompact_count = self.microcompact_count.saturating_add(1);
+        self.touch();
+    }
+
+    fn touch(&mut self) {
+        self.updated_at = Utc::now();
+    }
+}
+
+impl Default for ContextState {
+    fn default() -> Self {
+        Self {
+            schema_version: CONTEXT_STATE_SCHEMA_VERSION,
+            context_usage: 0,
+            source: ContextUsageSource::LocalProjected,
+            compact_count: 0,
+            microcompact_count: 0,
+            updated_at: Utc::now(),
+        }
+    }
+}
+
+/// Runtime context status exposed to SDK hosts without persisting model limits.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ContextStatus {
+    /// Version of the context-accounting contract.
+    pub schema_version: u32,
+    /// Active provider model identifier.
+    pub model: String,
+    /// Effective runtime context window resolved by aionrs configuration.
+    pub context_window: u64,
+    /// Best-known token occupancy for the next provider request.
+    pub context_usage: u64,
+    /// Whether `context_usage` is provider-reported or locally projected.
+    pub source: ContextUsageSource,
+    /// Number of successful full compactions in this session.
+    pub compact_count: u64,
+    /// Number of microcompact passes that actually cleared content.
+    pub microcompact_count: u64,
+    /// Last time any context accounting field changed.
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PromptUsage {
+    pub(crate) system_prompt_tokens: u64,
+    pub(crate) memory_tokens: u64,
+    pub(crate) skills_tokens: u64,
+    pub(crate) memory_files: Vec<String>,
+    pub(crate) skills: Vec<String>,
+}
+
+impl PromptUsage {
+    pub(crate) fn from_system_prompt(system_prompt: &str) -> Self {
+        Self {
+            system_prompt_tokens: estimate_text_tokens(system_prompt),
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn from_sections(
+        system_prompt: &str,
+        memory_prompt: Option<&str>,
+        skills_prompt: Option<&str>,
+        memory_files: Vec<String>,
+        skills: Vec<String>,
+    ) -> Self {
+        let total_tokens = estimate_text_tokens(system_prompt);
+        let memory_tokens = memory_prompt.map(estimate_text_tokens).unwrap_or(0);
+        let skills_tokens = skills_prompt.map(estimate_text_tokens).unwrap_or(0);
+
+        Self {
+            system_prompt_tokens: total_tokens.saturating_sub(memory_tokens.saturating_add(skills_tokens)),
+            memory_tokens,
+            skills_tokens,
+            memory_files,
+            skills,
+        }
+    }
+
+    pub(crate) fn total_tokens(&self) -> u64 {
+        self.system_prompt_tokens
+            .saturating_add(self.memory_tokens)
+            .saturating_add(self.skills_tokens)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NamedUsage {
+    pub(crate) name: String,
+    pub(crate) tokens: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MessageUsage {
+    pub(crate) index: usize,
+    pub(crate) role: Role,
+    pub(crate) tokens: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ContextBreakdown {
+    pub(crate) system_prompt: u64,
+    pub(crate) memory: u64,
+    pub(crate) skills: u64,
+    pub(crate) tools: u64,
+    pub(crate) messages: u64,
+    pub(crate) unattributed: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ContextSnapshot {
+    pub(crate) model: String,
+    pub(crate) context_usage: u64,
+    pub(crate) context_window: u64,
+    pub(crate) source: ContextUsageSource,
+    pub(crate) compact_count: u64,
+    pub(crate) microcompact_count: u64,
+    pub(crate) updated_at: DateTime<Utc>,
+    pub(crate) breakdown: ContextBreakdown,
+    pub(crate) memory_files: Vec<NamedUsage>,
+    pub(crate) skills: Vec<String>,
+    pub(crate) tools: Vec<NamedUsage>,
+    pub(crate) messages: Vec<MessageUsage>,
+}
+
+impl ContextSnapshot {
+    pub(crate) fn build(
+        model: &str,
+        context_window: usize,
+        state: &ContextState,
+        prompt: &PromptUsage,
+        dynamic_system_tokens: u64,
+        tools: &[ToolDef],
+        messages: &[Message],
+    ) -> Self {
+        let tool_usage = tools
+            .iter()
+            .map(|tool| NamedUsage {
+                name: tool.name.clone(),
+                tokens: estimate_tool_tokens(tool),
+            })
+            .collect::<Vec<_>>();
+        let message_usage = messages
+            .iter()
+            .enumerate()
+            .map(|(index, message)| MessageUsage {
+                index,
+                role: message.role,
+                tokens: estimate_message_tokens(message),
+            })
+            .collect::<Vec<_>>();
+
+        let raw = [
+            prompt.system_prompt_tokens.saturating_add(dynamic_system_tokens),
+            prompt.memory_tokens,
+            prompt.skills_tokens,
+            tool_usage.iter().map(|item| item.tokens).sum(),
+            message_usage.iter().map(|item| item.tokens).sum(),
+        ];
+        let raw_total = raw.iter().copied().fold(0_u64, u64::saturating_add);
+        let context_usage = if state.context_usage == 0 {
+            raw_total
+        } else {
+            state.context_usage
+        };
+        let (normalized, unattributed) = normalize_breakdown(raw, raw_total, context_usage);
+
+        let memory_files = prompt
+            .memory_files
+            .iter()
+            .cloned()
+            .map(|name| NamedUsage {
+                name,
+                tokens: prompt.memory_tokens,
+            })
+            .collect();
+
+        Self {
+            model: model.to_string(),
+            context_usage,
+            context_window: context_window as u64,
+            source: state.source,
+            compact_count: state.compact_count,
+            microcompact_count: state.microcompact_count,
+            updated_at: state.updated_at,
+            breakdown: ContextBreakdown {
+                system_prompt: normalized[0],
+                memory: normalized[1],
+                skills: normalized[2],
+                tools: normalized[3],
+                messages: normalized[4],
+                unattributed,
+            },
+            memory_files,
+            skills: prompt.skills.clone(),
+            tools: tool_usage,
+            messages: message_usage,
+        }
+    }
+}
+
+pub(crate) fn estimate_text_tokens(text: &str) -> u64 {
+    if text.is_empty() {
+        return 0;
+    }
+    text.len().div_ceil(CHARS_PER_TOKEN) as u64
+}
+
+pub(crate) fn estimate_content_tokens(content: &[ContentBlock]) -> u64 {
+    content.iter().fold(0_u64, |total, block| {
+        let tokens = match block {
+            ContentBlock::Text { text } => estimate_text_tokens(text),
+            ContentBlock::Image { .. } => estimate_tokens_from_tool_image(block),
+            ContentBlock::ToolUse { id, name, input, extra } => {
+                let extra_len = extra.as_ref().map_or(0, |value| value.to_string().len());
+                estimate_chars(id.len() + name.len() + input.to_string().len() + extra_len)
+            }
+            ContentBlock::ToolResult { .. } => estimate_tokens_from_tool_result(block),
+            ContentBlock::Thinking { thinking, signature } => {
+                estimate_chars(thinking.len() + signature.as_deref().map_or(0, str::len))
+            }
+            ContentBlock::ProviderItem { provider, item } => estimate_chars(provider.len() + item.to_string().len()),
+        };
+        total.saturating_add(tokens)
+    })
+}
+
+pub(crate) fn estimate_messages_tokens(messages: &[Message]) -> u64 {
+    messages
+        .iter()
+        .map(estimate_message_tokens)
+        .fold(0_u64, u64::saturating_add)
+}
+
+pub(crate) fn estimate_tool_definitions_tokens(tools: &[ToolDef]) -> u64 {
+    tools.iter().map(estimate_tool_tokens).fold(0_u64, u64::saturating_add)
+}
+
+fn estimate_message_tokens(message: &Message) -> u64 {
+    estimate_content_tokens(&message.content)
+}
+
+fn estimate_tool_tokens(tool: &ToolDef) -> u64 {
+    estimate_chars(tool.name.len() + tool.description.len() + tool.input_schema.to_string().len())
+}
+
+fn estimate_chars(chars: usize) -> u64 {
+    if chars == 0 {
+        0
+    } else {
+        chars.div_ceil(CHARS_PER_TOKEN) as u64
+    }
+}
+
+fn normalize_breakdown(raw: [u64; 5], raw_total: u64, context_usage: u64) -> ([u64; 5], u64) {
+    if raw_total == 0 {
+        return ([0; 5], context_usage);
+    }
+    if raw_total <= context_usage {
+        return (raw, context_usage - raw_total);
+    }
+
+    let mut normalized = [0_u64; 5];
+    for (index, value) in raw.into_iter().enumerate() {
+        normalized[index] = ((value as u128 * context_usage as u128) / raw_total as u128) as u64;
+    }
+    let normalized_total = normalized.iter().copied().fold(0_u64, u64::saturating_add);
+    (normalized, context_usage.saturating_sub(normalized_total))
+}
+
+fn default_schema_version() -> u32 {
+    CONTEXT_STATE_SCHEMA_VERSION
+}
+
+fn default_updated_at() -> DateTime<Utc> {
+    Utc::now()
+}
+
+#[cfg(test)]
+#[path = "context_usage_test.rs"]
+mod context_usage_test;

--- a/crates/aion-agent/src/context_usage_test.rs
+++ b/crates/aion-agent/src/context_usage_test.rs
@@ -13,12 +13,12 @@ mod tests {
         let mut state = ContextState::default();
         state.replace_with_provider_usage(89_600);
         state.record_compact();
-        state.record_microcompact(600);
+        state.record_microcompact();
 
         let value = serde_json::to_value(state).unwrap();
 
         assert_eq!(value["schema_version"], 1);
-        assert_eq!(value["context_usage"], 89_000);
+        assert_eq!(value["context_usage"], 89_600);
         assert_eq!(value["source"], "local_projected");
         assert_eq!(value["compact_count"], 1);
         assert_eq!(value["microcompact_count"], 1);

--- a/crates/aion-agent/src/context_usage_test.rs
+++ b/crates/aion-agent/src/context_usage_test.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use aion_types::message::{ContentBlock, Message, Role};
+    use aion_types::tool::ToolDef;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn context_state_serializes_stable_field_names() {
+        let mut state = ContextState::default();
+        state.replace_with_provider_usage(89_600);
+        state.record_compact();
+        state.record_microcompact(600);
+
+        let value = serde_json::to_value(state).unwrap();
+
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["context_usage"], 89_000);
+        assert_eq!(value["source"], "local_projected");
+        assert_eq!(value["compact_count"], 1);
+        assert_eq!(value["microcompact_count"], 1);
+        assert!(value.get("observed_context_window").is_none());
+        assert!(value.get("request_shape_fingerprint").is_none());
+    }
+
+    #[test]
+    fn provider_usage_replaces_local_projection() {
+        let mut state = ContextState::default();
+        state.add_local_estimate(500);
+        state.replace_with_provider_usage(1_200);
+
+        assert_eq!(state.context_usage, 1_200);
+        assert_eq!(state.source, ContextUsageSource::ProviderExact);
+    }
+
+    #[test]
+    fn breakdown_sums_to_authoritative_context_usage() {
+        let state = ContextState {
+            context_usage: 1_000,
+            source: ContextUsageSource::ProviderExact,
+            ..ContextState::default()
+        };
+        let prompt = PromptUsage {
+            system_prompt_tokens: 100,
+            memory_tokens: 50,
+            skills_tokens: 25,
+            memory_files: vec!["MEMORY.md".into()],
+            skills: vec!["review".into()],
+        };
+        let tools = vec![ToolDef {
+            name: "Read".into(),
+            description: "Read a file".into(),
+            input_schema: json!({"type": "object"}),
+            deferred: false,
+        }];
+        let messages = vec![Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "hello".repeat(20),
+            }],
+        )];
+
+        let snapshot = ContextSnapshot::build("test-model", 2_000, &state, &prompt, 0, &tools, &messages);
+        let breakdown = snapshot.breakdown;
+        let sum = breakdown
+            .system_prompt
+            .saturating_add(breakdown.memory)
+            .saturating_add(breakdown.skills)
+            .saturating_add(breakdown.tools)
+            .saturating_add(breakdown.messages)
+            .saturating_add(breakdown.unattributed);
+
+        assert_eq!(sum, 1_000);
+    }
+
+    #[test]
+    fn oversized_local_categories_are_scaled_to_provider_total() {
+        let raw = [500, 500, 500, 500, 500];
+        let (normalized, unattributed) = normalize_breakdown(raw, 2_500, 1_000);
+
+        assert_eq!(normalized, [200; 5]);
+        assert_eq!(unattributed, 0);
+    }
+}

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -1076,8 +1076,7 @@ impl AgentEngine {
                     "Microcompact: cleared {} tool results (~{} tokens freed)",
                     result.cleared_count, result.estimated_tokens_freed
                 ));
-                self.context_state
-                    .record_microcompact(result.estimated_tokens_freed as u64);
+                self.context_state.record_microcompact();
                 self.sync_compact_watermark();
                 self.save_session();
             }

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -11,6 +11,10 @@ use crate::compact::estimate::{estimate_tokens_from_tool_image, estimate_tokens_
 use crate::compact::micro::{microcompact, should_microcompact};
 use crate::compact::state::CompactState;
 use crate::confirm::ToolConfirmer;
+use crate::context_usage::{
+    ContextState, ContextStatus, PromptUsage, estimate_content_tokens, estimate_messages_tokens, estimate_text_tokens,
+    estimate_tool_definitions_tokens,
+};
 use crate::error::AgentError;
 use crate::orchestration::{ExecutionControl, execute_tool_calls, execute_tool_calls_with_approval};
 use crate::output::OutputSink;
@@ -38,6 +42,7 @@ use aion_tools::registry::ToolRegistry;
 use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
 use aion_types::message::{ContentBlock, ImageInputCapability, Message, Role, StopReason, TokenUsage};
 use aion_types::skill_types::{ContextModifier, PlanModeTransition, effort_to_string};
+use aion_types::tool::ToolDef;
 use anyhow::{Error as AnyhowError, Result as AnyhowResult};
 use chrono::Utc;
 use serde_json::to_string;
@@ -115,6 +120,10 @@ pub struct AgentEngine {
     compact_config: CompactConfig,
     /// Runtime context-size and compaction circuit-breaker state.
     compact_state: CompactState,
+    /// Persisted usage, source, and successful compaction counters.
+    context_state: ContextState,
+    /// Estimated category metadata for the system prompt.
+    prompt_usage: PromptUsage,
     /// Active compaction strategy level.
     compact_level: CompactLevel,
     /// Whether TOON-formatted compaction output is enabled.
@@ -172,7 +181,8 @@ impl AgentEngine {
         let allow_list = config.tools.allow_list.clone();
         let compact_config = config.compact.clone();
 
-        Self {
+        let prompt_usage = PromptUsage::from_system_prompt(&system_prompt);
+        let mut engine = Self {
             provider,
             model: config.model,
             max_tokens: config.max_tokens,
@@ -202,13 +212,17 @@ impl AgentEngine {
             protocol_writer: None,
             compact_config,
             compact_state: CompactState::new(),
+            context_state: ContextState::default(),
+            prompt_usage,
             compact_level: config.compact.compaction,
             toon_enabled: config.compact.toon,
             plan_state: PlanState::default(),
             plan_active_flag: None,
             cache_detector: CacheBreakDetector::new(),
             commands: default_registry(),
-        }
+        };
+        engine.refresh_local_context_estimate();
+        engine
     }
 
     /// Create from a resumed session
@@ -259,7 +273,11 @@ impl AgentEngine {
         let allow_list = config.tools.allow_list.clone();
         let compact_config = config.compact.clone();
 
-        Self {
+        let prompt_usage = PromptUsage::from_system_prompt(&system_prompt);
+        let context_state = session.context_state.clone();
+        let mut compact_state = CompactState::new();
+        compact_state.last_input_tokens = context_state.context_usage;
+        let mut engine = Self {
             provider,
             model: config.model.clone(),
             max_tokens: config.max_tokens,
@@ -288,14 +306,20 @@ impl AgentEngine {
             approval_manager: None,
             protocol_writer: None,
             compact_config,
-            compact_state: CompactState::new(),
+            compact_state,
+            context_state,
+            prompt_usage,
             compact_level: config.compact.compaction,
             toon_enabled: config.compact.toon,
             plan_state: PlanState::default(),
             plan_active_flag: None,
             cache_detector: CacheBreakDetector::new(),
             commands: default_registry(),
+        };
+        if engine.context_state.context_usage == 0 {
+            engine.refresh_local_context_estimate();
         }
+        engine
     }
 
     pub fn compaction_level(&self) -> CompactLevel {
@@ -322,12 +346,35 @@ impl AgentEngine {
 
     /// Replace the runtime authorization policy for registered tools.
     pub(crate) fn set_tool_policy(&mut self, tool_policy: ToolPolicy) {
+        let changed = self.tool_policy != tool_policy;
         self.tool_policy = tool_policy;
+        if changed {
+            self.refresh_local_context_estimate();
+        }
+    }
+
+    /// Replace bootstrap-derived prompt category metadata.
+    pub(crate) fn set_prompt_usage(&mut self, prompt_usage: PromptUsage) {
+        self.prompt_usage = prompt_usage;
     }
 
     /// Get the current session ID (if sessions are enabled and initialized)
     pub fn current_session_id(&self) -> Option<String> {
         self.current_session.as_ref().map(|s| s.id.clone())
+    }
+
+    /// Return the current context accounting status for SDK hosts.
+    pub fn context_status(&self) -> ContextStatus {
+        ContextStatus {
+            schema_version: self.context_state.schema_version,
+            model: self.model.clone(),
+            context_window: self.compact_config.context_window as u64,
+            context_usage: self.context_state.context_usage,
+            source: self.context_state.source,
+            compact_count: self.context_state.compact_count,
+            microcompact_count: self.context_state.microcompact_count,
+            updated_at: self.context_state.updated_at,
+        }
     }
 
     /// Get a reference to the output sink
@@ -378,13 +425,24 @@ impl AgentEngine {
     /// Run the agent loop with structured content blocks.
     ///
     /// This is the host-integration entry point for multimodal input such as
-    /// text and images. No marker parsing or slash-command interception is
-    /// performed.
+    /// text and images. A single text block containing a recognized slash
+    /// command is handled locally; multimodal inputs are never interpreted as
+    /// commands.
     pub async fn run_with_blocks(
         &mut self,
         content_blocks: Vec<ContentBlock>,
         msg_id: &str,
     ) -> Result<AgentResult, AgentError> {
+        let command_input = match content_blocks.as_slice() {
+            [ContentBlock::Text { text }] => Some(text.clone()),
+            _ => None,
+        };
+        if let Some(input) = command_input
+            && let Some(result) = self.handle_command(&input).await?
+        {
+            return Ok(result);
+        }
+
         let session_id = self.current_session.as_ref().map(|s| s.id.clone()).unwrap_or_default();
         let span = info_span!(
             target: "aion_agent",
@@ -399,7 +457,10 @@ impl AgentEngine {
         self.msg_id = msg_id.to_string();
         self.output.emit_stream_start(msg_id);
 
+        let user_tokens = estimate_content_tokens(&content_blocks);
         self.messages.push(Message::now(Role::User, content_blocks));
+        self.record_local_context_addition(user_tokens);
+        self.save_session();
 
         let mut guards = TurnGuards::new(
             self.max_turns_per_run,
@@ -429,6 +490,7 @@ impl AgentEngine {
                 TurnOutcome::ToolRound(outcome) => {
                     let assistant_content = build_assistant_content(&outcome);
                     self.messages.push(Message::now(Role::Assistant, assistant_content));
+                    self.save_session();
                     outcome.tool_calls
                 }
                 TurnOutcome::Final(outcome) => {
@@ -445,6 +507,7 @@ impl AgentEngine {
                 TurnOutcome::Truncated(outcome) => {
                     let assistant_content = build_assistant_content(&outcome);
                     self.messages.push(Message::now(Role::Assistant, assistant_content));
+                    self.save_session();
                     return self
                         .finalize_once(
                             FinalizationReason::MaxTokens,
@@ -523,25 +586,7 @@ impl AgentEngine {
     /// and recording the prompt state for cache diagnostics.
     fn build_request(&mut self, kind: TurnKind) -> LlmRequest {
         let image_input = self.compat.image_input();
-        // Build tool list: filter based on plan mode state
-        let tools = if kind.disable_tools() {
-            Vec::new()
-        } else if self.plan_state.is_active {
-            // Plan mode: only Info-category tools (excluding EnterPlanMode)
-            self.tools.to_tool_defs_filtered(|t| {
-                self.tool_policy.allows(t.name())
-                    && (!t.requires_image_input() || image_input.supports_images())
-                    && t.category() == ToolCategory::Info
-                    && t.name() != "EnterPlanMode"
-            })
-        } else {
-            // Normal mode: all compatible tools except ExitPlanMode
-            self.tools.to_tool_defs_filtered(|t| {
-                self.tool_policy.allows(t.name())
-                    && (!t.requires_image_input() || image_input.supports_images())
-                    && t.name() != "ExitPlanMode"
-            })
-        };
+        let tools = self.tool_definitions_for_turn(kind);
 
         // Build system prompt: append plan mode instructions when active
         let system = if self.plan_state.is_active {
@@ -572,6 +617,26 @@ impl AgentEngine {
             max_tokens: self.max_tokens,
             thinking: self.thinking.clone(),
             reasoning_effort: self.reasoning_effort.clone(),
+        }
+    }
+
+    fn tool_definitions_for_turn(&self, kind: TurnKind) -> Vec<ToolDef> {
+        let image_input = self.compat.image_input();
+        if kind.disable_tools() {
+            Vec::new()
+        } else if self.plan_state.is_active {
+            self.tools.to_tool_defs_filtered(|tool| {
+                self.tool_policy.allows(tool.name())
+                    && (!tool.requires_image_input() || image_input.supports_images())
+                    && tool.category() == ToolCategory::Info
+                    && tool.name() != "EnterPlanMode"
+            })
+        } else {
+            self.tools.to_tool_defs_filtered(|tool| {
+                self.tool_policy.allows(tool.name())
+                    && (!tool.requires_image_input() || image_input.supports_images())
+                    && tool.name() != "ExitPlanMode"
+            })
         }
     }
 
@@ -759,7 +824,11 @@ impl AgentEngine {
             let request = self.build_request(kind);
             let mut rx = self.provider.stream(&request).await?;
             let outcome = self.consume_stream(&mut rx).await?;
-            self.record_turn_usage(&outcome.usage);
+            let has_provider_usage = self.record_turn_usage(&outcome.usage);
+            if !has_provider_usage {
+                let assistant_content = build_assistant_content(&outcome);
+                self.record_local_context_addition(estimate_content_tokens(&assistant_content));
+            }
             Ok(outcome)
         }
         .instrument(span)
@@ -898,13 +967,20 @@ impl AgentEngine {
 
     /// Fold one turn's token usage into the running totals and replace the
     /// best-known context size with the provider's exact turn total.
-    fn record_turn_usage(&mut self, turn_usage: &TokenUsage) {
+    fn record_turn_usage(&mut self, turn_usage: &TokenUsage) -> bool {
         self.total_usage.input_tokens += turn_usage.input_tokens;
         self.total_usage.output_tokens += turn_usage.output_tokens;
         self.total_usage.cache_creation_tokens += turn_usage.cache_creation_tokens;
         self.total_usage.cache_read_tokens += turn_usage.cache_read_tokens;
 
-        self.compact_state.last_input_tokens = turn_usage.input_tokens.saturating_add(turn_usage.output_tokens);
+        let context_usage = turn_usage.input_tokens.saturating_add(turn_usage.output_tokens);
+        if context_usage == 0 {
+            debug!(target: "aion_agent", "provider omitted turn usage; retaining local context projection");
+            return false;
+        }
+
+        self.context_state.replace_with_provider_usage(context_usage);
+        self.sync_compact_watermark();
 
         // Cache break detection
         let cache_stats = CacheStats {
@@ -931,6 +1007,7 @@ impl AgentEngine {
                 }
             }
         }
+        true
     }
 
     /// Add content produced after the provider usage snapshot. Every final
@@ -945,7 +1022,7 @@ impl AgentEngine {
         });
         let added_tokens = tool_result_tokens.saturating_add(tool_image_tokens);
 
-        self.compact_state.last_input_tokens = self.compact_state.last_input_tokens.saturating_add(added_tokens);
+        self.record_local_context_addition(added_tokens);
         debug!(
             target: "aion_agent",
             tool_result_tokens,
@@ -953,6 +1030,36 @@ impl AgentEngine {
             context_tokens = self.compact_state.last_input_tokens,
             "tool results added to context token estimate"
         );
+    }
+
+    fn record_local_context_addition(&mut self, tokens: u64) {
+        self.context_state.add_local_estimate(tokens);
+        self.sync_compact_watermark();
+    }
+
+    fn sync_compact_watermark(&mut self) {
+        self.compact_state.last_input_tokens = self.context_state.context_usage;
+    }
+
+    fn refresh_local_context_estimate(&mut self) {
+        let tools = self.tool_definitions_for_turn(TurnKind::Normal);
+        let dynamic_system_tokens = self.dynamic_system_tokens();
+        let context_usage = self
+            .prompt_usage
+            .total_tokens()
+            .saturating_add(dynamic_system_tokens)
+            .saturating_add(estimate_tool_definitions_tokens(&tools))
+            .saturating_add(estimate_messages_tokens(&self.messages));
+        self.context_state.replace_with_local_estimate(context_usage);
+        self.sync_compact_watermark();
+    }
+
+    fn dynamic_system_tokens(&self) -> u64 {
+        if self.plan_state.is_active {
+            estimate_text_tokens(plan_mode_instructions())
+        } else {
+            0
+        }
     }
 
     /// Run the multi-level compaction pipeline before each API call.
@@ -969,6 +1076,10 @@ impl AgentEngine {
                     "Microcompact: cleared {} tool results (~{} tokens freed)",
                     result.cleared_count, result.estimated_tokens_freed
                 ));
+                self.context_state
+                    .record_microcompact(result.estimated_tokens_freed as u64);
+                self.sync_compact_watermark();
+                self.save_session();
             }
         }
 
@@ -1011,6 +1122,9 @@ impl AgentEngine {
                         result.messages_summarized, result.pre_compact_tokens
                     ));
                     self.messages = result.messages;
+                    self.context_state.record_compact();
+                    self.refresh_local_context_estimate();
+                    self.save_session();
                     compacted = true;
                 }
                 Err(CompactError::CircuitBroken { .. }) => {
@@ -1101,7 +1215,9 @@ impl AgentEngine {
     /// Initialize a new session for this engine run
     pub fn init_session(&mut self, provider_name: &str, cwd: &str, session_id: Option<&str>) -> AnyhowResult<()> {
         if let Some(mgr) = &self.session_manager {
-            let session = mgr.create(provider_name, &self.model, cwd, session_id)?;
+            let mut session = mgr.create(provider_name, &self.model, cwd, session_id)?;
+            session.context_state = self.context_state.clone();
+            mgr.save(&session)?;
             info!(target: "aion_agent", session_id = %session.id, provider = %provider_name, model = %self.model, "session started");
             self.current_session = Some(session);
         }
@@ -1225,6 +1341,20 @@ impl AgentEngine {
                     turns: 0,
                 }))
             }
+            Ok(CommandResult::ContextChanged) => {
+                self.refresh_local_context_estimate();
+                self.save_session();
+                info!(
+                    command = command.display_name,
+                    "Slash command executed and context persisted"
+                );
+                Ok(Some(AgentResult {
+                    text: String::new(),
+                    stop_reason: StopReason::EndTurn,
+                    usage: TokenUsage::default(),
+                    turns: 0,
+                }))
+            }
             Ok(CommandResult::Exit) => {
                 info!(command = command.display_name, "Slash command executed: exit");
                 Err(AgentError::UserAborted)
@@ -1238,6 +1368,8 @@ impl AgentEngine {
 
     async fn execute_command(&mut self, command: ParsedSlashCommand<'_>) -> Option<Result<CommandResult, AnyhowError>> {
         let cmd = self.commands.find(command.name)?;
+        let context_tools = self.tool_definitions_for_turn(TurnKind::Normal);
+        let dynamic_system_tokens = self.dynamic_system_tokens();
 
         // We need to borrow self mutably for CommandContext while also
         // borrowing self.commands immutably (already done above via find()).
@@ -1253,6 +1385,10 @@ impl AgentEngine {
             model: &self.model,
             output: self.output.as_ref(),
             registry: &self.commands,
+            context_state: &mut self.context_state,
+            prompt_usage: &self.prompt_usage,
+            context_tools: &context_tools,
+            dynamic_system_tokens,
         };
 
         // SAFETY: cmd_ptr points to a command inside self.commands which is only
@@ -1272,6 +1408,7 @@ impl AgentEngine {
 
     /// Apply context modifiers collected from skill tool executions.
     fn apply_context_modifiers(&mut self, modifiers: &[Option<ContextModifier>]) {
+        let mut request_shape_changed = false;
         for modifier in modifiers.iter().flatten() {
             if let Some(ref model) = modifier.model {
                 self.model = model.clone();
@@ -1295,6 +1432,7 @@ impl AgentEngine {
                         if let Some(ref flag) = self.plan_active_flag {
                             flag.store(true, Ordering::Release);
                         }
+                        request_shape_changed = true;
                     }
                     PlanModeTransition::Exit { .. } => {
                         self.plan_state.is_active = false;
@@ -1302,9 +1440,13 @@ impl AgentEngine {
                         if let Some(ref flag) = self.plan_active_flag {
                             flag.store(false, Ordering::Release);
                         }
+                        request_shape_changed = true;
                     }
                 }
             }
+        }
+        if request_shape_changed {
+            self.refresh_local_context_estimate();
         }
     }
 
@@ -1312,6 +1454,7 @@ impl AgentEngine {
         if let (Some(mgr), Some(session)) = (&self.session_manager, &mut self.current_session) {
             session.messages = self.messages.clone();
             session.total_usage = self.total_usage.clone();
+            session.context_state = self.context_state.clone();
             session.updated_at = Utc::now();
             if let Err(e) = mgr.save(session) {
                 self.output.emit_error(&format!("Failed to save session: {}", e));

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -70,6 +70,8 @@ mod tests_set_config {
             protocol_writer: None,
             compact_config: aion_config::compact::CompactConfig::default(),
             compact_state: super::CompactState::new(),
+            context_state: Default::default(),
+            prompt_usage: Default::default(),
             compact_level: CompactLevel::default(),
             toon_enabled: false,
             plan_state: Default::default(),
@@ -444,6 +446,8 @@ mod tests_phase6 {
             protocol_writer: None,
             compact_config: aion_config::compact::CompactConfig::default(),
             compact_state: super::CompactState::new(),
+            context_state: Default::default(),
+            prompt_usage: Default::default(),
             compact_level: CompactLevel::default(),
             toon_enabled: false,
             plan_state: Default::default(),
@@ -578,21 +582,28 @@ mod tests_phase6 {
 
 #[cfg(test)]
 mod tests_compact {
+    use std::env;
     use std::sync::{Arc, Mutex};
 
     use aion_config::compact::CompactConfig;
+    use aion_config::config::{CliArgs, Config};
     use aion_providers::error::ProviderError;
     use aion_providers::provider::LlmProvider;
     use aion_tools::registry::ToolRegistry;
     use aion_types::llm::{LlmEvent, LlmRequest};
-    use aion_types::message::{ContentBlock, ImageInputCapability, ImageUrl, Message, Role, TokenUsage};
+    use aion_types::message::{ContentBlock, ImageInputCapability, ImageUrl, Message, Role, StopReason, TokenUsage};
+    use chrono::Utc;
     use serde_json::json;
+    use tempfile::tempdir;
+    use tokio::sync::mpsc;
 
     use super::{CompactLevel, ProviderCompat};
     use crate::compact::auto::should_autocompact;
     use crate::compact::state::CompactState;
     use crate::confirm::ToolConfirmer;
+    use crate::context_usage::{ContextState, ContextUsageSource};
     use crate::output::OutputSink;
+    use crate::session::{Session, SessionManager};
 
     struct NullOutput;
     impl OutputSink for NullOutput {
@@ -642,6 +653,27 @@ mod tests_compact {
     impl LlmProvider for NullProvider {
         async fn stream(&self, _: &LlmRequest) -> Result<tokio::sync::mpsc::Receiver<LlmEvent>, ProviderError> {
             let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(rx)
+        }
+    }
+
+    struct SuccessfulProvider {
+        usage: TokenUsage,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for SuccessfulProvider {
+        async fn stream(&self, _: &LlmRequest) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+            let (tx, rx) = mpsc::channel(4);
+            tx.send(LlmEvent::TextDelta("<summary>condensed context</summary>".into()))
+                .await
+                .unwrap();
+            tx.send(LlmEvent::Done {
+                stop_reason: StopReason::EndTurn,
+                usage: self.usage.clone(),
+            })
+            .await
+            .unwrap();
             Ok(rx)
         }
     }
@@ -699,6 +731,8 @@ mod tests_compact {
             protocol_writer: None,
             compact_config,
             compact_state,
+            context_state: Default::default(),
+            prompt_usage: Default::default(),
             compact_level: CompactLevel::default(),
             toon_enabled: false,
             plan_state: Default::default(),
@@ -706,6 +740,26 @@ mod tests_compact {
             cache_detector: super::CacheBreakDetector::new(),
             commands: crate::commands::default_registry(),
         }
+    }
+
+    fn test_config() -> Config {
+        Config::resolve(&CliArgs {
+            provider: Some("anthropic".to_string()),
+            api_key: Some("sk-test".to_string()),
+            base_url: None,
+            model: Some("test-model".to_string()),
+            max_tokens: Some(4096),
+            thinking: None,
+            thinking_budget: None,
+            max_turns: None,
+            max_tool_call_malformed_turns: None,
+            max_tool_call_failure_turns: None,
+            system_prompt: None,
+            profile: None,
+            auto_approve: true,
+            project_dir: None,
+        })
+        .unwrap()
     }
 
     fn tool_use_msg(id: &str, name: &str) -> Message {
@@ -857,6 +911,126 @@ mod tests_compact {
         });
 
         assert_eq!(engine.compact_state.last_input_tokens, 795);
+        assert_eq!(engine.context_state.context_usage, 795);
+        assert_eq!(engine.context_state.source, ContextUsageSource::ProviderExact);
+    }
+
+    #[test]
+    fn missing_provider_usage_does_not_reset_context_to_zero() {
+        let mut engine = make_compact_engine(CompactConfig::default(), CompactState::new(), vec![]);
+        engine.context_state.replace_with_local_estimate(1_234);
+        engine.sync_compact_watermark();
+
+        let has_provider_usage = engine.record_turn_usage(&TokenUsage::default());
+
+        assert!(!has_provider_usage);
+        assert_eq!(engine.context_state.context_usage, 1_234);
+        assert_eq!(engine.compact_state.last_input_tokens, 1_234);
+        assert_eq!(engine.context_state.source, ContextUsageSource::LocalProjected);
+    }
+
+    #[test]
+    fn resume_restores_persisted_context_watermark_and_counts() {
+        let mut context_state = ContextState::default();
+        context_state.replace_with_provider_usage(54_321);
+        context_state.compact_count = 2;
+        context_state.microcompact_count = 5;
+        let session = Session {
+            id: "resume-context".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            provider: "anthropic".into(),
+            model: "test-model".into(),
+            cwd: "/tmp".into(),
+            total_usage: TokenUsage::default(),
+            context_state,
+            messages: Vec::new(),
+        };
+        let provider: Arc<dyn LlmProvider> = Arc::new(NullProvider);
+
+        let engine = super::AgentEngine::resume_with_provider(
+            provider,
+            test_config(),
+            ToolRegistry::new(),
+            Arc::new(NullOutput),
+            session,
+            env::temp_dir(),
+        );
+        let status = engine.context_status();
+
+        assert_eq!(status.context_usage, 54_321);
+        assert_eq!(status.compact_count, 2);
+        assert_eq!(status.microcompact_count, 5);
+        assert_eq!(status.source, ContextUsageSource::ProviderExact);
+        assert_eq!(engine.compact_state.last_input_tokens, 54_321);
+    }
+
+    #[tokio::test]
+    async fn user_message_and_local_projection_are_saved_before_provider_failure() {
+        let directory = tempdir().unwrap();
+        let mut config = test_config();
+        config.session.enabled = true;
+        config.session.directory = directory.path().display().to_string();
+        let provider: Arc<dyn LlmProvider> = Arc::new(RecordingRejectingProvider::default());
+        let mut engine = super::AgentEngine::new_with_provider(
+            provider,
+            config,
+            ToolRegistry::new(),
+            Arc::new(NullOutput),
+            directory.path().to_path_buf(),
+        );
+        engine
+            .init_session(
+                "anthropic",
+                &directory.path().display().to_string(),
+                Some("saved-before-call"),
+            )
+            .unwrap();
+
+        assert!(engine.run("hello before failure", "msg-1").await.is_err());
+
+        let manager = SessionManager::new(directory.path().to_path_buf(), 10);
+        let loaded = manager.load("saved-before-call").unwrap();
+        assert_eq!(loaded.messages.len(), 1);
+        assert!(loaded.context_state.context_usage > 0);
+        assert_eq!(loaded.context_state.source, ContextUsageSource::LocalProjected);
+    }
+
+    #[tokio::test]
+    async fn assistant_response_saves_exact_provider_context_usage() {
+        let directory = tempdir().unwrap();
+        let mut config = test_config();
+        config.session.enabled = true;
+        config.session.directory = directory.path().display().to_string();
+        let provider: Arc<dyn LlmProvider> = Arc::new(SuccessfulProvider {
+            usage: TokenUsage {
+                input_tokens: 100,
+                output_tokens: 20,
+                ..Default::default()
+            },
+        });
+        let mut engine = super::AgentEngine::new_with_provider(
+            provider,
+            config,
+            ToolRegistry::new(),
+            Arc::new(NullOutput),
+            directory.path().to_path_buf(),
+        );
+        engine
+            .init_session(
+                "anthropic",
+                &directory.path().display().to_string(),
+                Some("saved-after-response"),
+            )
+            .unwrap();
+
+        engine.run("hello", "msg-2").await.unwrap();
+
+        let manager = SessionManager::new(directory.path().to_path_buf(), 10);
+        let loaded = manager.load("saved-after-response").unwrap();
+        assert_eq!(loaded.messages.len(), 2);
+        assert_eq!(loaded.context_state.context_usage, 120);
+        assert_eq!(loaded.context_state.source, ContextUsageSource::ProviderExact);
     }
 
     #[test]
@@ -953,6 +1127,8 @@ mod tests_compact {
         let state = CompactState::new();
 
         let mut engine = make_compact_engine(config, state, messages);
+        engine.context_state.replace_with_provider_usage(1_000);
+        engine.sync_compact_watermark();
         engine.run_compaction().await.unwrap();
 
         // Last 3 tool results should be preserved
@@ -964,6 +1140,42 @@ mod tests_compact {
             .count();
 
         assert_eq!(cleared_count, 9);
+        assert_eq!(engine.context_state.microcompact_count, 1);
+        assert!(engine.context_state.context_usage < 1_000);
+        assert_eq!(engine.context_state.source, ContextUsageSource::LocalProjected);
+    }
+
+    #[tokio::test]
+    async fn successful_autocompact_updates_persisted_count_and_local_estimate() {
+        let config = CompactConfig {
+            context_window: 100,
+            autocompact_threshold_pct: Some(50),
+            emergency_buffer: 10,
+            ..Default::default()
+        };
+        let mut state = CompactState::new();
+        state.last_input_tokens = 60;
+        let messages = vec![
+            Message::new(Role::User, vec![ContentBlock::Text { text: "first".into() }]),
+            Message::new(Role::Assistant, vec![ContentBlock::Text { text: "second".into() }]),
+            Message::new(Role::User, vec![ContentBlock::Text { text: "third".into() }]),
+        ];
+        let mut engine = make_compact_engine(config, state, messages);
+        engine.provider = Arc::new(SuccessfulProvider {
+            usage: TokenUsage::default(),
+        });
+        engine.context_state.replace_with_provider_usage(60);
+        engine.sync_compact_watermark();
+
+        engine.run_compaction().await.unwrap();
+
+        assert_eq!(engine.context_state.compact_count, 1);
+        assert_eq!(engine.context_state.source, ContextUsageSource::LocalProjected);
+        assert_eq!(engine.messages.len(), 2);
+        assert_eq!(
+            engine.compact_state.last_input_tokens,
+            engine.context_state.context_usage
+        );
     }
 
     // -- Disabled config skips micro and auto but not emergency --
@@ -1169,6 +1381,8 @@ mod tests_plan_mode {
             protocol_writer: None,
             compact_config: aion_config::compact::CompactConfig::default(),
             compact_state: CompactState::new(),
+            context_state: Default::default(),
+            prompt_usage: Default::default(),
             compact_level: CompactLevel::default(),
             toon_enabled: false,
             plan_state: PlanState::default(),
@@ -1387,6 +1601,8 @@ mod tests_handle_command {
             protocol_writer: None,
             compact_config: CompactConfig::default(),
             compact_state: CompactState::new(),
+            context_state: Default::default(),
+            prompt_usage: Default::default(),
             compact_level: CompactLevel::default(),
             toon_enabled: false,
             plan_state: Default::default(),
@@ -1436,6 +1652,23 @@ mod tests_handle_command {
     }
 
     #[tokio::test]
+    async fn handle_context_command_is_read_only() {
+        let mut engine = make_engine();
+        engine.context_state.context_usage = 42_000;
+        let before = engine.context_state.clone();
+
+        let result = engine
+            .handle_command("/context all")
+            .await
+            .unwrap()
+            .expect("context command should be handled");
+
+        assert_eq!(result.turns, 0);
+        assert_eq!(engine.context_state, before);
+        assert!(engine.messages.is_empty());
+    }
+
+    #[tokio::test]
     async fn handle_command_with_args() {
         let mut engine = make_engine();
         let result = engine
@@ -1468,14 +1701,32 @@ mod tests_handle_command {
         assert!(matches!(err, AgentError::UserAborted));
     }
 
+    #[tokio::test]
+    async fn run_with_blocks_intercepts_single_text_context_command() {
+        let mut engine = make_engine();
+        let result = engine
+            .run_with_blocks(
+                vec![ContentBlock::Text {
+                    text: "/context".into(),
+                }],
+                "msg-context",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.turns, 0);
+        assert!(engine.messages.is_empty());
+    }
+
     #[test]
     fn slash_command_list_returns_all() {
         let engine = make_engine();
         let list = engine.slash_command_list();
-        assert!(list.len() >= 4);
+        assert!(list.len() >= 5);
         let names: Vec<&str> = list.iter().map(|(n, _)| n.as_str()).collect();
         assert!(names.contains(&"help"));
         assert!(names.contains(&"compact"));
+        assert!(names.contains(&"context"));
         assert!(names.contains(&"clear"));
         assert!(names.contains(&"quit"));
     }
@@ -2375,6 +2626,8 @@ mod tests_tool_policy_enforcement {
             protocol_writer: None,
             compact_config: Default::default(),
             compact_state: CompactState::new(),
+            context_state: Default::default(),
+            prompt_usage: Default::default(),
             compact_level: CompactLevel::default(),
             toon_enabled: false,
             plan_state: Default::default(),

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -1141,7 +1141,59 @@ mod tests_compact {
 
         assert_eq!(cleared_count, 9);
         assert_eq!(engine.context_state.microcompact_count, 1);
-        assert!(engine.context_state.context_usage < 1_000);
+        assert_eq!(engine.context_state.context_usage, 1_000);
+        assert_eq!(engine.compact_state.last_input_tokens, 1_000);
+        assert_eq!(engine.context_state.source, ContextUsageSource::LocalProjected);
+    }
+
+    #[tokio::test]
+    async fn microcompact_does_not_lower_the_emergency_watermark() {
+        let mut messages = Vec::new();
+        for i in 0..3 {
+            let id = format!("t{i}");
+            messages.push(tool_use_msg(&id, "Read"));
+            messages.push(tool_result_msg(&id, &"x".repeat(4_000)));
+        }
+
+        let config = CompactConfig {
+            context_window: 200_000,
+            emergency_buffer: 3_000,
+            max_failures: 3,
+            micro_keep_recent: 1,
+            ..Default::default()
+        };
+        let mut state = CompactState::new();
+        state.last_input_tokens = 198_000;
+        state.consecutive_failures = 3;
+
+        let mut engine = make_compact_engine(config, state, messages);
+        engine.context_state.replace_with_provider_usage(198_000);
+        engine.sync_compact_watermark();
+
+        let result = engine.run_compaction().await;
+
+        assert!(matches!(
+            result,
+            Err(super::AgentError::ContextTooLong {
+                input_tokens: 198_000,
+                limit: 197_000
+            })
+        ));
+        let cleared_count = engine
+            .messages
+            .iter()
+            .flat_map(|message| &message.content)
+            .filter(|block| {
+                matches!(
+                    block,
+                    ContentBlock::ToolResult { content, .. } if content == "[Tool result cleared]"
+                )
+            })
+            .count();
+        assert_eq!(cleared_count, 2);
+        assert_eq!(engine.context_state.microcompact_count, 1);
+        assert_eq!(engine.context_state.context_usage, 198_000);
+        assert_eq!(engine.compact_state.last_input_tokens, 198_000);
         assert_eq!(engine.context_state.source, ContextUsageSource::LocalProjected);
     }
 

--- a/crates/aion-agent/src/lib.rs
+++ b/crates/aion-agent/src/lib.rs
@@ -7,6 +7,7 @@ pub mod commands;
 pub mod compact;
 pub mod confirm;
 pub mod context;
+pub mod context_usage;
 pub mod engine;
 pub mod error;
 pub mod orchestration;

--- a/crates/aion-agent/src/session.rs
+++ b/crates/aion-agent/src/session.rs
@@ -11,6 +11,8 @@ use uuid::Uuid;
 
 use aion_types::message::{ContentBlock, Message, Role, TokenUsage};
 
+use crate::context_usage::ContextState;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: String,
@@ -20,6 +22,8 @@ pub struct Session {
     pub model: String,
     pub cwd: String,
     pub total_usage: TokenUsage,
+    #[serde(default)]
+    pub context_state: ContextState,
     pub messages: Vec<Message>,
 }
 
@@ -67,6 +71,7 @@ impl SessionManager {
             model: model.to_string(),
             cwd: cwd.to_string(),
             total_usage: TokenUsage::default(),
+            context_state: ContextState::default(),
             messages: Vec::new(),
         };
         self.with_session_lock(&session.id, || {

--- a/crates/aion-agent/src/session_test.rs
+++ b/crates/aion-agent/src/session_test.rs
@@ -27,6 +27,12 @@ mod tests {
         assert!(session.messages.is_empty());
         assert!(manager.state_path(&session.id).is_file());
         assert!(!dir.path().join("index.json").exists());
+
+        let state_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(manager.state_path(&session.id)).unwrap()).unwrap();
+        assert_eq!(state_json["context_state"]["schema_version"], 1);
+        assert_eq!(state_json["context_state"]["context_usage"], 0);
+        assert!(state_json["context_state"].get("observed_context_window").is_none());
     }
 
     #[test]
@@ -41,6 +47,18 @@ mod tests {
         assert_eq!(loaded.provider, "anthropic");
         assert_eq!(loaded.model, "claude-3");
         assert_eq!(loaded.cwd, "/home");
+    }
+
+    #[test]
+    fn test_load_session_without_context_state_uses_backward_compatible_default() {
+        let mut value = serde_json::to_value(sample_session("old-session", "old-model")).unwrap();
+        value.as_object_mut().unwrap().remove("context_state");
+
+        let loaded: Session = serde_json::from_value(value).unwrap();
+
+        assert_eq!(loaded.context_state.context_usage, 0);
+        assert_eq!(loaded.context_state.compact_count, 0);
+        assert_eq!(loaded.context_state.microcompact_count, 0);
     }
 
     #[test]
@@ -313,6 +331,7 @@ mod tests {
             model: model.to_string(),
             cwd: "/tmp".to_string(),
             total_usage: TokenUsage::default(),
+            context_state: ContextState::default(),
             messages: vec![Message::new(
                 Role::User,
                 vec![ContentBlock::Text {


### PR DESCRIPTION
## Summary

- Persist a versioned `context_state` in session `state.json`, including current context usage, usage source, compact/microcompact counts, and update time.
- Restore context accounting across restarts and update it after user input, provider responses, tool results, and successful compaction.
- Add `/context` and `/context all` with category estimates, and expose `AgentEngine::context_status()` for SDK hosts.
- Keep existing session files backward-compatible through serde defaults; the effective context window remains runtime configuration and is not persisted.

## Why

AionCore needs aionrs to own the effective context window and compaction decisions. Previously, the current context watermark and compaction history were runtime-only, so restarts lost that status and hosts could not query a consistent context view.

## Non-goals

- This PR does not add AionCore/AionUi structured context-status events or UI rendering.
- This PR does not introduce model-specific context limits in AionUi.
- This PR does not persist the runtime context window or request-shape fingerprints.

## Validation

- `just push -u origin jiahe/feat/context-usage`
  - `cargo fix --allow-dirty --allow-staged`
  - `cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged -- -D warnings`
  - `cargo fmt --all`
  - `cargo nextest run --workspace --profile default`
  - `cargo hakari generate --diff`
  - `cargo hakari manage-deps --dry-run`
  - `cargo hakari verify`
- `cargo test -p aion-agent`
- `cargo check --workspace`
- `git diff --check`

## Follow-up

After this lands and is released, AionCore can consume `AgentEngine::context_status()` and emit a structured context-status event for AionUi.
