### PR TITLE
feat(skills): support isolated bootstrap directories

### DIFF
--- a/crates/aion-agent/src/bootstrap.rs
+++ b/crates/aion-agent/src/bootstrap.rs
@@ -63,6 +63,7 @@ pub struct AgentBootstrap {
     config: Config,
     workspace: PathBuf,
     extra_skill_dirs: Vec<PathBuf>,
+    isolate_skill_dirs: bool,
 
     // Output integration.
     output: Arc<dyn OutputSink>,
@@ -104,6 +105,7 @@ impl AgentBootstrap {
             config,
             workspace: PathBuf::from(workspace.into()),
             extra_skill_dirs: Vec::new(),
+            isolate_skill_dirs: false,
             output,
             provider: None,
             resume_session: None,
@@ -139,6 +141,16 @@ impl AgentBootstrap {
     /// Add extra directories to scan for skills.
     pub fn extra_skill_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
         self.extra_skill_dirs = dirs;
+        self
+    }
+
+    /// Discover skills only from the supplied directories and bundled skills.
+    ///
+    /// Each directory is interpreted as a project root containing
+    /// `.aionrs/skills`.
+    pub fn isolated_skill_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
+        self.extra_skill_dirs = dirs;
+        self.isolate_skill_dirs = true;
         self
     }
 
@@ -269,7 +281,7 @@ impl AgentBootstrap {
     }
 
     async fn load_skills(&self, workspace: &Path, mcp_manager: Option<&McpManager>) -> Vec<SkillMetadata> {
-        load_all_skills(workspace, &self.extra_skill_dirs, false, mcp_manager).await
+        load_all_skills(workspace, &self.extra_skill_dirs, self.isolate_skill_dirs, mcp_manager).await
     }
 
     fn configure_system_prompt(&mut self, environment: &BootstrapEnvironment, skills: &[SkillMetadata]) -> PromptUsage {

--- a/crates/aion-agent/src/bootstrap_test.rs
+++ b/crates/aion-agent/src/bootstrap_test.rs
@@ -3,6 +3,7 @@ use super::*;
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::fs;
     use std::sync::Arc;
 
     use aion_config::config::{CliArgs, McpServerConfig, TransportType};
@@ -72,6 +73,34 @@ mod tests {
             project_dir: None,
         })
         .unwrap()
+    }
+
+    fn write_skill(project_root: &std::path::Path, name: &str) {
+        let skill_dir = project_root.join(".aionrs").join("skills").join(name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(skill_dir.join("SKILL.md"), "---\ndescription: test skill\n---\n").unwrap();
+    }
+
+    #[tokio::test]
+    async fn isolated_skill_dirs_excludes_workspace_skills() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let isolated_root = tempfile::TempDir::new().unwrap();
+        write_skill(workspace.path(), "workspace-only");
+        write_skill(isolated_root.path(), "isolated-only");
+
+        let output: Arc<dyn OutputSink> = Arc::new(NullSink);
+        let bootstrap = AgentBootstrap::new(test_config(), workspace.path().to_string_lossy(), output)
+            .isolated_skill_dirs(vec![isolated_root.path().to_path_buf()]);
+
+        let names = bootstrap
+            .load_skills(workspace.path(), None)
+            .await
+            .into_iter()
+            .map(|skill| skill.name)
+            .collect::<Vec<_>>();
+
+        assert!(names.iter().any(|name| name == "isolated-only"));
+        assert!(!names.iter().any(|name| name == "workspace-only"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `AgentBootstrap::isolated_skill_dirs` for hosts that must limit Skill discovery to explicitly supplied roots
- preserve bundled-Skill availability and the existing default discovery behavior
- cover workspace exclusion with a bootstrap-level test

## Verification
- `cargo fmt --all --check`
- `cargo test -p aion-agent isolated_skill_dirs_excludes_workspace_skills --lib`
- `cargo clippy -p aion-agent --tests -- -D warnings`

All checks above were run with the repository-pinned Rust 1.96.1 toolchain.