### PR TITLE
fix(memory): truncate MEMORY.md index on UTF-8 char boundary

### DIFF
--- a/crates/aion-memory/src/index.rs
+++ b/crates/aion-memory/src/index.rs
@@ -82,11 +82,14 @@ pub fn truncate_index(raw: &str) -> IndexTruncation {
         trimmed.to_owned()
     };
 
-    // Step 2: byte truncation (on the possibly line-truncated result)
+    // Step 2: byte truncation (on the possibly line-truncated result).
+    // The cap may land inside a multi-byte UTF-8 char (e.g. CJK text), where
+    // both slicing and `String::truncate` panic — round down to a char
+    // boundary first.
     if truncated.len() > MAX_INDEX_BYTES {
-        let cut_at = truncated[..MAX_INDEX_BYTES].rfind('\n').filter(|&pos| pos > 0);
-        let boundary = cut_at.unwrap_or(MAX_INDEX_BYTES);
-        truncated.truncate(boundary);
+        let cap = truncated.floor_char_boundary(MAX_INDEX_BYTES);
+        let cut_at = truncated[..cap].rfind('\n').filter(|&pos| pos > 0);
+        truncated.truncate(cut_at.unwrap_or(cap));
     }
 
     // Build the warning message

--- a/crates/aion-memory/tests/index_integration.rs
+++ b/crates/aion-memory/tests/index_integration.rs
@@ -312,3 +312,51 @@ fn tc_5_18_remove_from_nonexistent() {
     // Should not error — idempotent
     index::remove_index_entry(path, "anything.md").unwrap();
 }
+
+// ===========================================================================
+// TC-5.19: Truncation — byte cap lands inside a multi-byte UTF-8 char,
+// single long line (no newline before the cap). Regression for issue #3882.
+// ===========================================================================
+
+#[test]
+fn tc_5_19_byte_cap_mid_multibyte_char_single_line() {
+    // One long line of 3-byte CJK chars, 30,000 bytes total. Byte 25,000
+    // falls inside a char (25000 % 3 == 1), which used to panic:
+    // "byte index 25000 is not a char boundary".
+    let content = "\u{56fa}".repeat(10_000);
+
+    let result = index::truncate_index(&content);
+
+    assert!(result.was_truncated);
+    let before_warning = result.content.split("\n\n> WARNING:").next().unwrap();
+    // Cut must land on a char boundary at or below the cap, keeping only
+    // whole chars from the input.
+    assert!(before_warning.len() <= index::MAX_INDEX_BYTES);
+    assert!(before_warning.chars().all(|c| c == '\u{56fa}'));
+    assert!(!before_warning.is_empty());
+}
+
+// ===========================================================================
+// TC-5.20: Truncation — byte cap lands inside a multi-byte UTF-8 char,
+// multi-line content (cut falls back to the last newline before the cap).
+// Regression for issue #3882.
+// ===========================================================================
+
+#[test]
+fn tc_5_20_byte_cap_mid_multibyte_char_multiline() {
+    // 200 lines of 43 CJK chars (129 bytes) each => 25,999 bytes total,
+    // within the line cap but over the byte cap. Byte 25,000 sits at
+    // offset 40 of line 193 (40 % 3 == 1), i.e. inside a char.
+    let line = "\u{56fa}".repeat(43);
+    let content = std::iter::repeat_n(line.as_str(), 200).collect::<Vec<_>>().join("\n");
+    assert_eq!(content.len(), 25_999);
+
+    let result = index::truncate_index(&content);
+
+    assert!(result.was_truncated);
+    let before_warning = result.content.split("\n\n> WARNING:").next().unwrap();
+    // Should cut at the last newline before the cap: 192 whole lines.
+    assert_eq!(before_warning.lines().count(), 192);
+    assert!(before_warning.len() <= index::MAX_INDEX_BYTES);
+    assert!(before_warning.lines().all(|l| l == line));
+}


### PR DESCRIPTION
## Summary

Fixes iOfficeAI/AionUi#3882.

`truncate_index()` sliced the MEMORY.md index content at the raw 25,000-byte cap (`&s[..MAX_INDEX_BYTES]`). When the cap lands inside a multi-byte UTF-8 character — very likely with CJK content, where every char is 3 bytes — the slice panics:

```
byte index 25000 is not a char boundary; it is inside '固' (bytes 24999..25002)
```

The memory prompt is built during agent bootstrap, so the panic kills the agent at session start. Host applications surface this as `409 TEAM_RUNTIME_NOT_READY`, and every subsequent start fails until the file is manually shrunk.

## Root cause

Byte-index slicing and `String::truncate` are not char-boundary-safe. The trigger condition is: index content (within the 200-line cap) exceeds 25,000 bytes AND byte 25,000 falls inside a multi-byte character.

## Fix

Round the cap down to a char boundary with `str::floor_char_boundary` before searching for the newline cut point:

```rust
let cap = truncated.floor_char_boundary(MAX_INDEX_BYTES);
let cut_at = truncated[..cap].rfind('\n').filter(|&pos| pos > 0);
truncated.truncate(cut_at.unwrap_or(cap));
```

One change covers both panic sites (the slice itself and the no-newline fallback `truncate`). Behavior is otherwise unchanged: still cuts at the last newline before the cap and appends the truncation warning.

## Test plan

- [x] TC-5.19: single long CJK line with no newline before the cap — deterministically reproduced the panic before the fix (RED), passes after (GREEN)
- [x] TC-5.20: 200 CJK lines, within the line cap but over the byte cap, byte 25,000 mid-character — exercises the last-newline cut path
- [x] Full `aion-memory` suite passes
- [x] `just push` gate green: fmt, clippy, full workspace tests (2263 passed), hakari verify

## Local end-to-end verification

- Reproduced the original panic on an unpatched build using a >25 KB CJK `MEMORY.md` engineered so byte 25,000 falls mid-character.
- Rebuilt a host application (AionUi dev environment) against this branch: agent bootstrap over the same file completed without panic, the session mounted normally, and the system prompt contained the expected truncation warning ("25.4 KB, limit 24.4 KB"), which the model referenced in its reply.