### PR TITLE
feat(session): support session forking with turn-anchored boundaries

### DIFF
--- a/crates/aion-agent/src/compact/micro_test.rs
+++ b/crates/aion-agent/src/compact/micro_test.rs
@@ -42,6 +42,7 @@ mod tests {
             role: Role::Assistant,
             content: blocks,
             timestamp: Some(ts),
+            turn_id: None,
         }
     }
 

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -48,6 +48,7 @@ use chrono::Utc;
 use serde_json::to_string;
 use tokio::sync::mpsc::Receiver;
 use tracing::{Instrument, debug, error, info, info_span, warn};
+use uuid::Uuid;
 
 #[derive(Debug)]
 pub struct AgentResult {
@@ -86,6 +87,14 @@ pub struct AgentEngine {
     total_usage: TokenUsage,
     /// Output message ID for the currently streaming run.
     msg_id: String,
+    /// Turn id for the NEXT run, supplied by the host (e.g. AionCore passes
+    /// its conversation-layer turn id so DB rows and session messages share
+    /// one anchor). Consumed by `run_inner`; when absent a fresh id is minted.
+    pending_turn_id: Option<String>,
+    /// Turn id of the current (or most recently finished) run. Stamped on
+    /// every message appended via `push_history`, including late
+    /// `abort_current_turn` tool results.
+    current_turn_id: Option<String>,
     /// Maximum output tokens requested from the provider per turn.
     max_tokens: Option<u32>,
     /// Optional cap on counted model turns within a single run.
@@ -199,6 +208,8 @@ impl AgentEngine {
             messages: Vec::new(),
             total_usage: TokenUsage::default(),
             msg_id: String::new(),
+            pending_turn_id: None,
+            current_turn_id: None,
             max_turns_per_run: config.max_turns,
             max_tool_call_malformed_turns: config
                 .max_tool_call_malformed_turns
@@ -294,6 +305,8 @@ impl AgentEngine {
             messages: session.messages.clone(),
             total_usage: session.total_usage.clone(),
             msg_id: String::new(),
+            pending_turn_id: None,
+            current_turn_id: None,
             max_turns_per_run: config.max_turns,
             max_tool_call_malformed_turns: config
                 .max_tool_call_malformed_turns
@@ -459,12 +472,37 @@ impl AgentEngine {
         self.run_inner(content_blocks, msg_id).instrument(span).await
     }
 
+    /// Set the turn id for the NEXT run. Hosts that mint their own turn ids
+    /// (e.g. AionCore) pass them in so the session-side anchor matches their
+    /// message store; without a pending id the engine mints one per run.
+    pub fn set_next_turn_id(&mut self, turn_id: Option<String>) {
+        self.pending_turn_id = turn_id;
+    }
+
+    /// Turn id of the current (or most recently finished) run.
+    pub fn current_turn_id(&self) -> Option<&str> {
+        self.current_turn_id.as_deref()
+    }
+
+    /// Append a message to the conversation history, stamped with the
+    /// current run's turn id (the session-side fork anchor).
+    fn push_history(&mut self, role: Role, content: Vec<ContentBlock>) {
+        let mut message = Message::now(role, content);
+        message.turn_id = self.current_turn_id.clone();
+        self.messages.push(message);
+    }
+
     async fn run_inner(&mut self, content_blocks: Vec<ContentBlock>, msg_id: &str) -> Result<AgentResult, AgentError> {
         self.msg_id = msg_id.to_string();
+        self.current_turn_id = Some(
+            self.pending_turn_id
+                .take()
+                .unwrap_or_else(|| Uuid::now_v7().to_string()),
+        );
         self.output.emit_stream_start(msg_id);
 
         let user_tokens = estimate_content_tokens(&content_blocks);
-        self.messages.push(Message::now(Role::User, content_blocks));
+        self.push_history(Role::User, content_blocks);
         self.record_local_context_addition(user_tokens);
         self.save_session();
 
@@ -495,13 +533,13 @@ impl AgentEngine {
             let tool_calls = match TurnOutcome::from_stream(outcome) {
                 TurnOutcome::ToolRound(outcome) => {
                     let assistant_content = build_assistant_content(&outcome);
-                    self.messages.push(Message::now(Role::Assistant, assistant_content));
+                    self.push_history(Role::Assistant, assistant_content);
                     self.save_session();
                     outcome.tool_calls
                 }
                 TurnOutcome::Final(outcome) => {
                     let assistant_content = build_assistant_content(&outcome);
-                    self.messages.push(Message::now(Role::Assistant, assistant_content));
+                    self.push_history(Role::Assistant, assistant_content);
                     self.save_session();
                     return Ok(AgentResult {
                         text: outcome.assistant_text,
@@ -512,7 +550,7 @@ impl AgentEngine {
                 }
                 TurnOutcome::Truncated(outcome) => {
                     let assistant_content = build_assistant_content(&outcome);
-                    self.messages.push(Message::now(Role::Assistant, assistant_content));
+                    self.push_history(Role::Assistant, assistant_content);
                     self.save_session();
                     return self
                         .finalize_once(
@@ -553,7 +591,7 @@ impl AgentEngine {
                         text: EMPTY_FINAL_RETRY_PROMPT.to_string(),
                     }];
                     self.record_local_context_addition(estimate_content_tokens(&retry_blocks));
-                    self.messages.push(Message::now(Role::User, retry_blocks));
+                    self.push_history(Role::User, retry_blocks);
                     self.save_session();
                     continue;
                 }
@@ -584,9 +622,9 @@ impl AgentEngine {
             self.emit_tool_results(&tool_calls, &tool_results);
             self.record_tool_context_estimate(&tool_results, &follow_up_blocks);
 
-            self.messages.push(Message::now(Role::User, tool_results));
+            self.push_history(Role::User, tool_results);
             if !follow_up_blocks.is_empty() {
-                self.messages.push(Message::now(Role::User, follow_up_blocks));
+                self.push_history(Role::User, follow_up_blocks);
             }
 
             // Save session after each tool round.
@@ -872,7 +910,7 @@ impl AgentEngine {
 
         if is_success {
             let assistant_content = build_assistant_content(&outcome);
-            self.messages.push(Message::now(Role::Assistant, assistant_content));
+            self.push_history(Role::Assistant, assistant_content);
             self.save_session();
             return Ok(AgentResult {
                 text: combined_text,
@@ -899,12 +937,12 @@ impl AgentEngine {
             combined_text
         };
 
-        self.messages.push(Message::now(
+        self.push_history(
             Role::Assistant,
             vec![ContentBlock::Text {
                 text: fallback_text.clone(),
             }],
-        ));
+        );
         self.save_session();
         Ok(AgentResult {
             text: fallback_text,
@@ -1532,7 +1570,7 @@ impl AgentEngine {
             .collect();
 
         self.record_tool_context_estimate(&result_blocks, &[]);
-        self.messages.push(Message::now(Role::User, result_blocks));
+        self.push_history(Role::User, result_blocks);
         self.save_session();
     }
 

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -55,6 +55,8 @@ mod tests_set_config {
             messages: vec![],
             total_usage: Default::default(),
             msg_id: String::new(),
+            pending_turn_id: None,
+            current_turn_id: None,
             max_turns_per_run: Some(10),
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
@@ -431,6 +433,8 @@ mod tests_phase6 {
             messages: vec![],
             total_usage: Default::default(),
             msg_id: String::new(),
+            pending_turn_id: None,
+            current_turn_id: None,
             max_turns_per_run: Some(10),
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
@@ -716,6 +720,8 @@ mod tests_compact {
             messages,
             total_usage: Default::default(),
             msg_id: String::new(),
+            pending_turn_id: None,
+            current_turn_id: None,
             max_turns_per_run: Some(10),
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
@@ -937,6 +943,8 @@ mod tests_compact {
         context_state.microcompact_count = 5;
         let session = Session {
             id: "resume-context".into(),
+            forked_from: None,
+            root_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             provider: "anthropic".into(),
@@ -1031,6 +1039,56 @@ mod tests_compact {
         assert_eq!(loaded.messages.len(), 2);
         assert_eq!(loaded.context_state.context_usage, 120);
         assert_eq!(loaded.context_state.source, ContextUsageSource::ProviderExact);
+    }
+
+    #[tokio::test]
+    async fn run_stamps_one_turn_id_per_run_and_honors_host_supplied_id() {
+        let directory = tempdir().unwrap();
+        let mut config = test_config();
+        config.session.enabled = true;
+        config.session.directory = directory.path().display().to_string();
+        let provider: Arc<dyn LlmProvider> = Arc::new(SuccessfulProvider {
+            usage: TokenUsage::default(),
+        });
+        let mut engine = super::AgentEngine::new_with_provider(
+            provider,
+            config,
+            ToolRegistry::new(),
+            Arc::new(NullOutput),
+            directory.path().to_path_buf(),
+        );
+        engine
+            .init_session(
+                "anthropic",
+                &directory.path().display().to_string(),
+                Some("turn-stamps"),
+            )
+            .unwrap();
+
+        // Turn 1: engine mints its own id; user + assistant share it.
+        engine.run("first", "msg-1").await.unwrap();
+        let first_turn = engine.current_turn_id().expect("minted").to_owned();
+
+        // Turn 2: host-supplied id wins and is consumed exactly once.
+        engine.set_next_turn_id(Some("turn_host123".into()));
+        engine.run("second", "msg-2").await.unwrap();
+        assert_eq!(engine.current_turn_id(), Some("turn_host123"));
+
+        let manager = SessionManager::new(directory.path().to_path_buf(), 10);
+        let loaded = manager.load("turn-stamps").unwrap();
+        assert_eq!(loaded.messages.len(), 4);
+        let turn_ids: Vec<_> = loaded.messages.iter().map(|m| m.turn_id.as_deref()).collect();
+        assert_eq!(
+            turn_ids,
+            vec![
+                Some(first_turn.as_str()),
+                Some(first_turn.as_str()),
+                Some("turn_host123"),
+                Some("turn_host123"),
+            ],
+            "every message of a run carries that run's turn id"
+        );
+        assert_ne!(first_turn, "turn_host123");
     }
 
     #[test]
@@ -1418,6 +1476,8 @@ mod tests_plan_mode {
             messages: vec![],
             total_usage: Default::default(),
             msg_id: String::new(),
+            pending_turn_id: None,
+            current_turn_id: None,
             max_turns_per_run: Some(10),
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
@@ -1638,6 +1698,8 @@ mod tests_handle_command {
             messages: vec![],
             total_usage: Default::default(),
             msg_id: String::new(),
+            pending_turn_id: None,
+            current_turn_id: None,
             max_turns_per_run: Some(10),
             max_tool_call_malformed_turns: 3,
             max_tool_call_failure_turns: 3,
@@ -2662,6 +2724,8 @@ mod tests_tool_policy_enforcement {
             messages: Vec::new(),
             total_usage: Default::default(),
             msg_id: "test-message".to_string(),
+            pending_turn_id: None,
+            current_turn_id: None,
             max_tokens: Some(4096),
             max_turns_per_run: Some(10),
             max_tool_call_malformed_turns: 3,

--- a/crates/aion-agent/src/session.rs
+++ b/crates/aion-agent/src/session.rs
@@ -16,6 +16,15 @@ use crate::context_usage::ContextState;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: String,
+    /// Session this one was forked from (direct parent in the fork tree).
+    /// `None` = not a fork. Lineage only — never followed at load time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forked_from: Option<String>,
+    /// Root of the fork tree this session belongs to. `None` = this session
+    /// is itself the root. Stable across nested forks (a fork of a fork
+    /// keeps the original root).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_id: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub provider: String,
@@ -43,6 +52,15 @@ pub struct SessionMeta {
     pub message_count: usize,
 }
 
+/// Where to cut the copied history when forking a session.
+#[derive(Debug, Clone, Copy)]
+pub enum ForkBoundary<'a> {
+    /// Copy the full history (fork at HEAD).
+    Head,
+    /// Copy through the LAST message stamped with this turn id (inclusive).
+    AtTurn(&'a str),
+}
+
 pub struct SessionManager {
     directory: PathBuf,
     max_sessions: usize,
@@ -65,6 +83,8 @@ impl SessionManager {
         };
         let session = Session {
             id,
+            forked_from: None,
+            root_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             provider: provider.to_string(),
@@ -109,6 +129,76 @@ impl SessionManager {
 
             Err(anyhow::anyhow!("Session '{}' not found", id_or_latest))
         })
+    }
+
+    /// Fork a session: copy its full history at HEAD into a new session id.
+    ///
+    /// The source session is never modified. The fork records lineage via
+    /// `forked_from` (direct parent) and `root_id` (fork-tree root), and both
+    /// sessions continue independently afterwards. Pass `new_id` to fork into
+    /// a caller-chosen id (fails if it already exists), or `None` to generate
+    /// one.
+    pub fn fork(&self, source_id: &str, new_id: Option<&str>) -> anyhow::Result<Session> {
+        let source = self.load(source_id)?;
+        self.fork_from(&source, new_id, ForkBoundary::Head)
+    }
+
+    /// Fork from an already-loaded session, saving the fork in this manager's
+    /// directory. For callers that resolve the source from somewhere this
+    /// manager cannot see (e.g. a legacy layout in another directory): load
+    /// the source themselves, then materialize the fork here.
+    ///
+    /// `ForkBoundary::AtTurn` truncates the copied history after the LAST
+    /// message stamped with the anchor turn id (fork THROUGH that turn,
+    /// inclusive). An anchor that matches no message — pre-turn-tracking
+    /// history, or a turn folded away by compaction — is an error: the caller
+    /// must refuse rather than silently fork at the wrong point.
+    pub fn fork_from(
+        &self,
+        source: &Session,
+        new_id: Option<&str>,
+        boundary: ForkBoundary<'_>,
+    ) -> anyhow::Result<Session> {
+        let id = match new_id {
+            Some(custom_id) => custom_id.to_string(),
+            None => self.generate_unique_id()?,
+        };
+        let now = Utc::now();
+        let mut session = source.clone();
+        if let ForkBoundary::AtTurn(anchor) = boundary {
+            let cut = session
+                .messages
+                .iter()
+                .rposition(|message| message.turn_id.as_deref() == Some(anchor))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "fork anchor turn '{}' not found in session '{}' history",
+                        anchor,
+                        source.id
+                    )
+                })?;
+            session.messages.truncate(cut + 1);
+        }
+        session.root_id = Some(source.root_id.clone().unwrap_or_else(|| source.id.clone()));
+        session.forked_from = Some(source.id.clone());
+        session.id = id;
+        session.created_at = now;
+        session.updated_at = now;
+        self.with_session_lock(&session.id, || {
+            if self.session_exists(&session.id)? {
+                anyhow::bail!("Session ID '{}' already exists", session.id);
+            }
+            self.save_unlocked(&session)
+        })?;
+        self.cleanup_old()?;
+        tracing::info!(
+            target: "aion_agent",
+            source_id = %source.id,
+            fork_id = %session.id,
+            message_count = session.messages.len(),
+            "Forked session"
+        );
+        Ok(session)
     }
 
     /// List all sessions

--- a/crates/aion-agent/src/session_test.rs
+++ b/crates/aion-agent/src/session_test.rs
@@ -322,9 +322,176 @@ mod tests {
         assert!(manager.state_path("same-session").is_file());
     }
 
+    #[test]
+    fn test_fork_copies_history_into_new_session_with_lineage() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let mut source = sample_session("source-a", "model-x");
+        source.messages.push(Message::new(
+            Role::Assistant,
+            vec![ContentBlock::Text {
+                text: "reply".to_string(),
+            }],
+        ));
+        manager.save(&source).unwrap();
+
+        let fork = manager.fork("source-a", None).unwrap();
+
+        assert_ne!(fork.id, source.id);
+        assert_eq!(fork.forked_from.as_deref(), Some("source-a"));
+        assert_eq!(fork.root_id.as_deref(), Some("source-a"));
+        assert_eq!(fork.messages.len(), source.messages.len());
+        assert_eq!(fork.provider, source.provider);
+        assert_eq!(fork.model, source.model);
+        assert!(fork.created_at > source.created_at);
+        // The fork is persisted and independently loadable.
+        let loaded = manager.load(&fork.id).unwrap();
+        assert_eq!(loaded.messages.len(), source.messages.len());
+        assert_eq!(loaded.forked_from.as_deref(), Some("source-a"));
+    }
+
+    #[test]
+    fn test_fork_does_not_mutate_source_session() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let source = sample_session("source-b", "model-x");
+        manager.save(&source).unwrap();
+        let source_bytes_before = fs::read_to_string(manager.state_path("source-b")).unwrap();
+
+        let fork = manager.fork("source-b", None).unwrap();
+
+        let source_bytes_after = fs::read_to_string(manager.state_path("source-b")).unwrap();
+        assert_eq!(source_bytes_before, source_bytes_after);
+        // Diverging the fork afterwards still leaves the source untouched.
+        let mut fork = fork;
+        fork.messages.push(Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "new branch message".to_string(),
+            }],
+        ));
+        manager.save(&fork).unwrap();
+        let reloaded_source = manager.load("source-b").unwrap();
+        assert_eq!(reloaded_source.messages.len(), source.messages.len());
+        assert!(reloaded_source.forked_from.is_none());
+    }
+
+    #[test]
+    fn test_fork_with_custom_id_and_collision_bails() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        manager.save(&sample_session("source-c", "model-x")).unwrap();
+
+        let fork = manager.fork("source-c", Some("custom-fork-id")).unwrap();
+        assert_eq!(fork.id, "custom-fork-id");
+        assert!(manager.state_path("custom-fork-id").is_file());
+
+        // Forking into an id that already exists (including the source
+        // itself) must fail without touching the existing session.
+        let err = manager.fork("source-c", Some("custom-fork-id")).unwrap_err();
+        assert!(err.to_string().contains("already exists"), "unexpected error: {err}");
+        let err = manager.fork("source-c", Some("source-c")).unwrap_err();
+        assert!(err.to_string().contains("already exists"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_fork_of_fork_keeps_original_root() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        manager.save(&sample_session("root-session", "model-x")).unwrap();
+
+        let first = manager.fork("root-session", None).unwrap();
+        let second = manager.fork(&first.id, None).unwrap();
+
+        assert_eq!(second.forked_from.as_deref(), Some(first.id.as_str()));
+        assert_eq!(second.root_id.as_deref(), Some("root-session"));
+        assert_eq!(first.root_id.as_deref(), Some("root-session"));
+    }
+
+    #[test]
+    fn test_fork_at_turn_truncates_through_anchor_inclusive() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let mut source = sample_session("turn-source", "model-x");
+        source.messages.clear();
+        for (turn, text) in [
+            (Some("turn-1"), "u1"),
+            (Some("turn-1"), "a1"),
+            (Some("turn-2"), "u2"),
+            (Some("turn-2"), "a2"),
+            (Some("turn-3"), "u3"),
+        ] {
+            let mut m = Message::now(Role::User, vec![ContentBlock::Text { text: text.into() }]);
+            m.turn_id = turn.map(str::to_owned);
+            source.messages.push(m);
+        }
+        manager.save(&source).unwrap();
+
+        let fork = manager
+            .fork_from(&source, None, ForkBoundary::AtTurn("turn-2"))
+            .unwrap();
+
+        assert_eq!(fork.messages.len(), 4, "cut after the LAST turn-2 message, inclusive");
+        assert_eq!(fork.messages.last().unwrap().turn_id.as_deref(), Some("turn-2"));
+        // Source untouched.
+        assert_eq!(manager.load("turn-source").unwrap().messages.len(), 5);
+    }
+
+    #[test]
+    fn test_fork_at_unknown_anchor_is_refused_not_degraded() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        // sample_session's message carries no turn_id — the shape of
+        // pre-turn-tracking history or a compacted-away turn.
+        let source = sample_session("turn-source-2", "model-x");
+        manager.save(&source).unwrap();
+
+        let err = manager
+            .fork_from(&source, Some("should-not-exist"), ForkBoundary::AtTurn("turn-9"))
+            .unwrap_err();
+        assert!(err.to_string().contains("not found"), "unexpected error: {err}");
+        // Refusal must not leave a partial fork behind.
+        assert!(manager.load("should-not-exist").is_err());
+    }
+
+    #[test]
+    fn test_fork_nonexistent_source_errors() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+
+        assert!(manager.fork("no-such-session", None).is_err());
+    }
+
+    #[test]
+    fn test_session_without_lineage_fields_deserializes_as_root() {
+        let mut value = serde_json::to_value(sample_session("pre-fork-format", "old-model")).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("forked_from");
+        obj.remove("root_id");
+
+        let loaded: Session = serde_json::from_value(value).unwrap();
+
+        assert!(loaded.forked_from.is_none());
+        assert!(loaded.root_id.is_none());
+    }
+
+    #[test]
+    fn test_non_fork_session_serializes_without_lineage_keys() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let session = manager.create("openai", "gpt-4", "/tmp", None).unwrap();
+
+        let state_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(manager.state_path(&session.id)).unwrap()).unwrap();
+        assert!(state_json.get("forked_from").is_none());
+        assert!(state_json.get("root_id").is_none());
+    }
+
     fn sample_session(id: &str, model: &str) -> Session {
         Session {
             id: id.to_string(),
+            forked_from: None,
+            root_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             provider: "test-provider".to_string(),

--- a/crates/aion-agent/tests/microcompact_test.rs
+++ b/crates/aion-agent/tests/microcompact_test.rs
@@ -46,6 +46,7 @@ fn assistant_at(blocks: Vec<ContentBlock>, ts: chrono::DateTime<Utc>) -> Message
         role: Role::Assistant,
         content: blocks,
         timestamp: Some(ts),
+        turn_id: None,
     }
 }
 

--- a/crates/aion-cli/src/bootstrap.rs
+++ b/crates/aion-cli/src/bootstrap.rs
@@ -94,6 +94,7 @@ pub(crate) async fn build_engine(
     cwd: &str,
     output: Arc<dyn OutputSink>,
     resume_id: Option<&str>,
+    fork_session: bool,
     on_resume: impl FnOnce(&Session),
 ) -> anyhow::Result<BootstrapResult> {
     let mut agent_bootstrap = AgentBootstrap::new(config, cwd, output);
@@ -101,7 +102,13 @@ pub(crate) async fn build_engine(
     if let Some(resume_id) = resume_id {
         let cfg = agent_bootstrap.config();
         let session_mgr = SessionManager::new(cfg.session.directory.clone().into(), cfg.session.max_sessions);
-        let session = session_mgr.load(resume_id)?;
+        // Forking copies the source session's history into a new session id
+        // and activates the copy; the source session stays untouched.
+        let session = if fork_session {
+            session_mgr.fork(resume_id, None)?
+        } else {
+            session_mgr.load(resume_id)?
+        };
         on_resume(&session);
         agent_bootstrap = agent_bootstrap.resume(session);
     }

--- a/crates/aion-cli/src/cli.rs
+++ b/crates/aion-cli/src/cli.rs
@@ -81,6 +81,11 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) session_id: Option<String>,
 
+    /// With --resume: fork the session into a new session id instead of
+    /// continuing the original (the source session is left untouched)
+    #[arg(long, requires = "resume")]
+    pub(crate) fork_session: bool,
+
     // --- Output ---
     /// Disable colored output
     #[arg(long)]

--- a/crates/aion-cli/src/json_stream/session.rs
+++ b/crates/aion-cli/src/json_stream/session.rs
@@ -30,6 +30,7 @@ pub(crate) async fn run(
     cwd: &str,
     resume: Option<String>,
     session_id: Option<String>,
+    fork_session: bool,
 ) -> anyhow::Result<()> {
     let writer = Arc::new(ProtocolWriter::new());
     let protocol_sink = Arc::new(ProtocolSink::new(writer.clone()));
@@ -39,8 +40,17 @@ pub(crate) async fn run(
     let provider_name = config.provider_label.clone();
 
     // JSON stream mode never prints a resume banner — the host is expected
-    // to render its own resume UX from the `Ready` event's session_id.
-    let result = build_engine(config, cwd, output.clone(), resume.as_deref(), |_session| {}).await?;
+    // to render its own resume UX from the `Ready` event's session_id (which
+    // for a fork is the NEW session id, not the --resume source).
+    let result = build_engine(
+        config,
+        cwd,
+        output.clone(),
+        resume.as_deref(),
+        fork_session,
+        |_session| {},
+    )
+    .await?;
     let mut engine = result.engine;
     let initial_has_mcp = result.has_mcp;
 

--- a/crates/aion-cli/src/run.rs
+++ b/crates/aion-cli/src/run.rs
@@ -28,20 +28,39 @@ pub(crate) async fn run_main_flow(cli: Cli) -> anyhow::Result<()> {
 
     // Branch to JSON stream mode
     if cli.json_stream {
-        return json_stream::run(config, &cwd, cli.resume, cli.session_id).await;
+        return json_stream::run(config, &cwd, cli.resume, cli.session_id, cli.fork_session).await;
     }
 
     let provider_name = config.provider_label.clone();
     let terminal_for_resume = terminal.clone();
+    let fork_session = cli.fork_session;
 
-    let result = build_engine(config, &cwd, output.clone(), cli.resume.as_deref(), |session| {
-        terminal_for_resume.formatter().session_info(&format!(
-            "Resumed session {} ({} messages, {} model)",
-            session.id,
-            session.messages.len(),
-            session.model
-        ));
-    })
+    let result = build_engine(
+        config,
+        &cwd,
+        output.clone(),
+        cli.resume.as_deref(),
+        fork_session,
+        |session| {
+            let banner = if fork_session {
+                format!(
+                    "Forked session {} from {} ({} messages, {} model)",
+                    session.id,
+                    session.forked_from.as_deref().unwrap_or("?"),
+                    session.messages.len(),
+                    session.model
+                )
+            } else {
+                format!(
+                    "Resumed session {} ({} messages, {} model)",
+                    session.id,
+                    session.messages.len(),
+                    session.model
+                )
+            };
+            terminal_for_resume.formatter().session_info(&banner);
+        },
+    )
     .await?;
     let mut engine = result.engine;
 

--- a/crates/aion-types/src/message.rs
+++ b/crates/aion-types/src/message.rs
@@ -163,6 +163,13 @@ pub struct Message {
     /// whether old tool results should be cleared.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<DateTime<Utc>>,
+    /// The turn this message belongs to (every message appended during one
+    /// engine run carries the same id). Used as the session-side anchor when
+    /// forking a session at a historical turn. `None` on messages written
+    /// before turn tracking existed and on compaction-synthesized summaries —
+    /// such messages cannot anchor a fork.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
 }
 
 impl Message {
@@ -172,6 +179,7 @@ impl Message {
             role,
             content,
             timestamp: None,
+            turn_id: None,
         }
     }
 
@@ -181,6 +189,7 @@ impl Message {
             role,
             content,
             timestamp: Some(Utc::now()),
+            turn_id: None,
         }
     }
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,7 @@ subcommand runs its action and exits — it does not start the agent main flow.
 | `--auto-approve` | Skip all tool confirmations |
 | `--json-stream` | JSON Lines mode for host integration |
 | `--resume <id>` | Resume a previous session |
+| `--fork-session` | With `--resume`: fork into a new session id, leaving the original untouched |
 | `--log-dir <path>` | Enable file logging to the given directory |
 | `--log-level <filter>` | Log level filter (e.g. `debug`, `info`, `aion_providers=debug`) |
 
@@ -307,11 +308,17 @@ aionrs --resume latest
 # Resume a specific session
 aionrs --resume a1b2c3
 
+# Fork a session: copy its history into a new session id and continue
+# there, leaving the original session untouched
+aionrs --resume a1b2c3 --fork-session
+
 # Create a session with a custom ID
 aionrs --session-id my-conv-123
 ```
 
 - `--session-id` and `--resume` are mutually exclusive
+- `--fork-session` requires `--resume`; the forked session records its
+  parent in `forked_from` and the fork-tree root in `root_id`
 - `--session-id` errors if the ID already exists
 - Both flags work in interactive and `--json-stream` mode
 - Auto-saves after each tool round

--- a/docs/json-stream-protocol.md
+++ b/docs/json-stream-protocol.md
@@ -533,6 +533,7 @@ Between receiving `ready` and sending the first `message`, the client may inject
 |------|-------------|
 | `--session-id <ID>` | Use a specific session ID instead of auto-generating one. Errors if the ID already exists. |
 | `--resume <ID>` | Resume a previous session (loads conversation history). Use `latest` to resume the most recent. |
+| `--fork-session` | With `--resume`: fork the session into a NEW session id instead of continuing the original. The `ready` event's `session_id` carries the new id. |
 
 ```bash
 # New session with a custom ID
@@ -540,6 +541,9 @@ aionrs --json-stream --session-id my-conv-123 --provider openai --model gpt-4o
 
 # Resume an existing session
 aionrs --json-stream --resume my-conv-123 --provider openai --model gpt-4o
+
+# Fork an existing session into a new id (read it from `ready.session_id`)
+aionrs --json-stream --resume my-conv-123 --fork-session --provider openai --model gpt-4o
 ```
 
 ### 3.2 Message Turn


### PR DESCRIPTION
## Summary

- `SessionManager::fork` / `fork_from` copy a session's history into a new session id (Codex-thread-fork style): the source session file is never modified, and the fork records `forked_from` (direct parent) + `root_id` (fork-tree root, stable across nested forks) for lineage.
- `ForkBoundary` selects the cut: `Head` copies the full history; `AtTurn(anchor)` copies through the LAST message stamped with that turn id (inclusive). An unresolvable anchor (pre-turn-tracking history, or a turn folded away by compaction) is a hard error — callers must refuse rather than silently fork at the wrong point.
- Every message appended during one engine run is now stamped with a `turn_id`: hosts supply their own via `AgentEngine::set_next_turn_id` (so the host's message store and the session file share one anchor), standalone runs mint a UUIDv7 per run. The ten scattered `self.messages.push` sites are centralized into `push_history`.
- CLI: `--fork-session` (requires `--resume`) activates a fork of the resumed session and leaves the original untouched; in `--json-stream` mode the `ready` event's `session_id` carries the NEW id.

## Why

AionUi's conversation fork (fork-as-new-conversation) is already live for claude/codex/ACP backends; the embedded aionrs path had no session-fork primitive at all. This provides it, mirroring the codex thread-fork model (parent history → snapshot boundary → new id + lineage) so AionCore can cut the session file and its message rows at the same anchor.

## Compatibility

- `Session.forked_from` / `root_id` and `Message.turn_id` are `#[serde(default, skip_serializing_if)]` — pre-fork session files load unchanged, and non-fork sessions serialize without the new keys.
- `Message` gained a public field: downstream struct literals must add `turn_id` (AionCore adapts in its companion PR; its production code only uses constructors and is unaffected).
- Compaction-synthesized summary messages intentionally carry no `turn_id`: a folded-away turn can no longer anchor a fork.

## Test Plan / Validation

- `cargo test -p aion-agent --lib` — 440 passed (new: fork copy/lineage/collision, at-turn truncation, unresolvable-anchor refusal, per-run turn stamping incl. host-supplied id)
- `just push` full gate — fmt ✅, clippy `-D warnings` ✅, workspace tests 2273 passed / 2 skipped ✅, hakari verify ✅

## Non-goals

- No JSON-stream protocol command for forking (hosts integrate via the SDK; the CLI flag covers standalone use).
- No mid-history fork UX in the standalone CLI (flag forks at HEAD; the library API supports `AtTurn` for hosts).

## Related PRs

- AionCore integration (consumes `fork_from` + `set_next_turn_id`, stamps `backend_turn_id` on aionrs rows): follow-up PR in iOfficeAI/AionCore, must land AFTER this ships in a release and its git deps are bumped.

## Follow-up

- Release a tagged version so AionCore can drop its temporary path override and pin the new tag.