### PR TITLE
fix(agent): eliminate empty responses from embedded stream errors and reasoning-only turns

### DIFF
--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -57,6 +57,12 @@ pub struct AgentResult {
     pub turns: usize,
 }
 
+/// Corrective prompt injected before the single tool-enabled retry that
+/// follows an empty final response. Some models put the intended tool call
+/// (or the whole answer) inside reasoning content; a normal turn with tools
+/// still available lets them recover, unlike the tool-less finalization path.
+const EMPTY_FINAL_RETRY_PROMPT: &str = "The previous response contained no visible answer text. Respond again now: provide the answer as visible text, or issue the intended tool call as a proper tool call. Do not leave the answer or tool calls inside reasoning.";
+
 pub struct AgentEngine {
     // Provider request configuration.
     /// Shared LLM provider used to issue model requests.
@@ -467,6 +473,7 @@ impl AgentEngine {
             self.max_tool_call_malformed_turns,
             self.max_tool_call_failure_turns,
         );
+        let mut empty_final_retried = false;
         loop {
             if let Some(limit) = guards.turn_budget_reached() {
                 self.save_session();
@@ -524,16 +531,32 @@ impl AgentEngine {
                         assistant_text_bytes = outcome.assistant_text.len(),
                         thinking_text_bytes = outcome.thinking_text.len(),
                         tool_call_count = outcome.tool_calls.len(),
-                        "provider turn produced no valid final answer; retrying finalization"
+                        retried = empty_final_retried,
+                        "provider turn produced no valid final answer"
                     );
-                    return self
-                        .finalize_once(
-                            FinalizationReason::EmptyFinal,
-                            outcome.assistant_text,
-                            guards.counted_turns(),
-                            StopReason::EndTurn,
-                        )
-                        .await;
+                    if empty_final_retried {
+                        return self
+                            .finalize_once(
+                                FinalizationReason::EmptyFinal,
+                                outcome.assistant_text,
+                                guards.counted_turns(),
+                                StopReason::EndTurn,
+                            )
+                            .await;
+                    }
+
+                    // First retry runs as a normal turn with tools available,
+                    // so a model that hid its tool call in reasoning can
+                    // re-issue it properly instead of being forced into a
+                    // tool-less finalization answer.
+                    empty_final_retried = true;
+                    let retry_blocks = vec![ContentBlock::Text {
+                        text: EMPTY_FINAL_RETRY_PROMPT.to_string(),
+                    }];
+                    self.record_local_context_addition(estimate_content_tokens(&retry_blocks));
+                    self.messages.push(Message::now(Role::User, retry_blocks));
+                    self.save_session();
+                    continue;
                 }
             };
 

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -473,7 +473,6 @@ impl AgentEngine {
             self.max_tool_call_malformed_turns,
             self.max_tool_call_failure_turns,
         );
-        let mut empty_final_retried = false;
         loop {
             if let Some(limit) = guards.turn_budget_reached() {
                 self.save_session();
@@ -525,16 +524,17 @@ impl AgentEngine {
                         .await;
                 }
                 TurnOutcome::EmptyFinal(outcome) => {
+                    let retry_allowed = guards.allow_empty_final_retry();
                     warn!(
                         target: "aion_agent",
                         stop_reason = ?outcome.stop_reason,
                         assistant_text_bytes = outcome.assistant_text.len(),
                         thinking_text_bytes = outcome.thinking_text.len(),
                         tool_call_count = outcome.tool_calls.len(),
-                        retried = empty_final_retried,
+                        retried = !retry_allowed,
                         "provider turn produced no valid final answer"
                     );
-                    if empty_final_retried {
+                    if !retry_allowed {
                         return self
                             .finalize_once(
                                 FinalizationReason::EmptyFinal,
@@ -549,7 +549,6 @@ impl AgentEngine {
                     // so a model that hid its tool call in reasoning can
                     // re-issue it properly instead of being forced into a
                     // tool-less finalization answer.
-                    empty_final_retried = true;
                     let retry_blocks = vec![ContentBlock::Text {
                         text: EMPTY_FINAL_RETRY_PROMPT.to_string(),
                     }];

--- a/crates/aion-agent/src/turn.rs
+++ b/crates/aion-agent/src/turn.rs
@@ -134,6 +134,9 @@ pub(crate) struct TurnGuards {
     all_error_tool_rounds: ToolCallAllErrorRoundTracker,
     tool_call_cycles: ToolCallCycleTracker,
     tool_call_cycle_warning_emitted: bool,
+    /// Whether the single tool-enabled retry after an empty final response
+    /// has been spent for this run.
+    empty_final_retried: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -198,7 +201,19 @@ impl TurnGuards {
             }),
             tool_call_cycles: ToolCallCycleTracker::new(tool_failure_guards_enabled),
             tool_call_cycle_warning_emitted: false,
+            empty_final_retried: false,
         }
+    }
+
+    /// Grant the single tool-enabled retry that follows an empty final
+    /// response. Returns `true` the first time it is called in a run and
+    /// `false` afterwards.
+    pub(crate) fn allow_empty_final_retry(&mut self) -> bool {
+        if self.empty_final_retried {
+            return false;
+        }
+        self.empty_final_retried = true;
+        true
     }
 
     pub(crate) fn counted_turns(&self) -> usize {

--- a/crates/aion-agent/tests/engine_test.rs
+++ b/crates/aion-agent/tests/engine_test.rs
@@ -472,32 +472,91 @@ async fn empty_final_gets_one_visible_answer_nudge() {
 
     assert_eq!(result.text, "Visible answer");
     assert_eq!(result.stop_reason, StopReason::EndTurn);
-    assert_eq!(result.turns, 1);
+    // The nudge retry runs as a counted normal turn.
+    assert_eq!(result.turns, 2);
 
     let recorded = requests.lock().unwrap();
     assert_eq!(recorded.len(), 2);
-    assert_eq!(recorded[1].tool_count, 0);
+    // The first retry keeps tools available so a model that hid its tool
+    // call in reasoning can re-issue it properly.
+    assert_eq!(recorded[1].tool_count, 1);
     assert!(
         !contains_empty_assistant_message(&recorded[1].messages),
-        "empty finalization request must not include empty assistant content"
+        "empty-final retry request must not include empty assistant content"
     );
     let last_message = recorded[1]
         .messages
         .last()
-        .expect("finalization request should include control prompt");
+        .expect("retry request should include the corrective prompt");
     assert_eq!(last_message.role, Role::User);
     assert!(
         matches!(
             &last_message.content[..],
             [ContentBlock::Text { text }] if text.contains("visible answer text")
         ),
-        "empty finalization prompt should ask for visible answer text"
+        "empty-final retry prompt should ask for visible answer text"
+    );
+}
+
+#[tokio::test]
+async fn empty_final_retry_can_recover_through_a_tool_call() {
+    // Reproduces the reasoning-only turn: the model "answers" with thinking
+    // content only (e.g. a tool call written into reasoning), then uses the
+    // tool-enabled retry to issue the real tool call and finish the task.
+    let provider = Arc::new(FullRecordingRequestProvider::new(vec![
+        vec![
+            LlmEvent::ThinkingDelta("{\"tool\":\"mock_tool\"}".to_string()),
+            LlmEvent::Done {
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+            },
+        ],
+        vec![
+            LlmEvent::ToolUse {
+                id: "call-1".to_string(),
+                name: "mock_tool".to_string(),
+                input: json!({}),
+                extra: None,
+            },
+            LlmEvent::Done {
+                stop_reason: StopReason::ToolUse,
+                usage: TokenUsage::default(),
+            },
+        ],
+        vec![
+            LlmEvent::TextDelta("Recovered answer".to_string()),
+            LlmEvent::Done {
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+            },
+        ],
+    ]));
+    let requests = provider.requests();
+
+    let config = test_config();
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(MockTool::new("mock_tool", "tool output", false)));
+    let output = silent_output();
+
+    let mut engine = AgentEngine::new_with_provider(provider, config, registry, output, std::env::temp_dir());
+    let result = engine.run("Do the task", "").await.expect("engine should succeed");
+
+    assert_eq!(result.text, "Recovered answer");
+    assert_eq!(result.stop_reason, StopReason::EndTurn);
+
+    let recorded = requests.lock().unwrap();
+    assert_eq!(recorded.len(), 3);
+    assert_eq!(
+        recorded[1].tool_count, 1,
+        "retry after the reasoning-only turn must keep tools available"
     );
 }
 
 #[tokio::test]
 async fn empty_final_falls_back_after_one_empty_retry() {
     let dir = tempdir().expect("tempdir should be created");
+    // Empty normal turn, empty tool-enabled retry, then an empty tool-less
+    // finalization turn — the run must still fall back to visible text.
     let provider = Arc::new(FullRecordingRequestProvider::new(vec![
         vec![LlmEvent::Done {
             stop_reason: StopReason::EndTurn,
@@ -507,7 +566,12 @@ async fn empty_final_falls_back_after_one_empty_retry() {
             stop_reason: StopReason::EndTurn,
             usage: TokenUsage::default(),
         }],
+        vec![LlmEvent::Done {
+            stop_reason: StopReason::EndTurn,
+            usage: TokenUsage::default(),
+        }],
     ]));
+    let requests = provider.requests();
 
     let mut config = test_config();
     config.session.enabled = true;
@@ -525,8 +589,16 @@ async fn empty_final_falls_back_after_one_empty_retry() {
         .expect("engine should fall back successfully");
 
     assert_eq!(result.stop_reason, StopReason::EndTurn);
-    assert_eq!(result.turns, 1);
+    assert_eq!(result.turns, 2);
     assert!(result.text.contains("finished without visible answer text"));
+
+    let recorded = requests.lock().unwrap();
+    assert_eq!(recorded.len(), 3);
+    assert_eq!(
+        recorded[2].tool_count, 0,
+        "final finalization turn after the retry must disable tools"
+    );
+    drop(recorded);
 
     let session = SessionManager::new(dir.path().to_path_buf(), 10)
         .load("latest")

--- a/crates/aion-providers/src/error.rs
+++ b/crates/aion-providers/src/error.rs
@@ -33,7 +33,10 @@ impl ProviderError {
 /// embedded in SSE streams. Returns `None` when the body does not look like
 /// an error payload.
 pub(crate) fn provider_error_from_json_body(body: &Value, body_bytes: &[u8]) -> Option<ProviderError> {
-    let error = body.get("error").unwrap_or(body);
+    // Some gateways include `"error": null` in perfectly normal responses;
+    // treat a null error field the same as an absent one.
+    let error_field = body.get("error").filter(|error| !error.is_null());
+    let error = error_field.unwrap_or(body);
     let status = [
         error.get("code"),
         error.get("status"),
@@ -59,7 +62,7 @@ pub(crate) fn provider_error_from_json_body(body: &Value, body_bytes: &[u8]) -> 
             body: (!body_bytes.is_empty()).then(|| String::from_utf8_lossy(body_bytes).into_owned()),
         }),
         Some(status) => Some(ProviderError::Api { status, message }),
-        None if body.get("error").is_some() => Some(ProviderError::Parse(format!(
+        None if error_field.is_some() => Some(ProviderError::Parse(format!(
             "Provider returned a JSON error response without an HTTP status: {message}"
         ))),
         None => None,

--- a/crates/aion-providers/src/error.rs
+++ b/crates/aion-providers/src/error.rs
@@ -1,3 +1,5 @@
+use serde_json::Value;
+
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderError {
     #[error("HTTP error: {0}")]
@@ -22,6 +24,54 @@ impl ProviderError {
     pub fn is_retryable(&self) -> bool {
         matches!(self, ProviderError::RateLimited { .. } | ProviderError::Connection(_))
     }
+}
+
+/// Map a provider JSON error payload to a `ProviderError`.
+///
+/// Covers error bodies delivered with a successful HTTP status: whole-body
+/// JSON errors on non-streaming responses and `data: {"error": ...}` frames
+/// embedded in SSE streams. Returns `None` when the body does not look like
+/// an error payload.
+pub(crate) fn provider_error_from_json_body(body: &Value, body_bytes: &[u8]) -> Option<ProviderError> {
+    let error = body.get("error").unwrap_or(body);
+    let status = [
+        error.get("code"),
+        error.get("status"),
+        body.get("code"),
+        body.get("status"),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(json_http_status_code);
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .or_else(|| error.as_str())
+        .or_else(|| body.get("message").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .unwrap_or("Provider returned a JSON error response without a message")
+        .to_string();
+
+    match status {
+        Some(429) => Some(ProviderError::RateLimited {
+            retry_after_ms: 5000,
+            body: (!body_bytes.is_empty()).then(|| String::from_utf8_lossy(body_bytes).into_owned()),
+        }),
+        Some(status) => Some(ProviderError::Api { status, message }),
+        None if body.get("error").is_some() => Some(ProviderError::Parse(format!(
+            "Provider returned a JSON error response without an HTTP status: {message}"
+        ))),
+        None => None,
+    }
+}
+
+fn json_http_status_code(value: &Value) -> Option<u16> {
+    value
+        .as_u64()
+        .and_then(|status| u16::try_from(status).ok())
+        .or_else(|| value.as_str().and_then(|status| status.parse().ok()))
+        .filter(|status| (400..=599).contains(status))
 }
 
 #[cfg(test)]

--- a/crates/aion-providers/src/error_test.rs
+++ b/crates/aion-providers/src/error_test.rs
@@ -77,6 +77,16 @@ mod json_error_body_tests {
     }
 
     #[test]
+    fn null_error_field_is_not_mapped_to_an_error() {
+        // Normal 200 bodies from some gateways carry `"error": null`; they
+        // must pass through untouched on both the transport and SSE paths.
+        let body_text = r#"{"error":null,"choices":[{"message":{"content":"hi"}}]}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+
+        assert!(provider_error_from_json_body(&body, body_text.as_bytes()).is_none());
+    }
+
+    #[test]
     fn rate_limit_status_maps_to_rate_limited_with_body() {
         let body_text = r#"{"error":{"code":429,"message":"quota exceeded"}}"#;
         let body = serde_json::from_str(body_text).expect("test body should be valid JSON");

--- a/crates/aion-providers/src/error_test.rs
+++ b/crates/aion-providers/src/error_test.rs
@@ -24,3 +24,68 @@ mod retryable_tests {
         assert!(ProviderError::Connection("x".into()).is_retryable());
     }
 }
+
+#[cfg(test)]
+mod json_error_body_tests {
+    use super::*;
+
+    #[test]
+    fn json_top_level_error_shape_is_normalized() {
+        let body_text = r#"{"code":"503","message":"upstream busy"}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+        let error =
+            provider_error_from_json_body(&body, body_text.as_bytes()).expect("status 503 should map to an error");
+
+        assert!(matches!(
+            error,
+            ProviderError::Api { status: 503, message } if message == "upstream busy"
+        ));
+    }
+
+    #[test]
+    fn json_error_uses_http_status_when_provider_code_is_not_http() {
+        let body_text = r#"{"error":{"code":1001,"message":"upstream busy"},"status":503}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+        let error =
+            provider_error_from_json_body(&body, body_text.as_bytes()).expect("status 503 should map to an error");
+
+        assert!(matches!(
+            error,
+            ProviderError::Api { status: 503, message } if message == "upstream busy"
+        ));
+    }
+
+    #[test]
+    fn json_without_error_shape_is_not_mapped_to_an_error() {
+        let body_text = r#"{"choices":[]}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+
+        assert!(provider_error_from_json_body(&body, body_text.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn json_error_without_http_status_is_a_parse_error() {
+        let body_text = r#"{"error":{"code":"resource_exhausted","message":"upstream busy"}}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+        let error =
+            provider_error_from_json_body(&body, body_text.as_bytes()).expect("explicit error should be surfaced");
+
+        assert!(matches!(
+            error,
+            ProviderError::Parse(message) if message.contains("without an HTTP status")
+        ));
+    }
+
+    #[test]
+    fn rate_limit_status_maps_to_rate_limited_with_body() {
+        let body_text = r#"{"error":{"code":429,"message":"quota exceeded"}}"#;
+        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
+        let error =
+            provider_error_from_json_body(&body, body_text.as_bytes()).expect("status 429 should map to an error");
+
+        assert!(matches!(
+            error,
+            ProviderError::RateLimited { body: Some(body), .. } if body == body_text
+        ));
+    }
+}

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -162,11 +162,13 @@ pub(crate) fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id:
     let delta = &choice["delta"];
 
     // Reasoning content (OpenAI reasoning models). Some OpenAI-compatible
-    // gateways stream it under `reasoning` instead of `reasoning_content`.
+    // gateways stream it under `reasoning` instead of `reasoning_content`,
+    // and some send an empty `reasoning_content` placeholder alongside the
+    // real `reasoning` payload — an empty field must not shadow the other.
     if let Some(reasoning) = delta["reasoning_content"]
         .as_str()
-        .or_else(|| delta["reasoning"].as_str())
-        && !reasoning.is_empty()
+        .filter(|text| !text.is_empty())
+        .or_else(|| delta["reasoning"].as_str().filter(|text| !text.is_empty()))
     {
         events.push(LlmEvent::ThinkingDelta(reasoning.to_string()));
     }

--- a/crates/aion-providers/src/openai.rs
+++ b/crates/aion-providers/src/openai.rs
@@ -8,6 +8,7 @@ use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{StopReason, TokenUsage};
 
 use crate::composed::ComposedProvider;
+use crate::error::provider_error_from_json_body;
 use crate::openai_messages::generate_call_id;
 use crate::stream_diagnostics::{OpenAiStreamDiagnostics, StreamTermination};
 use crate::transport::{OpenAiTransport, ProviderTransport};
@@ -51,6 +52,10 @@ pub(crate) struct StreamState {
     /// Deferred Done event: populated when finish_reason arrives, emitted on
     /// [DONE] so the final usage-only chunk has a chance to update token counts.
     pending_done: Option<LlmEvent>,
+    /// Error payload carried inside a data frame of a 200-status stream
+    /// (e.g. `data: {"error": ...}`); the stream processor fails the stream
+    /// with it instead of letting the turn end as an empty success.
+    stream_error: Option<ProviderError>,
 }
 
 impl StreamState {
@@ -62,7 +67,13 @@ impl StreamState {
             cache_read_tokens: 0,
             diagnostics: OpenAiStreamDiagnostics::default(),
             pending_done: None,
+            stream_error: None,
         }
+    }
+
+    /// Take the provider error recorded from an in-stream error frame, if any.
+    pub(crate) fn take_stream_error(&mut self) -> Option<ProviderError> {
+        self.stream_error.take()
     }
 
     /// Emit the deferred Done event with up-to-date token counts.
@@ -120,6 +131,18 @@ pub(crate) fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id:
     };
     state.diagnostics.observe_json(&json);
 
+    // Some gateways deliver terminal errors as a data frame in a 200-status
+    // stream (`data: {"error": ...}`). Record the error so the stream
+    // processor fails the stream instead of producing an empty outcome.
+    if json.get("error").is_some_and(|error| !error.is_null()) {
+        state.stream_error = Some(
+            provider_error_from_json_body(&json, data.as_bytes()).unwrap_or_else(|| {
+                ProviderError::Parse("Provider returned an error payload inside a successful stream".to_string())
+            }),
+        );
+        return events;
+    }
+
     // Extract usage if present
     if let Some(usage) = json.get("usage") {
         state.input_tokens = usage["prompt_tokens"].as_u64().unwrap_or(state.input_tokens);
@@ -138,8 +161,11 @@ pub(crate) fn parse_sse_chunk(data: &str, state: &mut StreamState, auto_tool_id:
 
     let delta = &choice["delta"];
 
-    // Reasoning content (OpenAI reasoning models)
-    if let Some(reasoning) = delta["reasoning_content"].as_str()
+    // Reasoning content (OpenAI reasoning models). Some OpenAI-compatible
+    // gateways stream it under `reasoning` instead of `reasoning_content`.
+    if let Some(reasoning) = delta["reasoning_content"]
+        .as_str()
+        .or_else(|| delta["reasoning"].as_str())
         && !reasoning.is_empty()
     {
         events.push(LlmEvent::ThinkingDelta(reasoning.to_string()));

--- a/crates/aion-providers/src/openai_test.rs
+++ b/crates/aion-providers/src/openai_test.rs
@@ -326,6 +326,21 @@ mod tests {
     }
 
     #[test]
+    fn empty_reasoning_content_placeholder_does_not_shadow_reasoning() {
+        // Some gateways send `reasoning_content: ""` in every chunk alongside
+        // the real `reasoning` payload; the empty placeholder must not
+        // short-circuit the fallback.
+        let mut state = StreamState::new();
+
+        let chunk =
+            r#"{"choices":[{"delta":{"reasoning_content":"","reasoning":"real thinking"},"finish_reason":null}]}"#;
+        let events = parse_sse_chunk(chunk, &mut state, false);
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], LlmEvent::ThinkingDelta(text) if text == "real thinking"));
+    }
+
+    #[test]
     fn reasoning_content_takes_precedence_over_reasoning() {
         let mut state = StreamState::new();
 

--- a/crates/aion-providers/src/openai_test.rs
+++ b/crates/aion-providers/src/openai_test.rs
@@ -265,4 +265,75 @@ mod tests {
             assert!(id.is_empty(), "id should remain empty when auto_tool_id is disabled");
         }
     }
+
+    // --- in-stream error frames ---
+
+    #[test]
+    fn error_frame_is_recorded_and_emits_no_events() {
+        let mut state = StreamState::new();
+
+        let chunk = r#"{"error":{"code":500,"message":"upstream exploded"}}"#;
+        let events = parse_sse_chunk(chunk, &mut state, false);
+
+        assert!(events.is_empty());
+        let error = state.take_stream_error().expect("error frame should be recorded");
+        assert!(matches!(
+            error,
+            ProviderError::Api { status: 500, message } if message == "upstream exploded"
+        ));
+        assert!(state.take_stream_error().is_none(), "take should consume the error");
+    }
+
+    #[test]
+    fn error_frame_without_status_is_recorded_as_parse_error() {
+        let mut state = StreamState::new();
+
+        let chunk = r#"{"error":{"message":"upstream exploded"}}"#;
+        let events = parse_sse_chunk(chunk, &mut state, false);
+
+        assert!(events.is_empty());
+        assert!(matches!(
+            state.take_stream_error().expect("error frame should be recorded"),
+            ProviderError::Parse(_)
+        ));
+    }
+
+    #[test]
+    fn null_error_field_is_not_treated_as_an_error() {
+        // Some gateways include `"error": null` in normal chunks.
+        let mut state = StreamState::new();
+
+        let chunk = r#"{"error":null,"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#;
+        let events = parse_sse_chunk(chunk, &mut state, false);
+
+        assert!(matches!(&events[0], LlmEvent::TextDelta(text) if text == "hi"));
+        assert!(state.take_stream_error().is_none());
+    }
+
+    // --- reasoning field compatibility ---
+
+    #[test]
+    fn reasoning_field_is_mapped_to_thinking_delta() {
+        // OpenAI-compatible gateways may stream reasoning under `reasoning`
+        // instead of `reasoning_content`.
+        let mut state = StreamState::new();
+
+        let chunk = r#"{"choices":[{"delta":{"reasoning":"thinking..."},"finish_reason":null}]}"#;
+        let events = parse_sse_chunk(chunk, &mut state, false);
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], LlmEvent::ThinkingDelta(text) if text == "thinking..."));
+    }
+
+    #[test]
+    fn reasoning_content_takes_precedence_over_reasoning() {
+        let mut state = StreamState::new();
+
+        let chunk =
+            r#"{"choices":[{"delta":{"reasoning_content":"primary","reasoning":"secondary"},"finish_reason":null}]}"#;
+        let events = parse_sse_chunk(chunk, &mut state, false);
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], LlmEvent::ThinkingDelta(text) if text == "primary"));
+    }
 }

--- a/crates/aion-providers/src/parser.rs
+++ b/crates/aion-providers/src/parser.rs
@@ -51,8 +51,10 @@ impl ResponseParser for OpenAiParser {
         }
     }
 
-    fn finish(&self, _state: &mut Self::State) -> Vec<LlmEvent> {
-        Vec::new()
+    /// Flush the deferred Done at EOF so gateways that send `finish_reason`
+    /// but never a `[DONE]` sentinel still terminate the turn cleanly.
+    fn finish(&self, state: &mut Self::State) -> Vec<LlmEvent> {
+        state.flush_done().into_iter().collect()
     }
 }
 

--- a/crates/aion-providers/src/stream_diagnostics.rs
+++ b/crates/aion-providers/src/stream_diagnostics.rs
@@ -55,8 +55,10 @@ impl FinishReasonKind {
 pub(crate) enum StreamTermination {
     Done,
     Eof,
+    EofWithoutTerminal,
     ConsumerDropped,
     ConnectionError,
+    ProviderError,
 }
 
 impl StreamTermination {
@@ -64,8 +66,10 @@ impl StreamTermination {
         match self {
             Self::Done => "done",
             Self::Eof => "eof",
+            Self::EofWithoutTerminal => "eof_without_terminal",
             Self::ConsumerDropped => "consumer_dropped",
             Self::ConnectionError => "connection_error",
+            Self::ProviderError => "provider_error",
         }
     }
 }

--- a/crates/aion-providers/src/stream_process.rs
+++ b/crates/aion-providers/src/stream_process.rs
@@ -128,6 +128,7 @@ pub(crate) async fn process_openai_sse_stream(
     let mut decoder = Utf8StreamDecoder::default();
     let mut stream = response.bytes_stream();
     let mut emitted_content = false;
+    let mut emitted_done = false;
 
     while let Some(chunk) = stream.next().await {
         let chunk = match chunk {
@@ -162,6 +163,14 @@ pub(crate) async fn process_openai_sse_stream(
                     return StreamOutcome::Ok;
                 }
             }
+            if let Some(error) = state.take_stream_error() {
+                state.emit_diagnostics(StreamTermination::ProviderError, started_at.elapsed());
+                return if emitted_content {
+                    StreamOutcome::FailedPartial(error)
+                } else {
+                    StreamOutcome::FailedEmpty(error)
+                };
+            }
             if is_done {
                 state.emit_diagnostics(StreamTermination::Done, started_at.elapsed());
                 return StreamOutcome::Ok;
@@ -177,10 +186,24 @@ pub(crate) async fn process_openai_sse_stream(
         let events = parser.parse_frame(&frame, &mut state);
         for event in events {
             state.diagnostics_mut().observe_event(&event);
+            if matches!(
+                event,
+                LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
+            ) {
+                emitted_content = true;
+            }
             if tx.send(event).await.is_err() {
                 state.emit_diagnostics(StreamTermination::ConsumerDropped, started_at.elapsed());
                 return StreamOutcome::Ok;
             }
+        }
+        if let Some(error) = state.take_stream_error() {
+            state.emit_diagnostics(StreamTermination::ProviderError, started_at.elapsed());
+            return if emitted_content {
+                StreamOutcome::FailedPartial(error)
+            } else {
+                StreamOutcome::FailedEmpty(error)
+            };
         }
         if is_done {
             state.emit_diagnostics(StreamTermination::Done, started_at.elapsed());
@@ -188,16 +211,34 @@ pub(crate) async fn process_openai_sse_stream(
         }
     }
 
+    // `finish` flushes the deferred Done for gateways that send a
+    // finish_reason but no [DONE] sentinel.
     for event in parser.finish(&mut state) {
         state.diagnostics_mut().observe_event(&event);
+        if matches!(event, LlmEvent::Done { .. }) {
+            emitted_done = true;
+        }
         if tx.send(event).await.is_err() {
             state.emit_diagnostics(StreamTermination::ConsumerDropped, started_at.elapsed());
             return StreamOutcome::Ok;
         }
     }
 
-    state.emit_diagnostics(StreamTermination::Eof, started_at.elapsed());
-    StreamOutcome::Ok
+    if emitted_done {
+        state.emit_diagnostics(StreamTermination::Eof, started_at.elapsed());
+        return StreamOutcome::Ok;
+    }
+
+    // EOF without any terminal signal: the stream was cut off. Fail it so the
+    // runner can retry (empty) or surface an error (partial) instead of
+    // reporting an empty successful turn.
+    let error = ProviderError::Connection("OpenAI stream ended without a terminal event".to_string());
+    state.emit_diagnostics(StreamTermination::EofWithoutTerminal, started_at.elapsed());
+    if emitted_content {
+        StreamOutcome::FailedPartial(error)
+    } else {
+        StreamOutcome::FailedEmpty(error)
+    }
 }
 
 pub(crate) async fn process_anthropic_sse_stream(

--- a/crates/aion-providers/src/stream_process.rs
+++ b/crates/aion-providers/src/stream_process.rs
@@ -7,6 +7,7 @@ use aion_types::message::{StopReason, TokenUsage};
 
 use crate::error::ProviderError;
 use crate::framing::{FrameKind, SseBlockFramer, SseLineFramer, Utf8StreamDecoder, bedrock_payload_to_frame};
+use crate::openai::StreamState as OpenAiStreamState;
 use crate::parser::{AnthropicParser, OpenAiParser, OpenAiResponsesParser, ResponseParser};
 use crate::stream_diagnostics::StreamTermination;
 use crate::stream_runner::StreamOutcome;
@@ -111,6 +112,27 @@ pub(crate) async fn process_openai_responses_sse_stream(
     }
 }
 
+/// Pick the failure outcome for a broken stream: retryable when no answer
+/// content reached the consumer, terminal otherwise.
+fn failed_stream_outcome(emitted_answer: bool, error: ProviderError) -> StreamOutcome {
+    if emitted_answer {
+        StreamOutcome::FailedPartial(error)
+    } else {
+        StreamOutcome::FailedEmpty(error)
+    }
+}
+
+/// Fail the stream if the parser recorded an in-stream error frame.
+fn take_openai_stream_failure(
+    state: &mut OpenAiStreamState,
+    emitted_answer: bool,
+    started_at: Instant,
+) -> Option<StreamOutcome> {
+    let error = state.take_stream_error()?;
+    state.emit_diagnostics(StreamTermination::ProviderError, started_at.elapsed());
+    Some(failed_stream_outcome(emitted_answer, error))
+}
+
 pub(crate) async fn process_openai_sse_stream(
     response: reqwest::Response,
     tx: &mpsc::Sender<LlmEvent>,
@@ -127,7 +149,9 @@ pub(crate) async fn process_openai_sse_stream(
     let mut framer = SseLineFramer::default();
     let mut decoder = Utf8StreamDecoder::default();
     let mut stream = response.bytes_stream();
-    let mut emitted_content = false;
+    // Only visible answer content (text/tool calls) blocks a stream retry;
+    // a turn that produced nothing but reasoning deltas is safe to re-run.
+    let mut emitted_answer = false;
     let mut emitted_done = false;
 
     while let Some(chunk) = stream.next().await {
@@ -135,13 +159,8 @@ pub(crate) async fn process_openai_sse_stream(
             Ok(c) => c,
             Err(e) => {
                 let err = ProviderError::Connection(e.to_string());
-                let outcome = if emitted_content {
-                    StreamOutcome::FailedPartial(err)
-                } else {
-                    StreamOutcome::FailedEmpty(err)
-                };
                 state.emit_diagnostics(StreamTermination::ConnectionError, started_at.elapsed());
-                return outcome;
+                return failed_stream_outcome(emitted_answer, err);
             }
         };
         state.diagnostics_mut().observe_network_chunk(chunk.len());
@@ -152,24 +171,16 @@ pub(crate) async fn process_openai_sse_stream(
             let events = parser.parse_frame(&frame, &mut state);
             for event in events {
                 state.diagnostics_mut().observe_event(&event);
-                if matches!(
-                    event,
-                    LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
-                ) {
-                    emitted_content = true;
+                if matches!(event, LlmEvent::TextDelta(_) | LlmEvent::ToolUse { .. }) {
+                    emitted_answer = true;
                 }
                 if tx.send(event).await.is_err() {
                     state.emit_diagnostics(StreamTermination::ConsumerDropped, started_at.elapsed());
                     return StreamOutcome::Ok;
                 }
             }
-            if let Some(error) = state.take_stream_error() {
-                state.emit_diagnostics(StreamTermination::ProviderError, started_at.elapsed());
-                return if emitted_content {
-                    StreamOutcome::FailedPartial(error)
-                } else {
-                    StreamOutcome::FailedEmpty(error)
-                };
+            if let Some(outcome) = take_openai_stream_failure(&mut state, emitted_answer, started_at) {
+                return outcome;
             }
             if is_done {
                 state.emit_diagnostics(StreamTermination::Done, started_at.elapsed());
@@ -186,24 +197,16 @@ pub(crate) async fn process_openai_sse_stream(
         let events = parser.parse_frame(&frame, &mut state);
         for event in events {
             state.diagnostics_mut().observe_event(&event);
-            if matches!(
-                event,
-                LlmEvent::TextDelta(_) | LlmEvent::ThinkingDelta(_) | LlmEvent::ToolUse { .. }
-            ) {
-                emitted_content = true;
+            if matches!(event, LlmEvent::TextDelta(_) | LlmEvent::ToolUse { .. }) {
+                emitted_answer = true;
             }
             if tx.send(event).await.is_err() {
                 state.emit_diagnostics(StreamTermination::ConsumerDropped, started_at.elapsed());
                 return StreamOutcome::Ok;
             }
         }
-        if let Some(error) = state.take_stream_error() {
-            state.emit_diagnostics(StreamTermination::ProviderError, started_at.elapsed());
-            return if emitted_content {
-                StreamOutcome::FailedPartial(error)
-            } else {
-                StreamOutcome::FailedEmpty(error)
-            };
+        if let Some(outcome) = take_openai_stream_failure(&mut state, emitted_answer, started_at) {
+            return outcome;
         }
         if is_done {
             state.emit_diagnostics(StreamTermination::Done, started_at.elapsed());
@@ -230,15 +233,11 @@ pub(crate) async fn process_openai_sse_stream(
     }
 
     // EOF without any terminal signal: the stream was cut off. Fail it so the
-    // runner can retry (empty) or surface an error (partial) instead of
-    // reporting an empty successful turn.
+    // runner can retry (no answer content) or surface an error (partial
+    // answer) instead of reporting an empty successful turn.
     let error = ProviderError::Connection("OpenAI stream ended without a terminal event".to_string());
     state.emit_diagnostics(StreamTermination::EofWithoutTerminal, started_at.elapsed());
-    if emitted_content {
-        StreamOutcome::FailedPartial(error)
-    } else {
-        StreamOutcome::FailedEmpty(error)
-    }
+    failed_stream_outcome(emitted_answer, error)
 }
 
 pub(crate) async fn process_anthropic_sse_stream(

--- a/crates/aion-providers/src/stream_process_test.rs
+++ b/crates/aion-providers/src/stream_process_test.rs
@@ -207,6 +207,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn openai_sse_stream_cut_off_after_reasoning_only_fails_empty() {
+        // Thinking deltas alone must not block a retry: no answer content
+        // reached the consumer, so the cut-off stream is safe to re-run.
+        let reasoning = json!({
+            "choices": [{
+                "delta": {"reasoning_content": "pondering"},
+                "finish_reason": null
+            }]
+        });
+        let response = mock_response(format!("data: {reasoning}\n\n").into_bytes()).await;
+        let (tx, rx) = mpsc::channel(8);
+
+        let outcome = process_openai_sse_stream(response, &tx, false).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], LlmEvent::ThinkingDelta(text) if text == "pondering"));
+        assert!(matches!(
+            outcome,
+            StreamOutcome::FailedEmpty(ProviderError::Connection(_))
+        ));
+    }
+
+    #[tokio::test]
     async fn openai_sse_stream_embedded_error_frame_fails_empty() {
         let error = json!({
             "error": {"code": 500, "message": "upstream exploded"}

--- a/crates/aion-providers/src/stream_process_test.rs
+++ b/crates/aion-providers/src/stream_process_test.rs
@@ -143,7 +143,13 @@ mod tests {
         let summary = provider_stream_summary(&writer);
 
         assert!(matches!(outcome, StreamOutcome::Ok));
-        assert_eq!(events.len(), 1);
+        // The deferred Done is flushed at EOF, so the turn terminates cleanly
+        // with the usage from the finish_reason chunk.
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[1],
+            LlmEvent::Done { stop_reason: StopReason::EndTurn, usage } if usage.input_tokens == 12
+        ));
         assert_eq!(summary["level"], "WARN");
         assert_eq!(summary["fields"]["termination"], "eof");
         assert_eq!(summary["fields"]["done_seen"], false);
@@ -151,6 +157,98 @@ mod tests {
         assert_eq!(summary["fields"]["empty_answer"], false);
         assert_eq!(summary["fields"]["malformed_json"], false);
         assert_eq!(summary["fields"]["unexpected_finish_reason"], false);
+    }
+
+    #[tokio::test]
+    async fn openai_sse_stream_without_terminal_event_fails_empty() {
+        let content = json!({
+            "choices": [{
+                "delta": {},
+                "finish_reason": null
+            }]
+        });
+        let response = mock_response(format!("data: {content}\n\n").into_bytes()).await;
+        let (tx, rx) = mpsc::channel(8);
+
+        let outcome = process_openai_sse_stream(response, &tx, false).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+
+        assert!(events.is_empty());
+        assert!(matches!(
+            outcome,
+            StreamOutcome::FailedEmpty(ProviderError::Connection(message))
+                if message.contains("without a terminal event")
+        ));
+    }
+
+    #[tokio::test]
+    async fn openai_sse_stream_cut_off_after_content_fails_partial() {
+        let content = json!({
+            "choices": [{
+                "delta": {"content": "Hel"},
+                "finish_reason": null
+            }]
+        });
+        let response = mock_response(format!("data: {content}\n\n").into_bytes()).await;
+        let (tx, rx) = mpsc::channel(8);
+
+        let outcome = process_openai_sse_stream(response, &tx, false).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], LlmEvent::TextDelta(text) if text == "Hel"));
+        assert!(matches!(
+            outcome,
+            StreamOutcome::FailedPartial(ProviderError::Connection(message))
+                if message.contains("without a terminal event")
+        ));
+    }
+
+    #[tokio::test]
+    async fn openai_sse_stream_embedded_error_frame_fails_empty() {
+        let error = json!({
+            "error": {"code": 500, "message": "upstream exploded"}
+        });
+        let response = mock_response(format!("data: {error}\n\ndata: [DONE]\n\n").into_bytes()).await;
+        let (tx, rx) = mpsc::channel(8);
+
+        let outcome = process_openai_sse_stream(response, &tx, false).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+
+        assert!(events.is_empty());
+        assert!(matches!(
+            outcome,
+            StreamOutcome::FailedEmpty(ProviderError::Api { status: 500, message })
+                if message == "upstream exploded"
+        ));
+    }
+
+    #[tokio::test]
+    async fn openai_sse_stream_embedded_error_after_content_fails_partial() {
+        let content = json!({
+            "choices": [{
+                "delta": {"content": "Hel"},
+                "finish_reason": null
+            }]
+        });
+        let error = json!({
+            "error": {"code": 500, "message": "upstream exploded"}
+        });
+        let response = mock_response(format!("data: {content}\n\ndata: {error}\n\n").into_bytes()).await;
+        let (tx, rx) = mpsc::channel(8);
+
+        let outcome = process_openai_sse_stream(response, &tx, false).await;
+        drop(tx);
+        let events = collect_events(rx).await;
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            outcome,
+            StreamOutcome::FailedPartial(ProviderError::Api { status: 500, .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/aion-providers/src/transport.rs
+++ b/crates/aion-providers/src/transport.rs
@@ -6,7 +6,7 @@ use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde_json::Value;
 
 use crate::bedrock::BedrockTransportState;
-use crate::error::ProviderError;
+use crate::error::{ProviderError, provider_error_from_json_body};
 use crate::openai_responses_projector::OpenAiResponsesProjector;
 use crate::projector::{
     AnthropicWireProjector, OpenAiProjector, ResolvedToolWireShape, WireParams, WireProvider,
@@ -345,7 +345,7 @@ async fn inspect_success_json_response(
     }
 
     if let Ok(body) = serde_json::from_slice::<Value>(&body_bytes)
-        && let Some(error) = map_success_json_error(&body, &body_bytes)
+        && let Some(error) = provider_error_from_json_body(&body, &body_bytes)
     {
         let provider_status = provider_error_status(&error);
         tracing::warn!(
@@ -357,40 +357,6 @@ async fn inspect_success_json_response(
     }
 
     rebuild_response(status, version, headers, url, body_bytes)
-}
-
-fn map_success_json_error(body: &Value, body_bytes: &[u8]) -> Option<ProviderError> {
-    let error = body.get("error").unwrap_or(body);
-    let status = [
-        error.get("code"),
-        error.get("status"),
-        body.get("code"),
-        body.get("status"),
-    ]
-    .into_iter()
-    .flatten()
-    .find_map(json_http_status_code);
-    let message = error
-        .get("message")
-        .and_then(Value::as_str)
-        .or_else(|| error.as_str())
-        .or_else(|| body.get("message").and_then(Value::as_str))
-        .map(str::trim)
-        .filter(|message| !message.is_empty())
-        .unwrap_or("Provider returned a JSON error response without a message")
-        .to_string();
-
-    match status {
-        Some(429) => Some(ProviderError::RateLimited {
-            retry_after_ms: 5000,
-            body: (!body_bytes.is_empty()).then(|| String::from_utf8_lossy(body_bytes).into_owned()),
-        }),
-        Some(status) => Some(ProviderError::Api { status, message }),
-        None if body.get("error").is_some() => Some(ProviderError::Parse(format!(
-            "Provider returned a JSON error response without an HTTP status: {message}"
-        ))),
-        None => None,
-    }
 }
 
 fn rebuild_response<B>(
@@ -411,14 +377,6 @@ where
         .map_err(|error| ProviderError::Connection(format!("Failed to preserve provider response: {error}")))?;
     *response.headers_mut() = headers;
     Ok(reqwest::Response::from(response))
-}
-
-fn json_http_status_code(value: &Value) -> Option<u16> {
-    value
-        .as_u64()
-        .and_then(|status| u16::try_from(status).ok())
-        .or_else(|| value.as_str().and_then(|status| status.parse().ok()))
-        .filter(|status| (400..=599).contains(status))
 }
 
 fn provider_error_status(error: &ProviderError) -> Option<u16> {

--- a/crates/aion-providers/src/transport_test.rs
+++ b/crates/aion-providers/src/transport_test.rs
@@ -379,6 +379,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn openai_transport_preserves_successful_json_with_null_error_field() {
+        let server = MockServer::start().await;
+        let response_body = json!({
+            "error": null,
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "hello"
+                },
+                "finish_reason": "stop"
+            }]
+        });
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&server)
+            .await;
+        let transport = ProviderTransport::OpenAi(OpenAiTransport::new("test-key", &server.uri()));
+        let compat = ProviderCompat::openai_defaults();
+        let (body, tool_wire_shape) = transport
+            .project_body(&test_request(vec![]), &compat)
+            .expect("request body projection should succeed");
+        let request = transport
+            .build_projected_request("test-model", body, &compat, tool_wire_shape)
+            .expect("projected request should build");
+
+        let response = transport
+            .send(request)
+            .await
+            .expect("a null error field must not fail a successful response");
+
+        assert_eq!(
+            response
+                .json::<Value>()
+                .await
+                .expect("preserved response should remain valid JSON"),
+            response_body
+        );
+    }
+
+    #[tokio::test]
     async fn openai_transport_preserves_large_successful_json_response() {
         let server = MockServer::start().await;
         let response_body = json!({

--- a/crates/aion-providers/src/transport_test.rs
+++ b/crates/aion-providers/src/transport_test.rs
@@ -418,50 +418,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn successful_json_top_level_error_shape_is_normalized() {
-        let body_text = r#"{"code":"503","message":"upstream busy"}"#;
-        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
-        let error = map_success_json_error(&body, body_text.as_bytes()).expect("status 503 should map to an error");
-
-        assert!(matches!(
-            error,
-            ProviderError::Api { status: 503, message } if message == "upstream busy"
-        ));
-    }
-
-    #[test]
-    fn successful_json_uses_http_status_when_provider_code_is_not_http() {
-        let body_text = r#"{"error":{"code":1001,"message":"upstream busy"},"status":503}"#;
-        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
-        let error = map_success_json_error(&body, body_text.as_bytes()).expect("status 503 should map to an error");
-
-        assert!(matches!(
-            error,
-            ProviderError::Api { status: 503, message } if message == "upstream busy"
-        ));
-    }
-
-    #[test]
-    fn successful_json_without_error_shape_is_not_mapped_to_an_error() {
-        let body_text = r#"{"choices":[]}"#;
-        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
-
-        assert!(map_success_json_error(&body, body_text.as_bytes()).is_none());
-    }
-
-    #[test]
-    fn successful_json_error_without_http_status_is_a_parse_error() {
-        let body_text = r#"{"error":{"code":"resource_exhausted","message":"upstream busy"}}"#;
-        let body = serde_json::from_str(body_text).expect("test body should be valid JSON");
-        let error = map_success_json_error(&body, body_text.as_bytes()).expect("explicit error should be surfaced");
-
-        assert!(matches!(
-            error,
-            ProviderError::Parse(message) if message.contains("without an HTTP status")
-        ));
-    }
-
     #[tokio::test]
     async fn openai_transport_preserves_429_body_as_none_when_empty() {
         let server = MockServer::start().await;


### PR DESCRIPTION
## Summary

- **Chat Completions SSE streams no longer swallow embedded errors**: a `data: {"error": ...}` frame in a 200-status stream is now mapped to a `ProviderError` (via the JSON error mapping shared with the transport layer, moved to `error.rs`) and fails the stream as `FailedEmpty` (retryable) or `FailedPartial`, instead of ending the turn as an empty success.
- **Streams cut off before any terminal event now fail like the Responses path**: EOF without `[DONE]`/finish_reason returns `FailedEmpty`/`FailedPartial` so the runner can retry or surface an error. The deferred Done is flushed at EOF first, so gateways that send `finish_reason` but never a `[DONE]` sentinel still terminate cleanly — and now with correct usage instead of zeros.
- **The first empty-final retry keeps tools available**: models that emit the intended tool call inside reasoning content (empty visible answer, `finish_reason=stop`) get one corrective normal turn to re-issue the tool call properly; the tool-less finalization + fallback only kicks in on a second empty final.
- Reasoning deltas under the `reasoning` field (used by some OpenAI-compatible gateways instead of `reasoning_content`) are now mapped to thinking content instead of being dropped.
- New stream-diagnostics terminations `eof_without_terminal` and `provider_error` make these paths observable.

## Why

Reported empty-response failures reproduce in two ways: a low-quality model writing its tool call into reasoning content with empty visible text, and gateways returning HTTP 200 with the error wrapped in the response body / SSE stream. Both funneled into the same downstream path — a stream with no usable events defaulted to `EndTurn`, was classified as an empty final, and ended in the "finished without visible answer text" fallback.

## Non-goals

- Salvaging tool calls by parsing reasoning text (would need a `ProviderCompat` opt-in; tracked separately).
- Anthropic/Bedrock stream paths — they already handle in-stream error events.

## Test Plan

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — no warnings
- `cargo test --workspace` — all suites pass
- `just push` — full pipeline: **2251 tests run: 2251 passed, 2 skipped**, hakari verified
- New tests: in-stream error frames (empty/partial, with/without HTTP status, `"error": null` false-positive guard), EOF-without-terminal (empty/partial), deferred-Done flush at EOF with usage assertion, `reasoning` field mapping and precedence, and an engine integration test where a reasoning-only empty turn recovers through a real tool call on the tool-enabled retry.
- Updated 2 tests that encoded the old behavior (EOF summary event count; empty-final retry now a counted tool-enabled turn, finalization on the third call).

## Compatibility

No public API or protocol changes; `LlmProvider` trait untouched. aioncore consumes aionrs as a library and is unaffected beyond the improved runtime behavior. Previously silently-truncated partial streams now surface an explicit provider error instead of appearing successful.