### PR TITLE
feat(tui): add codex-style interactive repl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-test",
  "tracing",
@@ -65,6 +65,7 @@ dependencies = [
  "aion-types",
  "anyhow",
  "clap",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -97,7 +98,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-test",
  "toml",
@@ -123,7 +124,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "workspace-hack",
@@ -140,7 +141,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "workspace-hack",
 ]
@@ -190,7 +191,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-test",
  "tracing",
@@ -222,7 +223,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "unicode-width",
@@ -261,6 +262,7 @@ dependencies = [
  "anyhow",
  "crossterm",
  "futures",
+ "pulldown-cmark",
  "ratatui",
  "serde_json",
  "tokio",
@@ -388,6 +390,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -831,6 +842,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +897,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
@@ -1151,6 +1183,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1252,12 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
@@ -1390,6 +1438,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,10 +1473,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -2149,7 +2239,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2171,6 +2261,12 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -2263,6 +2359,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2382,27 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -2313,6 +2440,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2368,6 +2518,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,6 +2566,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2594,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "outref"
@@ -2526,6 +2702,100 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2643,6 +2913,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,7 +2937,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2671,13 +2952,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2717,6 +2998,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "rand"
@@ -2765,6 +3055,9 @@ dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
+ "ratatui-termina",
+ "ratatui-termion",
+ "ratatui-termwiz",
  "ratatui-widgets",
  "serde",
 ]
@@ -2784,7 +3077,7 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -2800,6 +3093,38 @@ dependencies = [
  "crossterm",
  "instability",
  "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termion"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c732202fa5a71a9da0991013f0853e53f87048f45198e3a1ca3ee722accc2f"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termion",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
 ]
 
 [[package]]
@@ -2839,7 +3164,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3338,9 +3663,15 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3427,6 +3758,17 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
@@ -3481,10 +3823,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termion"
+version = "4.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44138a9ae08f0f502f24104d82517ef4da7330c35acd638f1f29d3cd5475ecb"
+dependencies = [
+ "libc",
+ "numtoa",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2 0.10.9",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
 
 [[package]]
 name = "thiserror"
@@ -3492,7 +3929,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3760,7 +4208,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -3839,6 +4287,18 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -3923,6 +4383,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
@@ -3945,6 +4406,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "walkdir"
@@ -4118,6 +4588,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "aion-providers",
  "aion-skills",
  "aion-tools",
+ "aion-tui",
  "aion-types",
  "anyhow",
  "clap",
@@ -251,6 +252,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aion-tui"
+version = "0.2.11"
+dependencies = [
+ "aion-agent",
+ "aion-protocol",
+ "aion-types",
+ "anyhow",
+ "crossterm",
+ "futures",
+ "ratatui",
+ "serde_json",
+ "tokio",
+ "unicode-width",
+ "workspace-hack",
+]
+
+[[package]]
 name = "aion-types"
 version = "0.2.11"
 dependencies = [
@@ -313,7 +331,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -324,7 +342,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -332,6 +350,15 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arc-swap"
@@ -840,6 +867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +886,15 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -955,6 +997,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1101,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix",
@@ -1100,6 +1157,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1201,7 +1292,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1295,7 +1386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1566,6 +1657,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1865,6 +1961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +1997,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1931,6 +2042,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,7 +2078,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1962,6 +2086,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2009,6 +2142,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,12 +2191,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2189,7 +2348,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2237,6 +2396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2444,39 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -2347,6 +2548,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
@@ -2550,6 +2757,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "hashbrown 0.17.0",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.0",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,7 +3002,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3088,7 +3361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3108,10 +3381,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "subtle"
@@ -3174,10 +3474,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3222,7 +3522,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -3551,6 +3853,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,7 +4151,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4188,13 +4501,14 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.13.0",
  "cc",
+ "either",
  "futures-channel",
  "futures-core",
  "futures-sink",
  "futures-task",
  "futures-util",
  "getrandom 0.2.17",
- "getrandom 0.3.4",
+ "hashbrown 0.16.1",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -4215,6 +4529,7 @@ dependencies = [
  "smallvec",
  "subtle",
  "syn 2.0.118",
+ "syn 3.0.3",
  "time",
  "tokio",
  "tokio-rustls",
@@ -4224,7 +4539,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "uuid",
- "windows-sys 0.60.2",
  "windows-sys 0.61.2",
  "winnow",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,8 @@ notify = "8"
 
 # Terminal color and event support
 crossterm = { version = "0.29", features = ["event-stream"] }
-ratatui = { version = "0.30.2", default-features = false, features = ["crossterm", "crossterm_0_29"] }
+pulldown-cmark = { version = "0.13.4", default-features = false }
+ratatui = { version = "0.30.2", default-features = false, features = ["crossterm", "crossterm_0_29", "scrolling-regions"] }
 
 # TTY detection
 is-terminal = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/aion-skills",
     "crates/aion-memory",
     "crates/aion-agent",
+    "crates/aion-tui",
     "crates/aion-cli",
     "workspace-hack",
 ]
@@ -35,6 +36,7 @@ aion-mcp       = { path = "crates/aion-mcp" }
 aion-skills    = { path = "crates/aion-skills" }
 aion-memory    = { path = "crates/aion-memory" }
 aion-agent     = { path = "crates/aion-agent" }
+aion-tui       = { path = "crates/aion-tui" }
 
 # Async runtime
 tokio   = { version = "1", features = ["full"] }
@@ -87,8 +89,9 @@ regex = "1"
 # File system change notification (for skill hot-reload)
 notify = "8"
 
-# Terminal color support
-crossterm = "0.29"
+# Terminal color and event support
+crossterm = { version = "0.29", features = ["event-stream"] }
+ratatui = { version = "0.30.2", default-features = false, features = ["crossterm", "crossterm_0_29"] }
 
 # TTY detection
 is-terminal = "0.4"

--- a/README.md
+++ b/README.md
@@ -45,9 +45,23 @@ aionrs
 aionrs --help
 ```
 
-Interactive terminal sessions open a full-screen conversation UI. Type `/` to
-browse available commands; use Enter to send, Shift+Enter (or Ctrl+J as a fallback) for a newline, and
-Ctrl+C to stop the active turn.
+Interactive terminal sessions keep finalized conversation in the terminal's
+native scrollback with an inline composer at the bottom. Type `/` to browse
+available commands; use Enter to send, Shift+Enter (or Ctrl+J as a fallback)
+for a newline, and Ctrl+C to stop the active turn. Use the mouse wheel to read
+earlier finalized conversation content. Mouse capture stays
+disabled so terminal text can be selected and copied normally. Consecutive tool
+calls are collected under one `• Tools` step with an appended status row for
+each call. Status keeps an explicit label and semantic color, while tool input
+and output use a responsive one-line preview instead of occupying the
+conversation viewport.
+
+TUI-owned commands include `/status`, `/model`, `/permissions`, `/new`,
+`/resume`, `/mcp`, and `/skills`. Running `/resume` without an ID opens a
+full-screen, mouse- and keyboard-navigable picker containing every saved session
+up to the configured `session.max_sessions` retention limit. Session switches
+rebuild the agent runtime without exiting the interactive UI. A fresh TUI does
+not create a session until the first conversation message is sent.
 
 ## Runtime Limits
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ aionrs
 aionrs --help
 ```
 
+Interactive terminal sessions open a full-screen conversation UI. Type `/` to
+browse available commands; use Enter to send, Shift+Enter (or Ctrl+J as a fallback) for a newline, and
+Ctrl+C to stop the active turn.
+
 ## Runtime Limits
 
 `max_turns` is the broad model-turn limit per run. It is unset by default,

--- a/crates/aion-agent/src/commands/mod.rs
+++ b/crates/aion-agent/src/commands/mod.rs
@@ -5,4 +5,4 @@ pub mod help;
 pub mod quit;
 mod registry;
 
-pub use registry::{CommandContext, CommandRegistry, CommandResult, SlashCommand, default_registry};
+pub use registry::{CommandContext, CommandRegistry, CommandResult, CommandSpec, SlashCommand, default_registry};

--- a/crates/aion-agent/src/commands/registry.rs
+++ b/crates/aion-agent/src/commands/registry.rs
@@ -11,6 +11,14 @@ use aion_providers::LlmProvider;
 use aion_types::message::Message;
 use aion_types::tool::ToolDef;
 
+/// User-facing metadata for a registered slash command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandSpec {
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub description: String,
+}
+
 /// Result of executing a slash command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandResult {
@@ -74,6 +82,17 @@ impl CommandRegistry {
 
     pub fn all(&self) -> &[Box<dyn SlashCommand>] {
         &self.commands
+    }
+
+    pub fn specs(&self) -> Vec<CommandSpec> {
+        self.commands
+            .iter()
+            .map(|command| CommandSpec {
+                name: command.name().to_string(),
+                aliases: command.aliases().iter().map(|alias| (*alias).to_string()).collect(),
+                description: command.description().to_string(),
+            })
+            .collect()
     }
 }
 

--- a/crates/aion-agent/src/commands/registry_test.rs
+++ b/crates/aion-agent/src/commands/registry_test.rs
@@ -33,4 +33,12 @@ mod tests {
         let registry = default_registry();
         assert_eq!(registry.all().len(), 5);
     }
+
+    #[test]
+    fn specs_include_aliases_for_interactive_discovery() {
+        let specs = default_registry().specs();
+        let quit = specs.iter().find(|spec| spec.name == "quit").unwrap();
+        assert_eq!(quit.aliases, ["exit"]);
+        assert_eq!(quit.description, "Exit the REPL");
+    }
 }

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -396,6 +396,11 @@ impl AgentEngine {
         }
     }
 
+    /// Return the model-visible skills loaded for this engine runtime.
+    pub fn skill_names(&self) -> &[String] {
+        &self.prompt_usage.skills
+    }
+
     /// Get a reference to the output sink
     pub fn output(&self) -> &dyn OutputSink {
         self.output.as_ref()
@@ -1304,6 +1309,9 @@ impl AgentEngine {
 
         if let Some(new_model) = model {
             let old = replace(&mut self.model, new_model.clone());
+            if let Some(session) = &mut self.current_session {
+                session.model = new_model.clone();
+            }
             changes.push(format!("model: {old} → {new_model}"));
         }
 
@@ -1376,6 +1384,10 @@ impl AgentEngine {
                     changes.push(format!("compaction: invalid ({e})"));
                 }
             }
+        }
+
+        if model_changed {
+            self.save_session();
         }
 
         changes

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::cache_diagnostics::{CacheBreakDetector, CacheDiagnostic, CacheStats};
-use crate::commands::{CommandContext, CommandRegistry, CommandResult, SlashCommand, default_registry};
+use crate::commands::{CommandContext, CommandRegistry, CommandResult, CommandSpec, SlashCommand, default_registry};
 use crate::compact::auto::{CompactError, autocompact, should_autocompact};
 use crate::compact::emergency::is_at_emergency_limit;
 use crate::compact::estimate::{estimate_tokens_from_tool_image, estimate_tokens_from_tool_result};
@@ -747,7 +747,7 @@ impl AgentEngine {
         let (executable_results, executable_modifiers, follow_up_blocks) = if executable_tool_calls.is_empty() {
             (Vec::new(), Vec::new(), Vec::new())
         } else if let Some(ref approval_mgr) = self.approval_manager {
-            // JSON stream mode: use protocol-based approval
+            // Interactive hosts use protocol-based approval.
             let writer = self
                 .protocol_writer
                 .as_ref()
@@ -1463,6 +1463,11 @@ impl AgentEngine {
             .iter()
             .map(|cmd| (cmd.name().to_string(), cmd.description().to_string()))
             .collect()
+    }
+
+    /// Return user-facing metadata for interactive slash-command discovery.
+    pub fn slash_commands(&self) -> Vec<CommandSpec> {
+        self.commands.specs()
     }
 
     /// Apply context modifiers collected from skill tool executions.

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -17,10 +17,12 @@ mod tests_set_config {
     use aion_tools::registry::ToolRegistry;
     use aion_types::llm::{LlmEvent, LlmRequest};
     use aion_types::message::ImageInputCapability;
+    use tempfile::tempdir;
 
     use super::{CompactLevel, ProviderCompat};
     use crate::confirm::ToolConfirmer;
     use crate::output::OutputSink;
+    use crate::session::SessionManager;
 
     struct NullOutput;
     impl OutputSink for NullOutput {
@@ -99,6 +101,23 @@ mod tests_set_config {
         assert_eq!(changes.len(), 1);
         assert!(changes[0].contains("old-model"));
         assert!(changes[0].contains("new-model"));
+    }
+
+    #[test]
+    fn set_config_model_change_persists_session_metadata_immediately() {
+        let directory = tempdir().unwrap();
+        let manager = SessionManager::new(directory.path().to_path_buf(), 10);
+        let session = manager
+            .create("openai", "old-model", "/workspace", Some("model-switch"))
+            .unwrap();
+        let mut engine = make_engine("old-model");
+        engine.session_manager = Some(manager);
+        engine.current_session = Some(session);
+
+        engine.apply_config_update(Some("new-model".into()), None, None, None, None, None);
+
+        let manager = SessionManager::new(directory.path().to_path_buf(), 10);
+        assert_eq!(manager.load("model-switch").unwrap().model, "new-model");
     }
 
     #[test]

--- a/crates/aion-agent/src/session.rs
+++ b/crates/aion-agent/src/session.rs
@@ -226,12 +226,15 @@ impl SessionManager {
     }
 
     fn load_current(&self, session_id: &str) -> anyhow::Result<Option<Session>> {
-        let path = self.state_path(session_id);
-        match fs::read_to_string(path) {
-            Ok(content) => Ok(Some(serde_json::from_str(&content)?)),
-            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(error.into()),
+        if let Some(session) = load_session_file(&self.state_path(session_id))? {
+            return Ok(Some(session));
         }
+
+        let Some(session) = load_session_file(&self.nested_state_path(session_id))? else {
+            return Ok(None);
+        };
+        self.save_unlocked(&session)?;
+        Ok(Some(session))
     }
 
     fn save_unlocked(&self, session: &Session) -> anyhow::Result<()> {
@@ -242,8 +245,18 @@ impl SessionManager {
     }
 
     fn list_current(&self) -> anyhow::Result<Vec<SessionMeta>> {
-        let sessions_dir = self.sessions_dir();
-        let entries = match fs::read_dir(&sessions_dir) {
+        let mut sessions = HashMap::new();
+        for meta in self.list_current_in(&self.nested_sessions_dir())? {
+            sessions.insert(meta.id.clone(), meta);
+        }
+        for meta in self.list_current_in(&self.directory)? {
+            sessions.insert(meta.id.clone(), meta);
+        }
+        Ok(sessions.into_values().collect())
+    }
+
+    fn list_current_in(&self, directory: &Path) -> anyhow::Result<Vec<SessionMeta>> {
+        let entries = match fs::read_dir(directory) {
             Ok(entries) => entries,
             Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
             Err(error) => return Err(error.into()),
@@ -358,7 +371,7 @@ impl SessionManager {
     }
 
     fn session_exists(&self, session_id: &str) -> anyhow::Result<bool> {
-        if self.state_path(session_id).is_file() {
+        if self.state_path(session_id).is_file() || self.nested_state_path(session_id).is_file() {
             return Ok(true);
         }
         Ok(self.find_legacy_session_file(session_id)?.is_some())
@@ -374,16 +387,24 @@ impl SessionManager {
         anyhow::bail!("failed to generate unique session id")
     }
 
-    fn sessions_dir(&self) -> PathBuf {
+    fn nested_sessions_dir(&self) -> PathBuf {
         self.directory.join("sessions")
     }
 
     fn session_dir(&self, session_id: &str) -> PathBuf {
-        self.sessions_dir().join(encode_session_id(session_id))
+        self.directory.join(encode_session_id(session_id))
+    }
+
+    fn nested_session_dir(&self, session_id: &str) -> PathBuf {
+        self.nested_sessions_dir().join(encode_session_id(session_id))
     }
 
     fn state_path(&self, session_id: &str) -> PathBuf {
         self.session_dir(session_id).join("state.json")
+    }
+
+    fn nested_state_path(&self, session_id: &str) -> PathBuf {
+        self.nested_session_dir(session_id).join("state.json")
     }
 
     fn with_session_lock<T>(&self, session_id: &str, f: impl FnOnce() -> anyhow::Result<T>) -> anyhow::Result<T> {
@@ -408,14 +429,20 @@ impl SessionManager {
             let _guard = lock
                 .lock()
                 .map_err(|_| anyhow::anyhow!("session lock poisoned for '{}'", meta.id))?;
-            match fs::remove_dir_all(self.session_dir(&meta.id)) {
-                Ok(()) => {}
-                Err(error) if error.kind() == ErrorKind::NotFound => {}
-                Err(error) => return Err(error.into()),
-            }
+            self.remove_session_layouts(&meta.id)?;
         }
 
         Ok(())
+    }
+
+    fn remove_session_layouts(&self, session_id: &str) -> anyhow::Result<()> {
+        let session_dir = self.session_dir(session_id);
+        if session_dir == self.nested_sessions_dir() {
+            remove_file_if_exists(&self.state_path(session_id))?;
+        } else {
+            remove_dir_if_exists(&session_dir)?;
+        }
+        remove_dir_if_exists(&self.nested_session_dir(session_id))
     }
 }
 
@@ -478,6 +505,30 @@ fn read_session_file_if_valid(path: &Path) -> anyhow::Result<Option<Session>> {
             );
             Ok(None)
         }
+    }
+}
+
+fn load_session_file(path: &Path) -> anyhow::Result<Option<Session>> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(Some(serde_json::from_str(&content)?)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn remove_dir_if_exists(path: &Path) -> anyhow::Result<()> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn remove_file_if_exists(path: &Path) -> anyhow::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
     }
 }
 

--- a/crates/aion-agent/src/session_test.rs
+++ b/crates/aion-agent/src/session_test.rs
@@ -26,6 +26,7 @@ mod tests {
         assert_eq!(session.cwd, "/tmp");
         assert!(session.messages.is_empty());
         assert!(manager.state_path(&session.id).is_file());
+        assert!(!manager.nested_state_path(&session.id).exists());
         assert!(!dir.path().join("index.json").exists());
 
         let state_json: serde_json::Value =
@@ -150,6 +151,25 @@ mod tests {
     }
 
     #[test]
+    fn test_load_nested_current_layout_migrates_to_flat_layout() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 10);
+        let session = sample_session("nested-session", "nested model");
+        let nested_path = manager.nested_state_path(&session.id);
+        fs::create_dir_all(nested_path.parent().unwrap()).unwrap();
+        fs::write(&nested_path, serde_json::to_string_pretty(&session).unwrap()).unwrap();
+
+        let listed = manager.list().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, session.id);
+
+        let loaded = manager.load(&session.id).unwrap();
+        assert_eq!(loaded.model, "nested model");
+        assert!(manager.state_path(&session.id).is_file());
+        assert!(nested_path.is_file());
+    }
+
+    #[test]
     fn test_list_merges_legacy_and_current_sessions() {
         let dir = tempdir().unwrap();
         let manager = SessionManager::new(dir.path().to_path_buf(), 10);
@@ -264,6 +284,23 @@ mod tests {
         let list = manager.list().unwrap();
         assert_eq!(list.len(), 2);
         assert!(list.iter().any(|meta| meta.id == "legacy-session"));
+    }
+
+    #[test]
+    fn test_cleanup_removes_old_nested_current_layout() {
+        let dir = tempdir().unwrap();
+        let manager = SessionManager::new(dir.path().to_path_buf(), 1);
+        let old = sample_session("old-nested-session", "old model");
+        let old_path = manager.nested_state_path(&old.id);
+        fs::create_dir_all(old_path.parent().unwrap()).unwrap();
+        fs::write(&old_path, serde_json::to_string_pretty(&old).unwrap()).unwrap();
+
+        manager
+            .create("openai", "new model", "/tmp", Some("new-session"))
+            .unwrap();
+
+        assert!(!old_path.exists());
+        assert!(manager.state_path("new-session").is_file());
     }
 
     #[test]

--- a/crates/aion-cli/Cargo.toml
+++ b/crates/aion-cli/Cargo.toml
@@ -31,3 +31,6 @@ clap.workspace               = true
 tracing.workspace            = true
 tracing-subscriber.workspace = true
 workspace-hack.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/aion-cli/Cargo.toml
+++ b/crates/aion-cli/Cargo.toml
@@ -23,6 +23,7 @@ aion-mcp.workspace      = true
 aion-protocol.workspace = true
 aion-skills.workspace   = true
 aion-types.workspace    = true
+aion-tui.workspace      = true
 
 tokio.workspace              = true
 anyhow.workspace             = true

--- a/crates/aion-cli/src/run.rs
+++ b/crates/aion-cli/src/run.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::env;
 use std::io::{self, IsTerminal};
 use std::sync::Arc;
@@ -6,9 +7,11 @@ use aion_agent::engine::AgentEngine;
 use aion_agent::error::AgentError;
 use aion_agent::output::OutputSink;
 use aion_agent::output::terminal::TerminalSink;
-use aion_config::config::Config;
+use aion_agent::session::{Session, SessionManager};
+use aion_config::config::{Config, SessionConfig};
 use aion_mcp::manager::McpManager;
-use aion_tui::{TuiMetadata, TuiRuntime};
+use aion_tui::{TuiMetadata, TuiOutcome, TuiRuntime, TuiSession};
+use aion_types::message::Message;
 
 use crate::bootstrap::{build_engine, init_logging, resolve_config};
 use crate::cli::Cli;
@@ -41,44 +44,148 @@ pub(crate) async fn run_main_flow(cli: Cli) -> anyhow::Result<()> {
 }
 
 async fn run_tui_flow(config: Config, cwd: &str, cli: &Cli) -> anyhow::Result<()> {
-    let provider_name = config.provider_label.clone();
+    let mut active_config = config;
     let mut tui = TuiRuntime::new(TuiMetadata {
-        model: config.model.clone(),
-        provider: provider_name.clone(),
+        model: active_config.model.clone(),
+        provider: active_config.provider_label.clone(),
         cwd: cwd.to_string(),
         no_color: cli.no_color,
     });
     let output = tui.output_sink();
-    let mut resumed_messages = None;
-    let fork_session = cli.fork_session;
-
-    let result = build_engine(
-        config,
+    tui.prepare_terminal()?;
+    let mut runtime = build_tui_engine(
+        active_config.clone(),
         cwd,
         output.clone(),
         cli.resume.as_deref(),
-        fork_session,
-        |session| {
-            resumed_messages = Some(session.messages.clone());
-            emit_resume_banner(output.as_ref(), session, fork_session);
-        },
+        cli.session_id.as_deref(),
+        cli.fork_session,
     )
     .await?;
-    let mut engine = result.engine;
-    let mcp_managers = result.mcp_managers;
+    configure_tui(&mut tui, &runtime, &active_config);
 
-    if cli.resume.is_none() {
-        engine.init_session(&provider_name, cwd, cli.session_id.as_deref())?;
-    }
+    loop {
+        let outcome = tui.run(&mut runtime.engine).await?;
+        let (resume_id, session_id) = match outcome {
+            TuiOutcome::Exit => {
+                shutdown(&runtime.engine, &runtime.mcp_managers).await;
+                return Ok(());
+            }
+            TuiOutcome::NewSession => (None, None),
+            TuiOutcome::ResumeSession(session_id) => (Some(session_id), None),
+        };
 
-    tui.set_commands(engine.slash_commands());
-    tui.set_session_id(engine.current_session_id());
-    if let Some(messages) = resumed_messages {
-        tui.set_history(&messages);
+        active_config.model = runtime.engine.context_status().model;
+        let next = build_tui_engine(
+            active_config.clone(),
+            cwd,
+            output.clone(),
+            resume_id.as_deref(),
+            session_id,
+            false,
+        )
+        .await;
+        match next {
+            Ok(next) => {
+                shutdown(&runtime.engine, &runtime.mcp_managers).await;
+                runtime = next;
+                configure_tui(&mut tui, &runtime, &active_config);
+            }
+            Err(error) => {
+                tui.show_error(format!("Could not switch session: {error}"));
+            }
+        }
     }
-    let run_result = tui.run(&mut engine).await;
-    shutdown(&engine, &mcp_managers).await;
-    run_result
+}
+
+struct TuiEngineRuntime {
+    engine: AgentEngine,
+    mcp_managers: Vec<Arc<McpManager>>,
+    history: Vec<Message>,
+    session_initialization_pending: bool,
+    requested_session_id: Option<String>,
+}
+
+async fn build_tui_engine(
+    config: Config,
+    cwd: &str,
+    output: Arc<dyn OutputSink>,
+    resume_id: Option<&str>,
+    session_id: Option<&str>,
+    fork_session: bool,
+) -> anyhow::Result<TuiEngineRuntime> {
+    let mut history = None;
+    let result = build_engine(config, cwd, output.clone(), resume_id, fork_session, |session| {
+        history = Some(session.messages.clone());
+    })
+    .await?;
+    Ok(TuiEngineRuntime {
+        engine: result.engine,
+        mcp_managers: result.mcp_managers,
+        history: history.unwrap_or_default(),
+        session_initialization_pending: resume_id.is_none(),
+        requested_session_id: session_id.map(str::to_string),
+    })
+}
+
+fn configure_tui(tui: &mut TuiRuntime, runtime: &TuiEngineRuntime, config: &Config) {
+    let session_id = runtime.engine.current_session_id();
+    tui.set_commands(runtime.engine.slash_commands());
+    tui.reset_session(
+        runtime.engine.context_status().model,
+        config.provider_label.clone(),
+        session_id.clone(),
+        &runtime.history,
+    );
+    if runtime.session_initialization_pending {
+        tui.defer_session_initialization(runtime.requested_session_id.clone());
+    }
+    tui.set_runtime_catalog(
+        mcp_catalog(&runtime.mcp_managers),
+        runtime.engine.skill_names().to_vec(),
+        session_catalog(&config.session, session_id.as_deref()),
+    );
+}
+
+fn mcp_catalog(managers: &[Arc<McpManager>]) -> Vec<String> {
+    let mut servers = Vec::new();
+    for manager in managers {
+        let tools = manager.all_tools();
+        for name in manager.server_names() {
+            let tool_count = tools.iter().filter(|(server, _)| *server == name).count();
+            servers.push(format!("{name} · {tool_count} tools"));
+        }
+    }
+    servers.sort();
+    servers
+}
+
+fn session_catalog(config: &SessionConfig, current_session_id: Option<&str>) -> Result<Vec<TuiSession>, String> {
+    if !config.enabled {
+        return Ok(Vec::new());
+    }
+    let manager = SessionManager::new(config.directory.clone().into(), config.max_sessions);
+    manager.list().map_err(|error| error.to_string()).map(|mut sessions| {
+        sessions.sort_by_key(|session| Reverse(session.updated_at));
+        sessions
+            .into_iter()
+            .filter(|session| Some(session.id.as_str()) != current_session_id)
+            .map(|session| {
+                let summary = if session.summary.is_empty() {
+                    "(empty session)".to_string()
+                } else {
+                    session.summary
+                };
+                TuiSession::new(
+                    session.id,
+                    session.model,
+                    summary,
+                    session.updated_at.format("%Y-%m-%d %H:%M UTC").to_string(),
+                    session.message_count,
+                )
+            })
+            .collect()
+    })
 }
 
 async fn run_plain_flow(config: Config, cwd: &str, cli: &Cli, prompt: &str) -> anyhow::Result<()> {
@@ -126,11 +233,7 @@ async fn run_plain_flow(config: Config, cwd: &str, cli: &Cli, prompt: &str) -> a
     Ok(())
 }
 
-fn emit_resume_banner(output: &dyn OutputSink, session: &aion_agent::session::Session, fork_session: bool) {
-    output.emit_info(&resume_banner(session, fork_session));
-}
-
-fn resume_banner(session: &aion_agent::session::Session, fork_session: bool) -> String {
+fn resume_banner(session: &Session, fork_session: bool) -> String {
     if fork_session {
         format!(
             "Forked session {} from {} ({} messages, {} model)",
@@ -196,3 +299,7 @@ async fn repl_loop(
 
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "run_test.rs"]
+mod run_test;

--- a/crates/aion-cli/src/run.rs
+++ b/crates/aion-cli/src/run.rs
@@ -1,10 +1,14 @@
 use std::env;
+use std::io::{self, IsTerminal};
 use std::sync::Arc;
 
 use aion_agent::engine::AgentEngine;
 use aion_agent::error::AgentError;
 use aion_agent::output::OutputSink;
 use aion_agent::output::terminal::TerminalSink;
+use aion_config::config::Config;
+use aion_mcp::manager::McpManager;
+use aion_tui::{TuiMetadata, TuiRuntime};
 
 use crate::bootstrap::{build_engine, init_logging, resolve_config};
 use crate::cli::Cli;
@@ -18,9 +22,6 @@ pub(crate) async fn run_main_flow(cli: Cli) -> anyhow::Result<()> {
         anyhow::bail!("Cannot use --resume and --session-id together");
     }
 
-    let terminal = Arc::new(TerminalSink::new(cli.no_color));
-    let output: Arc<dyn OutputSink> = terminal.clone();
-
     let config = resolve_config(&cli)?;
     let _log_guard = init_logging(&config, cli.log_dir.as_deref(), cli.log_level.as_deref());
 
@@ -31,48 +32,86 @@ pub(crate) async fn run_main_flow(cli: Cli) -> anyhow::Result<()> {
         return json_stream::run(config, &cwd, cli.resume, cli.session_id, cli.fork_session).await;
     }
 
+    let prompt = cli.prompt.join(" ");
+    if prompt.is_empty() && io::stdin().is_terminal() && io::stdout().is_terminal() {
+        return run_tui_flow(config, &cwd, &cli).await;
+    }
+
+    run_plain_flow(config, &cwd, &cli, &prompt).await
+}
+
+async fn run_tui_flow(config: Config, cwd: &str, cli: &Cli) -> anyhow::Result<()> {
+    let provider_name = config.provider_label.clone();
+    let mut tui = TuiRuntime::new(TuiMetadata {
+        model: config.model.clone(),
+        provider: provider_name.clone(),
+        cwd: cwd.to_string(),
+        no_color: cli.no_color,
+    });
+    let output = tui.output_sink();
+    let mut resumed_messages = None;
+    let fork_session = cli.fork_session;
+
+    let result = build_engine(
+        config,
+        cwd,
+        output.clone(),
+        cli.resume.as_deref(),
+        fork_session,
+        |session| {
+            resumed_messages = Some(session.messages.clone());
+            emit_resume_banner(output.as_ref(), session, fork_session);
+        },
+    )
+    .await?;
+    let mut engine = result.engine;
+    let mcp_managers = result.mcp_managers;
+
+    if cli.resume.is_none() {
+        engine.init_session(&provider_name, cwd, cli.session_id.as_deref())?;
+    }
+
+    tui.set_commands(engine.slash_commands());
+    tui.set_session_id(engine.current_session_id());
+    if let Some(messages) = resumed_messages {
+        tui.set_history(&messages);
+    }
+    let run_result = tui.run(&mut engine).await;
+    shutdown(&engine, &mcp_managers).await;
+    run_result
+}
+
+async fn run_plain_flow(config: Config, cwd: &str, cli: &Cli, prompt: &str) -> anyhow::Result<()> {
+    let terminal = Arc::new(TerminalSink::new(cli.no_color));
+    let output: Arc<dyn OutputSink> = terminal.clone();
+
     let provider_name = config.provider_label.clone();
     let terminal_for_resume = terminal.clone();
     let fork_session = cli.fork_session;
 
     let result = build_engine(
         config,
-        &cwd,
+        cwd,
         output.clone(),
         cli.resume.as_deref(),
         fork_session,
         |session| {
-            let banner = if fork_session {
-                format!(
-                    "Forked session {} from {} ({} messages, {} model)",
-                    session.id,
-                    session.forked_from.as_deref().unwrap_or("?"),
-                    session.messages.len(),
-                    session.model
-                )
-            } else {
-                format!(
-                    "Resumed session {} ({} messages, {} model)",
-                    session.id,
-                    session.messages.len(),
-                    session.model
-                )
-            };
+            let banner = resume_banner(session, fork_session);
             terminal_for_resume.formatter().session_info(&banner);
         },
     )
     .await?;
     let mut engine = result.engine;
+    let mcp_managers = result.mcp_managers;
 
     if cli.resume.is_none() {
-        engine.init_session(&provider_name, &cwd, cli.session_id.as_deref())?;
+        engine.init_session(&provider_name, cwd, cli.session_id.as_deref())?;
     }
 
-    let prompt = cli.prompt.join(" ");
     if prompt.is_empty() {
         repl_loop(&mut engine, &terminal, &output).await?;
     } else {
-        let run_result = engine.run(&prompt, "").await?;
+        let run_result = engine.run(prompt, "").await?;
         output.emit_stream_end(
             "",
             run_result.turns,
@@ -83,13 +122,38 @@ pub(crate) async fn run_main_flow(cli: Cli) -> anyhow::Result<()> {
         );
     }
 
-    engine.run_stop_hooks().await;
-
-    for mgr in &result.mcp_managers {
-        mgr.shutdown().await;
-    }
-
+    shutdown(&engine, &mcp_managers).await;
     Ok(())
+}
+
+fn emit_resume_banner(output: &dyn OutputSink, session: &aion_agent::session::Session, fork_session: bool) {
+    output.emit_info(&resume_banner(session, fork_session));
+}
+
+fn resume_banner(session: &aion_agent::session::Session, fork_session: bool) -> String {
+    if fork_session {
+        format!(
+            "Forked session {} from {} ({} messages, {} model)",
+            session.id,
+            session.forked_from.as_deref().unwrap_or("?"),
+            session.messages.len(),
+            session.model
+        )
+    } else {
+        format!(
+            "Resumed session {} ({} messages, {} model)",
+            session.id,
+            session.messages.len(),
+            session.model
+        )
+    }
+}
+
+async fn shutdown(engine: &AgentEngine, managers: &[Arc<McpManager>]) {
+    engine.run_stop_hooks().await;
+    for manager in managers {
+        manager.shutdown().await;
+    }
 }
 
 async fn repl_loop(

--- a/crates/aion-cli/src/run_test.rs
+++ b/crates/aion-cli/src/run_test.rs
@@ -1,0 +1,30 @@
+use aion_agent::session::SessionManager;
+use aion_config::config::SessionConfig;
+use tempfile::tempdir;
+
+use super::session_catalog;
+
+#[test]
+fn session_catalog_does_not_truncate_entries_to_ten() {
+    let directory = tempdir().expect("temporary session directory should be created");
+    let manager = SessionManager::new(directory.path().to_path_buf(), 20);
+    for index in 0..15 {
+        manager
+            .create(
+                "openai",
+                "test-model",
+                "/workspace",
+                Some(&format!("session-{index:02}")),
+            )
+            .expect("test session should be created");
+    }
+    let config = SessionConfig {
+        enabled: true,
+        directory: directory.path().to_string_lossy().into_owned(),
+        max_sessions: 20,
+    };
+
+    let sessions = session_catalog(&config, None).expect("session catalog should load");
+
+    assert_eq!(sessions.len(), 15);
+}

--- a/crates/aion-tui/Cargo.toml
+++ b/crates/aion-tui/Cargo.toml
@@ -14,6 +14,7 @@ aion-types.workspace    = true
 anyhow.workspace        = true
 crossterm.workspace     = true
 futures.workspace       = true
+pulldown-cmark.workspace = true
 ratatui.workspace       = true
 serde_json.workspace    = true
 tokio.workspace         = true

--- a/crates/aion-tui/Cargo.toml
+++ b/crates/aion-tui/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "aion-tui"
+description = "Interactive terminal user interface for aionrs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+aion-agent.workspace    = true
+aion-protocol.workspace = true
+aion-types.workspace    = true
+
+anyhow.workspace        = true
+crossterm.workspace     = true
+futures.workspace       = true
+ratatui.workspace       = true
+serde_json.workspace    = true
+tokio.workspace         = true
+unicode-width.workspace = true
+workspace-hack.workspace = true

--- a/crates/aion-tui/src/app.rs
+++ b/crates/aion-tui/src/app.rs
@@ -1,0 +1,304 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use aion_agent::commands::CommandSpec;
+use aion_agent::engine::AgentEngine;
+use aion_agent::error::AgentError;
+use aion_agent::output::OutputSink;
+use aion_protocol::commands::ApprovalScope;
+use aion_protocol::writer::ProtocolEmitter;
+use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
+use aion_types::message::Message;
+use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use futures::StreamExt;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use tokio::time;
+
+use crate::event::{AgentEvent, TuiProtocolEmitter, TuiSink};
+use crate::state::AppState;
+use crate::terminal::{AppTerminal, TerminalSession};
+use crate::ui;
+
+static MESSAGE_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+pub struct TuiMetadata {
+    pub model: String,
+    pub provider: String,
+    pub cwd: String,
+    pub no_color: bool,
+}
+
+pub struct TuiRuntime {
+    state: AppState,
+    tx: UnboundedSender<AgentEvent>,
+    rx: UnboundedReceiver<AgentEvent>,
+    approval_manager: Arc<ToolApprovalManager>,
+    protocol_emitter: Arc<dyn ProtocolEmitter>,
+}
+
+impl TuiRuntime {
+    pub fn new(metadata: TuiMetadata) -> Self {
+        let (tx, rx) = unbounded_channel();
+        let protocol_emitter = TuiProtocolEmitter::shared(tx.clone());
+        Self {
+            state: AppState::new(metadata.model, metadata.provider, metadata.cwd, metadata.no_color),
+            tx,
+            rx,
+            approval_manager: Arc::new(ToolApprovalManager::new()),
+            protocol_emitter,
+        }
+    }
+
+    pub fn output_sink(&self) -> Arc<dyn OutputSink> {
+        TuiSink::shared(self.tx.clone())
+    }
+
+    pub fn set_commands(&mut self, commands: Vec<CommandSpec>) {
+        self.state.set_commands(commands);
+    }
+
+    pub fn set_session_id(&mut self, session_id: Option<String>) {
+        self.state.session_id = session_id;
+    }
+
+    pub fn set_history(&mut self, messages: &[Message]) {
+        self.state.set_history(messages);
+    }
+
+    pub async fn run(&mut self, engine: &mut AgentEngine) -> anyhow::Result<()> {
+        engine.set_approval_manager(self.approval_manager.clone());
+        engine.set_protocol_writer(self.protocol_emitter.clone());
+
+        let mut terminal_session = TerminalSession::enter()?;
+        let mut terminal_events = EventStream::new();
+        let mut ticker = time::interval(Duration::from_millis(120));
+        ticker.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        loop {
+            self.draw(terminal_session.terminal())?;
+            tokio::select! {
+                event = self.rx.recv() => {
+                    if let Some(event) = event {
+                        self.state.handle_agent_event(event);
+                    }
+                }
+                event = terminal_events.next() => {
+                    let Some(event) = event else {
+                        return Ok(());
+                    };
+                    match event? {
+                        Event::Key(key) if is_key_press(key) => {
+                            match self.handle_idle_key(key) {
+                                IdleAction::Continue => {}
+                                IdleAction::Exit => return Ok(()),
+                                IdleAction::Submit(input) => {
+                                    if self.run_turn(engine, input, terminal_session.terminal(), &mut terminal_events, &mut ticker).await? {
+                                        return Ok(());
+                                    }
+                                }
+                            }
+                        }
+                        Event::Paste(text) => {
+                            self.state.composer.insert_text(&text);
+                            self.update_popup();
+                        }
+                        Event::Resize(_, _) => {}
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    async fn run_turn(
+        &mut self,
+        engine: &mut AgentEngine,
+        input: String,
+        terminal: &mut AppTerminal,
+        terminal_events: &mut EventStream,
+        ticker: &mut time::Interval,
+    ) -> anyhow::Result<bool> {
+        self.state.begin_turn(&input);
+        let message_id = format!("tui-{}", MESSAGE_SEQUENCE.fetch_add(1, Ordering::Relaxed));
+        let mut cancelled = false;
+        let result = {
+            let engine_future = engine.run(&input, &message_id);
+            tokio::pin!(engine_future);
+
+            loop {
+                self.draw(terminal)?;
+                tokio::select! {
+                    result = &mut engine_future => break Some(result),
+                    event = self.rx.recv() => {
+                        if let Some(event) = event {
+                            self.state.handle_agent_event(event);
+                        }
+                    }
+                    event = terminal_events.next() => {
+                        let Some(event) = event else {
+                            cancelled = true;
+                            break None;
+                        };
+                        match event? {
+                            Event::Key(key)
+                                if is_key_press(key) && self.handle_running_key(key) =>
+                            {
+                                cancelled = true;
+                                break None;
+                            }
+                            Event::Resize(_, _) => {}
+                            _ => {}
+                        }
+                    }
+                    _ = ticker.tick() => self.state.tick(),
+                }
+            }
+        };
+
+        if cancelled {
+            self.deny_pending_approval("Turn cancelled");
+            engine.abort_current_turn("Turn cancelled by user");
+            self.state.cancel_turn();
+            self.drain_agent_events();
+            return Ok(false);
+        }
+
+        self.drain_agent_events();
+        match result {
+            Some(Ok(result)) => {
+                self.state.finish_turn(result.turns, result.usage);
+                Ok(false)
+            }
+            Some(Err(AgentError::UserAborted)) => {
+                self.state.busy = false;
+                Ok(true)
+            }
+            Some(Err(error)) => {
+                self.state.busy = false;
+                self.state.handle_agent_event(AgentEvent::Error(error.to_string()));
+                Ok(false)
+            }
+            None => Ok(false),
+        }
+    }
+
+    fn handle_idle_key(&mut self, key: KeyEvent) -> IdleAction {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            if self.state.composer.is_empty() {
+                return IdleAction::Exit;
+            }
+            self.state.composer.clear();
+            self.update_popup();
+            return IdleAction::Continue;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL)
+            && key.code == KeyCode::Char('d')
+            && self.state.composer.is_empty()
+        {
+            return IdleAction::Exit;
+        }
+
+        let popup_visible = self.state.popup.is_visible(&self.state.composer.text());
+        match key.code {
+            KeyCode::PageUp => self.state.scroll_back = self.state.scroll_back.saturating_add(5),
+            KeyCode::PageDown => self.state.scroll_back = self.state.scroll_back.saturating_sub(5),
+            KeyCode::Up if popup_visible => self.state.popup.move_previous(),
+            KeyCode::Down if popup_visible => self.state.popup.move_next(),
+            KeyCode::Tab if popup_visible => {
+                if let Some(name) = self.state.popup.selected_name() {
+                    self.state.composer.replace_command(&name);
+                    self.update_popup();
+                }
+            }
+            KeyCode::Enter if !key.modifiers.contains(KeyModifiers::SHIFT) => {
+                if popup_visible && let Some(name) = self.state.popup.selected_name() {
+                    self.state.composer.replace_command(&name);
+                }
+                let input = self.state.composer.take();
+                self.update_popup();
+                if !input.trim().is_empty() {
+                    return IdleAction::Submit(input);
+                }
+            }
+            KeyCode::Esc if popup_visible => {
+                self.state.composer.clear();
+                self.update_popup();
+            }
+            _ => {
+                if self.state.composer.input(key) {
+                    self.update_popup();
+                }
+            }
+        }
+        IdleAction::Continue
+    }
+
+    /// Returns true when the active turn should be cancelled.
+    fn handle_running_key(&mut self, key: KeyEvent) -> bool {
+        if let Some(request) = &self.state.approval {
+            let call_id = request.call_id.clone();
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    self.approval_manager.approve(&call_id, ApprovalScope::Once);
+                    self.state.approval = None;
+                }
+                KeyCode::Char('a') => {
+                    self.approval_manager.approve(&call_id, ApprovalScope::Always);
+                    self.state.approval = None;
+                }
+                KeyCode::Char('n') | KeyCode::Esc => {
+                    self.approval_manager.resolve(
+                        &call_id,
+                        ToolApprovalResult::Denied {
+                            reason: "Denied by user".to_string(),
+                        },
+                    );
+                    self.state.approval = None;
+                }
+                _ => {}
+            }
+            return false;
+        }
+
+        key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c')
+    }
+
+    fn deny_pending_approval(&mut self, reason: &str) {
+        let Some(request) = self.state.approval.take() else {
+            return;
+        };
+        self.approval_manager.resolve(
+            &request.call_id,
+            ToolApprovalResult::Denied {
+                reason: reason.to_string(),
+            },
+        );
+    }
+
+    fn update_popup(&mut self) {
+        let text = self.state.composer.text();
+        self.state.popup.update(&text);
+    }
+
+    fn drain_agent_events(&mut self) {
+        while let Ok(event) = self.rx.try_recv() {
+            self.state.handle_agent_event(event);
+        }
+    }
+
+    fn draw(&mut self, terminal: &mut AppTerminal) -> anyhow::Result<()> {
+        terminal.draw(|frame| ui::render(frame, &self.state))?;
+        Ok(())
+    }
+}
+
+fn is_key_press(key: KeyEvent) -> bool {
+    matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat)
+}
+
+enum IdleAction {
+    Continue,
+    Submit(String),
+    Exit,
+}

--- a/crates/aion-tui/src/app.rs
+++ b/crates/aion-tui/src/app.rs
@@ -6,7 +6,7 @@ use aion_agent::commands::CommandSpec;
 use aion_agent::engine::AgentEngine;
 use aion_agent::error::AgentError;
 use aion_agent::output::OutputSink;
-use aion_protocol::commands::ApprovalScope;
+use aion_protocol::commands::{ApprovalScope, SessionMode};
 use aion_protocol::writer::ProtocolEmitter;
 use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
 use aion_types::message::Message;
@@ -15,9 +15,11 @@ use futures::StreamExt;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::time;
 
+use crate::app_command::ApplicationCommand;
 use crate::event::{AgentEvent, TuiProtocolEmitter, TuiSink};
+use crate::session_picker::TuiSession;
 use crate::state::AppState;
-use crate::terminal::{AppTerminal, TerminalSession};
+use crate::terminal::{AppTerminal, TerminalSession, clear_synchronized, draw_synchronized, insert_history_lines};
 use crate::ui;
 
 static MESSAGE_SEQUENCE: AtomicU64 = AtomicU64::new(1);
@@ -29,12 +31,28 @@ pub struct TuiMetadata {
     pub no_color: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TuiOutcome {
+    Exit,
+    NewSession,
+    ResumeSession(String),
+}
+
 pub struct TuiRuntime {
     state: AppState,
     tx: UnboundedSender<AgentEvent>,
     rx: UnboundedReceiver<AgentEvent>,
     approval_manager: Arc<ToolApprovalManager>,
     protocol_emitter: Arc<dyn ProtocolEmitter>,
+    terminal_session: Option<TerminalSession>,
+    mcp_servers: Vec<String>,
+    skills: Vec<String>,
+    session_catalog_error: Option<String>,
+    needs_full_clear: bool,
+    session_configured: bool,
+    history_replay_pending: bool,
+    session_initialization_pending: bool,
+    requested_session_id: Option<String>,
 }
 
 impl TuiRuntime {
@@ -47,6 +65,15 @@ impl TuiRuntime {
             rx,
             approval_manager: Arc::new(ToolApprovalManager::new()),
             protocol_emitter,
+            terminal_session: None,
+            mcp_servers: Vec::new(),
+            skills: Vec::new(),
+            session_catalog_error: None,
+            needs_full_clear: false,
+            session_configured: false,
+            history_replay_pending: false,
+            session_initialization_pending: false,
+            requested_session_id: None,
         }
     }
 
@@ -54,28 +81,82 @@ impl TuiRuntime {
         TuiSink::shared(self.tx.clone())
     }
 
+    pub fn prepare_terminal(&mut self) -> anyhow::Result<()> {
+        if self.terminal_session.is_some() {
+            return Ok(());
+        }
+        self.state.begin_initialization();
+        let mut terminal_session = TerminalSession::enter()?;
+        draw_synchronized(terminal_session.terminal(), |frame| ui::render(frame, &self.state))?;
+        self.terminal_session = Some(terminal_session);
+        Ok(())
+    }
+
     pub fn set_commands(&mut self, commands: Vec<CommandSpec>) {
         self.state.set_commands(commands);
     }
 
-    pub fn set_session_id(&mut self, session_id: Option<String>) {
-        self.state.session_id = session_id;
+    pub fn reset_session(&mut self, model: String, provider: String, session_id: Option<String>, messages: &[Message]) {
+        self.drain_agent_events();
+        self.state.reset_session(model, provider, session_id, messages);
+        self.needs_full_clear = self.session_configured;
+        self.session_configured = true;
+        self.history_replay_pending = true;
+        self.session_initialization_pending = false;
+        self.requested_session_id = None;
     }
 
-    pub fn set_history(&mut self, messages: &[Message]) {
-        self.state.set_history(messages);
+    pub fn defer_session_initialization(&mut self, requested_session_id: Option<String>) {
+        self.session_initialization_pending = true;
+        self.requested_session_id = requested_session_id;
     }
 
-    pub async fn run(&mut self, engine: &mut AgentEngine) -> anyhow::Result<()> {
+    pub fn set_runtime_catalog(
+        &mut self,
+        mcp_servers: Vec<String>,
+        skills: Vec<String>,
+        sessions: Result<Vec<TuiSession>, String>,
+    ) {
+        self.mcp_servers = mcp_servers;
+        self.skills = skills;
+        match sessions {
+            Ok(sessions) => {
+                self.state.session_picker.set_sessions(sessions);
+                self.session_catalog_error = None;
+            }
+            Err(error) => {
+                self.state.session_picker.set_sessions(Vec::new());
+                self.session_catalog_error = Some(error);
+            }
+        }
+    }
+
+    pub fn show_error(&mut self, error: impl Into<String>) {
+        self.state.push_error(error);
+    }
+
+    pub async fn run(&mut self, engine: &mut AgentEngine) -> anyhow::Result<TuiOutcome> {
         engine.set_approval_manager(self.approval_manager.clone());
         engine.set_protocol_writer(self.protocol_emitter.clone());
 
-        let mut terminal_session = TerminalSession::enter()?;
+        let mut terminal_session = match self.terminal_session.take() {
+            Some(session) => session,
+            None => TerminalSession::enter()?,
+        };
+        if self.needs_full_clear {
+            terminal_session.reset_inline()?;
+            self.needs_full_clear = false;
+        }
+        if self.history_replay_pending {
+            self.commit_pending_history(terminal_session.terminal())?;
+            self.history_replay_pending = false;
+        }
         let mut terminal_events = EventStream::new();
         let mut ticker = time::interval(Duration::from_millis(120));
         ticker.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
-        loop {
+        let outcome = loop {
+            terminal_session.set_picker_mode(self.state.session_picker.is_visible())?;
             self.draw(terminal_session.terminal())?;
             tokio::select! {
                 event = self.rx.recv() => {
@@ -85,30 +166,162 @@ impl TuiRuntime {
                 }
                 event = terminal_events.next() => {
                     let Some(event) = event else {
-                        return Ok(());
+                        break TuiOutcome::Exit;
                     };
                     match event? {
                         Event::Key(key) if is_key_press(key) => {
                             match self.handle_idle_key(key) {
                                 IdleAction::Continue => {}
-                                IdleAction::Exit => return Ok(()),
+                                IdleAction::Exit => break TuiOutcome::Exit,
+                                IdleAction::Outcome(outcome) => break outcome,
                                 IdleAction::Submit(input) => {
-                                    if self.run_turn(engine, input, terminal_session.terminal(), &mut terminal_events, &mut ticker).await? {
-                                        return Ok(());
+                                    match self.handle_application_command(engine, &input) {
+                                        CommandAction::Handled => {
+                                            self.commit_pending_history(terminal_session.terminal())?;
+                                        }
+                                        CommandAction::Outcome(outcome) => break outcome,
+                                        CommandAction::PassThrough => {
+                                            if self.run_turn(engine, input, terminal_session.terminal(), &mut terminal_events, &mut ticker).await? {
+                                                break TuiOutcome::Exit;
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
                         Event::Paste(text) => {
-                            self.state.composer.insert_text(&text);
-                            self.update_popup();
+                            if !self.state.session_picker.is_visible() {
+                                self.state.composer.insert_text(&text);
+                                self.update_popup();
+                            }
                         }
-                        Event::Resize(_, _) => {}
+                        Event::Resize(_, _) => {
+                            clear_synchronized(terminal_session.terminal())?;
+                        }
                         _ => {}
                     }
                 }
             }
+        };
+
+        terminal_session.set_picker_mode(false)?;
+        if !matches!(&outcome, TuiOutcome::Exit) {
+            self.terminal_session = Some(terminal_session);
         }
+        Ok(outcome)
+    }
+
+    fn handle_application_command(&mut self, engine: &mut AgentEngine, input: &str) -> CommandAction {
+        let Some(command) = ApplicationCommand::parse(input) else {
+            return CommandAction::PassThrough;
+        };
+
+        match command {
+            ApplicationCommand::Help => {
+                self.state
+                    .push_info("Commands", application_help(self.state.popup.commands()));
+            }
+            ApplicationCommand::Status => {
+                let context = engine.context_status();
+                let percent = if context.context_window == 0 {
+                    0.0
+                } else {
+                    context.context_usage as f64 * 100.0 / context.context_window as f64
+                };
+                let text = format!(
+                    "Provider: {}\nModel: {}\nSession: {}\nPermissions: {}\nContext: {}/{} tokens ({percent:.1}%)\nContext source: {:?}\nCompactions: {} full, {} micro\nWorking directory: {}",
+                    self.state.provider,
+                    context.model,
+                    self.state.session_id.as_deref().unwrap_or("new"),
+                    self.approval_manager.current_mode(),
+                    context.context_usage,
+                    context.context_window,
+                    context.source,
+                    context.compact_count,
+                    context.microcompact_count,
+                    self.state.cwd,
+                );
+                self.state.push_info("Status", text);
+            }
+            ApplicationCommand::Permissions(args) => {
+                if args.is_empty() {
+                    self.state.push_info(
+                        "Permissions",
+                        format!(
+                            "Current mode: {}\nModes: default, auto_edit, yolo\nUse /permissions <mode> to change it.",
+                            self.approval_manager.current_mode()
+                        ),
+                    );
+                } else if let Some(mode) = permission_mode(&args) {
+                    self.approval_manager.set_mode(mode);
+                    self.state.push_info(
+                        "Permissions",
+                        format!("Approval mode changed to {}", self.approval_manager.current_mode()),
+                    );
+                } else {
+                    self.state.push_error(format!(
+                        "Unknown permission mode: {args}. Use default, auto_edit, or yolo."
+                    ));
+                }
+            }
+            ApplicationCommand::Model(model) => {
+                if model.is_empty() {
+                    self.state.push_info(
+                        "Model",
+                        format!("Current model: {}\nUse /model <name> to change it.", self.state.model),
+                    );
+                } else if model.chars().any(char::is_whitespace) {
+                    self.state.push_error("Model name cannot contain whitespace");
+                } else {
+                    let changes = engine.apply_config_update(Some(model), None, None, None, None, None);
+                    self.state.model = engine.context_status().model;
+                    self.state.push_info("Model", changes.join("\n"));
+                }
+            }
+            ApplicationCommand::New => {
+                self.state.push_info("Session", "Starting a new session…");
+                return CommandAction::Outcome(TuiOutcome::NewSession);
+            }
+            ApplicationCommand::Resume(session_id) => {
+                if session_id.is_empty() {
+                    if let Some(error) = &self.session_catalog_error {
+                        self.state.push_error(format!("Could not list saved sessions: {error}"));
+                    } else if self.state.session_picker.is_empty() {
+                        self.state
+                            .push_info("Resume", "No saved sessions found. Use /resume <id> or /resume latest.");
+                    } else {
+                        self.state.session_picker.open();
+                    }
+                } else if session_id.chars().any(char::is_whitespace) {
+                    self.state.push_error("Session ID cannot contain whitespace");
+                } else {
+                    self.state
+                        .push_info("Session", format!("Resuming session {session_id}…"));
+                    return CommandAction::Outcome(TuiOutcome::ResumeSession(session_id));
+                }
+            }
+            ApplicationCommand::Mcp => {
+                let text = if self.mcp_servers.is_empty() {
+                    "No MCP servers connected".to_string()
+                } else {
+                    format!(
+                        "Connected servers · {}\n  {}",
+                        self.mcp_servers.len(),
+                        self.mcp_servers.join("\n  ")
+                    )
+                };
+                self.state.push_info("MCP", text);
+            }
+            ApplicationCommand::Skills => {
+                let text = if self.skills.is_empty() {
+                    "No model-visible skills loaded".to_string()
+                } else {
+                    format!("Loaded skills · {}\n  {}", self.skills.len(), self.skills.join("\n  "))
+                };
+                self.state.push_info("Skills", text);
+            }
+        }
+        CommandAction::Handled
     }
 
     async fn run_turn(
@@ -119,7 +332,21 @@ impl TuiRuntime {
         terminal_events: &mut EventStream,
         ticker: &mut time::Interval,
     ) -> anyhow::Result<bool> {
+        if self.session_initialization_pending && starts_conversation(&input) {
+            engine.init_session(
+                &self.state.provider,
+                &self.state.cwd,
+                self.requested_session_id.as_deref(),
+            )?;
+            self.session_initialization_pending = false;
+            self.requested_session_id = None;
+            self.state.session_id = engine.current_session_id();
+        }
+        if self.state.pending_transcript().is_empty() && self.state.show_welcome {
+            self.commit_pending_history(terminal)?;
+        }
         self.state.begin_turn(&input);
+        self.commit_pending_history(terminal)?;
         let message_id = format!("tui-{}", MESSAGE_SEQUENCE.fetch_add(1, Ordering::Relaxed));
         let mut cancelled = false;
         let result = {
@@ -127,6 +354,7 @@ impl TuiRuntime {
             tokio::pin!(engine_future);
 
             loop {
+                self.commit_streaming_history(terminal)?;
                 self.draw(terminal)?;
                 tokio::select! {
                     result = &mut engine_future => break Some(result),
@@ -147,7 +375,7 @@ impl TuiRuntime {
                                 cancelled = true;
                                 break None;
                             }
-                            Event::Resize(_, _) => {}
+                            Event::Resize(_, _) => clear_synchronized(terminal)?,
                             _ => {}
                         }
                     }
@@ -161,6 +389,7 @@ impl TuiRuntime {
             engine.abort_current_turn("Turn cancelled by user");
             self.state.cancel_turn();
             self.drain_agent_events();
+            self.commit_pending_history(terminal)?;
             return Ok(false);
         }
 
@@ -168,6 +397,7 @@ impl TuiRuntime {
         match result {
             Some(Ok(result)) => {
                 self.state.finish_turn(result.turns, result.usage);
+                self.commit_pending_history(terminal)?;
                 Ok(false)
             }
             Some(Err(AgentError::UserAborted)) => {
@@ -177,6 +407,7 @@ impl TuiRuntime {
             Some(Err(error)) => {
                 self.state.busy = false;
                 self.state.handle_agent_event(AgentEvent::Error(error.to_string()));
+                self.commit_pending_history(terminal)?;
                 Ok(false)
             }
             None => Ok(false),
@@ -184,6 +415,9 @@ impl TuiRuntime {
     }
 
     fn handle_idle_key(&mut self, key: KeyEvent) -> IdleAction {
+        if self.state.session_picker.is_visible() {
+            return self.handle_session_picker_key(key);
+        }
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
             if self.state.composer.is_empty() {
                 return IdleAction::Exit;
@@ -201,8 +435,6 @@ impl TuiRuntime {
 
         let popup_visible = self.state.popup.is_visible(&self.state.composer.text());
         match key.code {
-            KeyCode::PageUp => self.state.scroll_back = self.state.scroll_back.saturating_add(5),
-            KeyCode::PageDown => self.state.scroll_back = self.state.scroll_back.saturating_sub(5),
             KeyCode::Up if popup_visible => self.state.popup.move_previous(),
             KeyCode::Down if popup_visible => self.state.popup.move_next(),
             KeyCode::Tab if popup_visible => {
@@ -230,6 +462,29 @@ impl TuiRuntime {
                     self.update_popup();
                 }
             }
+        }
+        IdleAction::Continue
+    }
+
+    fn handle_session_picker_key(&mut self, key: KeyEvent) -> IdleAction {
+        match key.code {
+            KeyCode::Up => self.state.session_picker.move_previous(),
+            KeyCode::Down => self.state.session_picker.move_next(),
+            KeyCode::Enter => {
+                let Some(session_id) = self.state.session_picker.selected_id() else {
+                    self.state.session_picker.close();
+                    return IdleAction::Continue;
+                };
+                self.state.session_picker.close();
+                self.state
+                    .push_info("Session", format!("Resuming session {session_id}…"));
+                return IdleAction::Outcome(TuiOutcome::ResumeSession(session_id));
+            }
+            KeyCode::Esc | KeyCode::Char('q') => self.state.session_picker.close(),
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.state.session_picker.close();
+            }
+            _ => {}
         }
         IdleAction::Continue
     }
@@ -287,18 +542,90 @@ impl TuiRuntime {
         }
     }
 
-    fn draw(&mut self, terminal: &mut AppTerminal) -> anyhow::Result<()> {
-        terminal.draw(|frame| ui::render(frame, &self.state))?;
+    fn draw(&self, terminal: &mut AppTerminal) -> anyhow::Result<()> {
+        draw_synchronized(terminal, |frame| ui::render(frame, &self.state))
+    }
+
+    fn commit_pending_history(&mut self, terminal: &mut AppTerminal) -> anyhow::Result<()> {
+        let width = terminal.size()?.width.saturating_sub(2).max(1);
+        let lines = if self.state.pending_transcript().is_empty() && self.state.show_welcome {
+            self.state.show_welcome = false;
+            ui::welcome_history_lines(&self.state, width)
+        } else {
+            ui::pending_history_lines(&self.state, width)
+        };
+        if lines.is_empty() {
+            return Ok(());
+        }
+        insert_history_lines(terminal, lines)?;
+        self.state.mark_transcript_committed();
+        clear_synchronized(terminal)
+    }
+
+    fn commit_streaming_history(&mut self, terminal: &mut AppTerminal) -> anyhow::Result<()> {
+        if !self.state.can_commit_streaming_lines() {
+            return Ok(());
+        }
+
+        let width = terminal.size()?.width.saturating_sub(2).max(1);
+        let Some(commit) = ui::streaming_history_commit(&self.state, width) else {
+            return Ok(());
+        };
+
+        insert_history_lines(terminal, commit.lines)?;
+        self.state
+            .commit_streaming_prefix(commit.complete_entries, commit.active_byte_count);
         Ok(())
     }
+}
+
+fn application_help(commands: &[CommandSpec]) -> String {
+    let mut output = String::from("Available commands:\n");
+    for command in commands {
+        output.push_str(&format!("  /{:<12} {}\n", command.name, command.description));
+    }
+    output.push_str(
+        "\nInput and navigation:\n\
+         Enter         Send message\n\
+         Shift+Enter   Insert newline\n\
+         Ctrl+C        Stop current turn, or quit when idle\n\
+         Mouse wheel   Scroll conversation\n\
+         Drag          Select terminal text\n\
+         /             Show command menu",
+    );
+    output
 }
 
 fn is_key_press(key: KeyEvent) -> bool {
     matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat)
 }
 
+fn starts_conversation(input: &str) -> bool {
+    !input.trim_start().starts_with('/')
+}
+
 enum IdleAction {
     Continue,
     Submit(String),
+    Outcome(TuiOutcome),
     Exit,
 }
+
+enum CommandAction {
+    PassThrough,
+    Handled,
+    Outcome(TuiOutcome),
+}
+
+fn permission_mode(value: &str) -> Option<SessionMode> {
+    match value {
+        "default" => Some(SessionMode::Default),
+        "auto_edit" | "auto-edit" => Some(SessionMode::AutoEdit),
+        "yolo" => Some(SessionMode::Yolo),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "app_test.rs"]
+mod app_test;

--- a/crates/aion-tui/src/app_command.rs
+++ b/crates/aion-tui/src/app_command.rs
@@ -1,0 +1,55 @@
+use aion_agent::commands::CommandSpec;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum ApplicationCommand {
+    Help,
+    Mcp,
+    Model(String),
+    New,
+    Permissions(String),
+    Resume(String),
+    Skills,
+    Status,
+}
+
+impl ApplicationCommand {
+    pub(super) fn parse(input: &str) -> Option<Self> {
+        let command = input.trim().strip_prefix('/')?;
+        let (name, args) = command.split_once(char::is_whitespace).unwrap_or((command, ""));
+        let args = args.trim().to_string();
+        match name {
+            "help" => Some(Self::Help),
+            "mcp" => Some(Self::Mcp),
+            "model" => Some(Self::Model(args)),
+            "new" => Some(Self::New),
+            "permissions" => Some(Self::Permissions(args)),
+            "resume" => Some(Self::Resume(args)),
+            "skills" => Some(Self::Skills),
+            "status" => Some(Self::Status),
+            _ => None,
+        }
+    }
+}
+
+pub(super) fn application_command_specs() -> Vec<CommandSpec> {
+    [
+        ("mcp", "Show connected MCP servers"),
+        ("model", "Show or change the active model"),
+        ("new", "Start a new session"),
+        ("permissions", "Show or change the approval mode"),
+        ("resume", "Resume a saved session"),
+        ("skills", "Show loaded skills"),
+        ("status", "Show session and context status"),
+    ]
+    .into_iter()
+    .map(|(name, description)| CommandSpec {
+        name: name.to_string(),
+        aliases: Vec::new(),
+        description: description.to_string(),
+    })
+    .collect()
+}
+
+#[cfg(test)]
+#[path = "app_command_test.rs"]
+mod app_command_test;

--- a/crates/aion-tui/src/app_command_test.rs
+++ b/crates/aion-tui/src/app_command_test.rs
@@ -1,0 +1,29 @@
+use super::{ApplicationCommand, application_command_specs};
+
+#[test]
+fn parses_application_commands_and_preserves_arguments() {
+    assert_eq!(
+        ApplicationCommand::parse("/model gpt-5.5"),
+        Some(ApplicationCommand::Model("gpt-5.5".to_string()))
+    );
+    assert_eq!(
+        ApplicationCommand::parse(" /resume   latest "),
+        Some(ApplicationCommand::Resume("latest".to_string()))
+    );
+    assert_eq!(ApplicationCommand::parse("/status"), Some(ApplicationCommand::Status));
+}
+
+#[test]
+fn ignores_agent_and_plain_messages() {
+    assert_eq!(ApplicationCommand::parse("/compact"), None);
+    assert_eq!(ApplicationCommand::parse("hello"), None);
+}
+
+#[test]
+fn catalog_contains_only_tui_owned_commands() {
+    let specs = application_command_specs();
+    assert!(specs.iter().any(|spec| spec.name == "status"));
+    assert!(specs.iter().any(|spec| spec.name == "resume"));
+    assert!(!specs.iter().any(|spec| spec.name == "compact"));
+    assert!(!specs.iter().any(|spec| spec.name == "help"));
+}

--- a/crates/aion-tui/src/app_test.rs
+++ b/crates/aion-tui/src/app_test.rs
@@ -1,0 +1,114 @@
+use aion_protocol::commands::SessionMode;
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::{IdleAction, TuiMetadata, TuiOutcome, TuiRuntime, application_help, permission_mode, starts_conversation};
+use crate::event::AgentEvent;
+use crate::session_picker::TuiSession;
+
+#[test]
+fn permission_modes_accept_documented_spellings() {
+    assert_eq!(permission_mode("default"), Some(SessionMode::Default));
+    assert_eq!(permission_mode("auto_edit"), Some(SessionMode::AutoEdit));
+    assert_eq!(permission_mode("auto-edit"), Some(SessionMode::AutoEdit));
+    assert_eq!(permission_mode("yolo"), Some(SessionMode::Yolo));
+    assert_eq!(permission_mode("unsafe"), None);
+}
+
+fn runtime() -> TuiRuntime {
+    TuiRuntime::new(TuiMetadata {
+        model: "model".to_string(),
+        provider: "provider".to_string(),
+        cwd: "/workspace".to_string(),
+        no_color: true,
+    })
+}
+
+fn session(id: &str) -> TuiSession {
+    TuiSession::new(
+        id.to_string(),
+        "model".to_string(),
+        "summary".to_string(),
+        "2026-08-13 12:00 UTC".to_string(),
+        2,
+    )
+}
+
+#[test]
+fn resume_picker_uses_arrow_keys_and_enter() {
+    let mut runtime = runtime();
+    runtime
+        .state
+        .session_picker
+        .set_sessions(vec![session("first"), session("second")]);
+    assert!(runtime.state.session_picker.open());
+
+    assert!(matches!(
+        runtime.handle_idle_key(KeyEvent::from(KeyCode::Down)),
+        IdleAction::Continue
+    ));
+    let outcome = runtime.handle_idle_key(KeyEvent::from(KeyCode::Enter));
+    assert!(matches!(
+        outcome,
+        IdleAction::Outcome(TuiOutcome::ResumeSession(session_id)) if session_id == "second"
+    ));
+    assert!(!runtime.state.session_picker.is_visible());
+}
+
+#[test]
+fn resetting_a_session_discards_queued_events_from_the_previous_session() {
+    let mut runtime = runtime();
+    runtime.reset_session(
+        "first-model".to_string(),
+        "first-provider".to_string(),
+        Some("first-session".to_string()),
+        &[],
+    );
+    assert!(!runtime.needs_full_clear);
+
+    runtime
+        .tx
+        .send(AgentEvent::Info("stale session output".to_string()))
+        .expect("event channel should be open");
+
+    runtime.reset_session(
+        "next-model".to_string(),
+        "next-provider".to_string(),
+        Some("next-session".to_string()),
+        &[],
+    );
+
+    assert!(runtime.state.transcript.is_empty());
+    assert!(runtime.needs_full_clear);
+}
+
+#[test]
+fn only_real_messages_start_a_lazy_session() {
+    assert!(starts_conversation("hello"));
+    assert!(starts_conversation("  hello"));
+    assert!(!starts_conversation("/status"));
+    assert!(!starts_conversation("  /resume latest"));
+}
+
+#[test]
+fn a_fresh_runtime_can_defer_a_requested_session_id() {
+    let mut runtime = runtime();
+    runtime.defer_session_initialization(Some("custom-session".to_string()));
+
+    assert!(runtime.session_initialization_pending);
+    assert_eq!(runtime.requested_session_id.as_deref(), Some("custom-session"));
+    assert!(runtime.state.session_id.is_none());
+}
+
+#[test]
+fn help_contains_input_and_navigation_guidance() {
+    let output = application_help(&[aion_agent::commands::CommandSpec {
+        name: "status".to_string(),
+        aliases: Vec::new(),
+        description: "Show status".to_string(),
+    }]);
+
+    assert!(output.contains("/status"));
+    assert!(output.contains("Shift+Enter   Insert newline"));
+    assert!(output.contains("Mouse wheel   Scroll conversation"));
+    assert!(output.contains("Drag          Select terminal text"));
+}

--- a/crates/aion-tui/src/command_popup.rs
+++ b/crates/aion-tui/src/command_popup.rs
@@ -46,6 +46,10 @@ impl CommandPopup {
         self.selected
     }
 
+    pub(super) fn commands(&self) -> &[CommandSpec] {
+        &self.commands
+    }
+
     pub(super) fn move_next(&mut self) {
         let count = self.matches().len();
         if count > 0 {

--- a/crates/aion-tui/src/command_popup.rs
+++ b/crates/aion-tui/src/command_popup.rs
@@ -1,0 +1,100 @@
+use aion_agent::commands::CommandSpec;
+
+#[derive(Debug, Default)]
+pub(super) struct CommandPopup {
+    commands: Vec<CommandSpec>,
+    filter: String,
+    selected: usize,
+}
+
+impl CommandPopup {
+    pub(super) fn set_commands(&mut self, commands: Vec<CommandSpec>) {
+        self.commands = commands;
+        self.selected = 0;
+    }
+
+    pub(super) fn update(&mut self, composer_text: &str) {
+        let filter = command_filter(composer_text).unwrap_or_default();
+        if filter != self.filter {
+            self.filter = filter;
+            self.selected = 0;
+        }
+        self.clamp_selection();
+    }
+
+    pub(super) fn is_visible(&self, composer_text: &str) -> bool {
+        command_filter(composer_text).is_some() && !self.matches().is_empty()
+    }
+
+    pub(super) fn matches(&self) -> Vec<&CommandSpec> {
+        let filter = self.filter.to_ascii_lowercase();
+        let mut prefix = Vec::new();
+        let mut contains = Vec::new();
+        for command in &self.commands {
+            let name = command.name.to_ascii_lowercase();
+            if name.starts_with(&filter) {
+                prefix.push(command);
+            } else if name.contains(&filter) || command.aliases.iter().any(|alias| alias.contains(&filter)) {
+                contains.push(command);
+            }
+        }
+        prefix.extend(contains);
+        prefix
+    }
+
+    pub(super) fn selected(&self) -> usize {
+        self.selected
+    }
+
+    pub(super) fn move_next(&mut self) {
+        let count = self.matches().len();
+        if count > 0 {
+            self.selected = (self.selected + 1) % count;
+        }
+    }
+
+    pub(super) fn move_previous(&mut self) {
+        let count = self.matches().len();
+        if count > 0 {
+            self.selected = self.selected.checked_sub(1).unwrap_or(count - 1);
+        }
+    }
+
+    pub(super) fn selected_name(&self) -> Option<String> {
+        self.matches().get(self.selected).map(|command| command.name.clone())
+    }
+
+    pub(super) fn recognizes(&self, input: &str) -> bool {
+        let Some(name) = input
+            .trim()
+            .strip_prefix('/')
+            .and_then(|value| value.split_whitespace().next())
+        else {
+            return false;
+        };
+        self.commands
+            .iter()
+            .any(|command| command.name == name || command.aliases.iter().any(|alias| alias == name))
+    }
+
+    fn clamp_selection(&mut self) {
+        let count = self.matches().len();
+        if count == 0 {
+            self.selected = 0;
+        } else if self.selected >= count {
+            self.selected = count - 1;
+        }
+    }
+}
+
+fn command_filter(text: &str) -> Option<String> {
+    let value = text.strip_prefix('/')?;
+    if value.chars().any(char::is_whitespace) {
+        return None;
+    }
+    Some(value.to_string())
+}
+
+#[cfg(test)]
+#[path = "command_popup_test.rs"]
+mod command_popup_test;

--- a/crates/aion-tui/src/command_popup_test.rs
+++ b/crates/aion-tui/src/command_popup_test.rs
@@ -1,0 +1,62 @@
+use aion_agent::commands::CommandSpec;
+
+use super::CommandPopup;
+
+fn commands() -> Vec<CommandSpec> {
+    vec![
+        CommandSpec {
+            name: "compact".to_string(),
+            aliases: Vec::new(),
+            description: "Compress context".to_string(),
+        },
+        CommandSpec {
+            name: "context".to_string(),
+            aliases: Vec::new(),
+            description: "Show context".to_string(),
+        },
+        CommandSpec {
+            name: "quit".to_string(),
+            aliases: vec!["exit".to_string()],
+            description: "Exit".to_string(),
+        },
+    ]
+}
+
+#[test]
+fn slash_opens_all_commands_and_text_filters_them() {
+    let mut popup = CommandPopup::default();
+    popup.set_commands(commands());
+    popup.update("/");
+    assert_eq!(popup.matches().len(), 3);
+    popup.update("/cont");
+    assert_eq!(popup.matches().len(), 1);
+    assert_eq!(popup.selected_name().as_deref(), Some("context"));
+}
+
+#[test]
+fn changing_filter_resets_stale_selection() {
+    let mut popup = CommandPopup::default();
+    popup.set_commands(commands());
+    popup.update("/");
+    popup.move_next();
+    popup.move_next();
+    popup.update("/co");
+    assert_eq!(popup.selected(), 0);
+    assert_eq!(popup.selected_name().as_deref(), Some("compact"));
+}
+
+#[test]
+fn alias_is_recognized_but_not_duplicated_in_catalog() {
+    let mut popup = CommandPopup::default();
+    popup.set_commands(commands());
+    assert!(popup.recognizes("/exit"));
+    assert_eq!(popup.matches().len(), 3);
+}
+
+#[test]
+fn arguments_close_command_popup() {
+    let mut popup = CommandPopup::default();
+    popup.set_commands(commands());
+    popup.update("/context all");
+    assert!(!popup.is_visible("/context all"));
+}

--- a/crates/aion-tui/src/composer.rs
+++ b/crates/aion-tui/src/composer.rs
@@ -1,0 +1,180 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use unicode_width::UnicodeWidthChar;
+
+#[derive(Debug, Default)]
+pub(super) struct Composer {
+    text: Vec<char>,
+    cursor: usize,
+    history: Vec<String>,
+    history_index: Option<usize>,
+}
+
+impl Composer {
+    pub(super) fn text(&self) -> String {
+        self.text.iter().collect()
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.text.clear();
+        self.cursor = 0;
+        self.history_index = None;
+    }
+
+    pub(super) fn take(&mut self) -> String {
+        let value = self.text();
+        if !value.trim().is_empty() {
+            self.history.push(value.clone());
+        }
+        self.clear();
+        value
+    }
+
+    pub(super) fn insert_text(&mut self, text: &str) {
+        for character in text.chars() {
+            self.text.insert(self.cursor, character);
+            self.cursor += 1;
+        }
+        self.history_index = None;
+    }
+
+    pub(super) fn input(&mut self, key: KeyEvent) -> bool {
+        match key.code {
+            KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.text.insert(self.cursor, character);
+                self.cursor += 1;
+            }
+            KeyCode::Backspace if self.cursor > 0 => {
+                self.cursor -= 1;
+                self.text.remove(self.cursor);
+            }
+            KeyCode::Delete if self.cursor < self.text.len() => {
+                self.text.remove(self.cursor);
+            }
+            KeyCode::Left if self.cursor > 0 => self.cursor -= 1,
+            KeyCode::Right if self.cursor < self.text.len() => self.cursor += 1,
+            KeyCode::Home => self.cursor = self.line_start(),
+            KeyCode::End => self.cursor = self.line_end(),
+            KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                self.text.insert(self.cursor, '\n');
+                self.cursor += 1;
+            }
+            KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.text.insert(self.cursor, '\n');
+                self.cursor += 1;
+            }
+            KeyCode::Up => self.recall_older(),
+            KeyCode::Down => self.recall_newer(),
+            _ => return false,
+        }
+        true
+    }
+
+    pub(super) fn replace_command(&mut self, name: &str) {
+        self.text = format!("/{name}").chars().collect();
+        self.cursor = self.text.len();
+        self.history_index = None;
+    }
+
+    pub(super) fn visual_cursor(&self, width: u16) -> (u16, u16) {
+        let usable_width = width.max(1) as usize;
+        let mut row = 0usize;
+        let mut column = 0usize;
+        for character in self.text.iter().take(self.cursor) {
+            if *character == '\n' {
+                row += 1;
+                column = 0;
+                continue;
+            }
+            let character_width = character.width().unwrap_or(0).max(1);
+            if column + character_width > usable_width {
+                row += 1;
+                column = 0;
+            }
+            column += character_width;
+            if column >= usable_width {
+                row += 1;
+                column = 0;
+            }
+        }
+        (column as u16, row as u16)
+    }
+
+    pub(super) fn visual_height(&self, width: u16, max_height: u16) -> u16 {
+        let (_, row) = self.visual_end(width);
+        (row + 1).clamp(1, max_height)
+    }
+
+    fn visual_end(&self, width: u16) -> (u16, u16) {
+        let usable_width = width.max(1) as usize;
+        let mut row = 0usize;
+        let mut column = 0usize;
+        for character in &self.text {
+            if *character == '\n' {
+                row += 1;
+                column = 0;
+                continue;
+            }
+            let character_width = character.width().unwrap_or(0).max(1);
+            if column + character_width > usable_width {
+                row += 1;
+                column = 0;
+            }
+            column += character_width;
+            if column >= usable_width {
+                row += 1;
+                column = 0;
+            }
+        }
+        (column as u16, row as u16)
+    }
+
+    fn line_start(&self) -> usize {
+        self.text[..self.cursor]
+            .iter()
+            .rposition(|character| *character == '\n')
+            .map_or(0, |index| index + 1)
+    }
+
+    fn line_end(&self) -> usize {
+        self.text[self.cursor..]
+            .iter()
+            .position(|character| *character == '\n')
+            .map_or(self.text.len(), |index| self.cursor + index)
+    }
+
+    fn recall_older(&mut self) {
+        if self.history.is_empty() || self.text.contains(&'\n') {
+            return;
+        }
+        let index = match self.history_index {
+            Some(index) => index.saturating_sub(1),
+            None => self.history.len() - 1,
+        };
+        self.set_history(index);
+    }
+
+    fn recall_newer(&mut self) {
+        let Some(index) = self.history_index else {
+            return;
+        };
+        if index + 1 >= self.history.len() {
+            self.clear();
+        } else {
+            self.set_history(index + 1);
+        }
+    }
+
+    fn set_history(&mut self, index: usize) {
+        self.text = self.history[index].chars().collect();
+        self.cursor = self.text.len();
+        self.history_index = Some(index);
+    }
+}
+
+#[cfg(test)]
+#[path = "composer_test.rs"]
+mod composer_test;

--- a/crates/aion-tui/src/composer_test.rs
+++ b/crates/aion-tui/src/composer_test.rs
@@ -1,0 +1,51 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::Composer;
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+#[test]
+fn edits_unicode_text_without_splitting_characters() {
+    let mut composer = Composer::default();
+    composer.input(key(KeyCode::Char('你')));
+    composer.input(key(KeyCode::Char('好')));
+    composer.input(key(KeyCode::Left));
+    composer.input(key(KeyCode::Backspace));
+    assert_eq!(composer.text(), "好");
+}
+
+#[test]
+fn command_replacement_moves_cursor_to_end() {
+    let mut composer = Composer::default();
+    composer.replace_command("compact");
+    composer.input(key(KeyCode::Char(' ')));
+    assert_eq!(composer.text(), "/compact ");
+}
+
+#[test]
+fn cjk_cursor_uses_display_width() {
+    let mut composer = Composer::default();
+    composer.input(key(KeyCode::Char('你')));
+    composer.input(key(KeyCode::Char('a')));
+    assert_eq!(composer.visual_cursor(20), (3, 0));
+}
+
+#[test]
+fn shift_enter_inserts_a_newline() {
+    let mut composer = Composer::default();
+    composer.input(key(KeyCode::Char('a')));
+    composer.input(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
+    composer.input(key(KeyCode::Char('b')));
+    assert_eq!(composer.text(), "a\nb");
+}
+
+#[test]
+fn control_j_is_a_newline_fallback() {
+    let mut composer = Composer::default();
+    composer.input(key(KeyCode::Char('a')));
+    composer.input(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL));
+    composer.input(key(KeyCode::Char('b')));
+    assert_eq!(composer.text(), "a\nb");
+}

--- a/crates/aion-tui/src/event.rs
+++ b/crates/aion-tui/src/event.rs
@@ -14,6 +14,7 @@ pub(super) enum AgentEvent {
     Info(String),
     Error(String),
     ToolCall {
+        call_id: String,
         name: String,
         input: String,
     },
@@ -69,8 +70,9 @@ impl OutputSink for TuiSink {
         self.send(AgentEvent::Thinking(text.to_string()));
     }
 
-    fn emit_tool_call(&self, _tool_use_id: &str, name: &str, input: &str) {
+    fn emit_tool_call(&self, tool_use_id: &str, name: &str, input: &str) {
         self.send(AgentEvent::ToolCall {
+            call_id: tool_use_id.to_string(),
             name: name.to_string(),
             input: input.to_string(),
         });

--- a/crates/aion-tui/src/event.rs
+++ b/crates/aion-tui/src/event.rs
@@ -1,0 +1,163 @@
+use std::io;
+use std::sync::Arc;
+
+use aion_agent::output::OutputSink;
+use aion_protocol::events::{ProtocolEvent, ToolStatus};
+use aion_protocol::writer::ProtocolEmitter;
+use tokio::sync::mpsc::UnboundedSender;
+
+#[derive(Debug)]
+pub(super) enum AgentEvent {
+    StreamStart,
+    TextDelta(String),
+    Thinking(String),
+    Info(String),
+    Error(String),
+    ToolCall {
+        name: String,
+        input: String,
+    },
+    ToolResult {
+        call_id: String,
+        name: String,
+        is_error: bool,
+        content: String,
+    },
+    ApprovalRequested {
+        call_id: String,
+        name: String,
+        description: String,
+        input: String,
+    },
+    ToolRunning {
+        call_id: String,
+        name: String,
+    },
+    ProtocolToolResult {
+        call_id: String,
+        name: String,
+        is_error: bool,
+        content: String,
+    },
+    ToolCancelled {
+        call_id: String,
+        name: String,
+        reason: String,
+    },
+}
+
+pub(super) struct TuiSink {
+    tx: UnboundedSender<AgentEvent>,
+}
+
+impl TuiSink {
+    pub(super) fn shared(tx: UnboundedSender<AgentEvent>) -> Arc<dyn OutputSink> {
+        Arc::new(Self { tx })
+    }
+
+    fn send(&self, event: AgentEvent) {
+        let _ = self.tx.send(event);
+    }
+}
+
+impl OutputSink for TuiSink {
+    fn emit_text_delta(&self, text: &str, _msg_id: &str) {
+        self.send(AgentEvent::TextDelta(text.to_string()));
+    }
+
+    fn emit_thinking(&self, text: &str, _msg_id: &str) {
+        self.send(AgentEvent::Thinking(text.to_string()));
+    }
+
+    fn emit_tool_call(&self, _tool_use_id: &str, name: &str, input: &str) {
+        self.send(AgentEvent::ToolCall {
+            name: name.to_string(),
+            input: input.to_string(),
+        });
+    }
+
+    fn emit_tool_result(&self, tool_use_id: &str, name: &str, is_error: bool, content: &str) {
+        self.send(AgentEvent::ToolResult {
+            call_id: tool_use_id.to_string(),
+            name: name.to_string(),
+            is_error,
+            content: content.to_string(),
+        });
+    }
+
+    fn emit_stream_start(&self, _msg_id: &str) {
+        self.send(AgentEvent::StreamStart);
+    }
+
+    fn emit_stream_end(
+        &self,
+        _msg_id: &str,
+        _turns: usize,
+        _input_tokens: u64,
+        _output_tokens: u64,
+        _cache_creation_tokens: u64,
+        _cache_read_tokens: u64,
+    ) {
+    }
+
+    fn emit_error(&self, msg: &str) {
+        self.send(AgentEvent::Error(msg.to_string()));
+    }
+
+    fn emit_info(&self, msg: &str) {
+        self.send(AgentEvent::Info(msg.to_string()));
+    }
+}
+
+pub(super) struct TuiProtocolEmitter {
+    tx: UnboundedSender<AgentEvent>,
+}
+
+impl TuiProtocolEmitter {
+    pub(super) fn shared(tx: UnboundedSender<AgentEvent>) -> Arc<dyn ProtocolEmitter> {
+        Arc::new(Self { tx })
+    }
+
+    fn send(&self, event: AgentEvent) {
+        let _ = self.tx.send(event);
+    }
+}
+
+impl ProtocolEmitter for TuiProtocolEmitter {
+    fn emit(&self, event: &ProtocolEvent) -> io::Result<()> {
+        match event {
+            ProtocolEvent::ToolRequest { call_id, tool, .. } => {
+                let input = serde_json::to_string_pretty(&tool.args).unwrap_or_else(|_| tool.args.to_string());
+                self.send(AgentEvent::ApprovalRequested {
+                    call_id: call_id.clone(),
+                    name: tool.name.clone(),
+                    description: tool.description.clone(),
+                    input,
+                });
+            }
+            ProtocolEvent::ToolRunning { call_id, tool_name, .. } => self.send(AgentEvent::ToolRunning {
+                call_id: call_id.clone(),
+                name: tool_name.clone(),
+            }),
+            ProtocolEvent::ToolResult {
+                call_id,
+                tool_name,
+                status,
+                output,
+                ..
+            } => self.send(AgentEvent::ProtocolToolResult {
+                call_id: call_id.clone(),
+                name: tool_name.clone(),
+                is_error: matches!(status, ToolStatus::Error),
+                content: output.clone(),
+            }),
+            ProtocolEvent::ToolCancelled { call_id, reason, .. } => self.send(AgentEvent::ToolCancelled {
+                call_id: call_id.clone(),
+                name: "tool".to_string(),
+                reason: reason.clone(),
+            }),
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/crates/aion-tui/src/lib.rs
+++ b/crates/aion-tui/src/lib.rs
@@ -1,10 +1,14 @@
 mod app;
+mod app_command;
 mod command_popup;
 mod composer;
 mod event;
+mod markdown;
+mod session_picker;
 mod state;
 mod terminal;
 mod transcript;
 mod ui;
 
-pub use app::{TuiMetadata, TuiRuntime};
+pub use app::{TuiMetadata, TuiOutcome, TuiRuntime};
+pub use session_picker::TuiSession;

--- a/crates/aion-tui/src/lib.rs
+++ b/crates/aion-tui/src/lib.rs
@@ -1,0 +1,10 @@
+mod app;
+mod command_popup;
+mod composer;
+mod event;
+mod state;
+mod terminal;
+mod transcript;
+mod ui;
+
+pub use app::{TuiMetadata, TuiRuntime};

--- a/crates/aion-tui/src/markdown.rs
+++ b/crates/aion-tui/src/markdown.rs
@@ -1,0 +1,437 @@
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct MarkdownTheme {
+    pub(super) body: Style,
+    pub(super) inline_code: Style,
+    pub(super) code_block: Style,
+    pub(super) marker: Style,
+    pub(super) rule: Style,
+}
+
+pub(super) fn render_markdown(input: &str, width: u16, theme: MarkdownTheme) -> Vec<Line<'static>> {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TASKLISTS);
+    let parser = Parser::new_ext(input, options);
+    let mut renderer = MarkdownRenderer::new(width.max(1), theme);
+    renderer.render(parser);
+    renderer.finish()
+}
+
+#[derive(Debug)]
+struct CodeBlock {
+    content: String,
+}
+
+#[derive(Debug)]
+struct ListState {
+    next: Option<u64>,
+    marker: Option<String>,
+    indent: usize,
+}
+
+impl ListState {
+    fn new(next: Option<u64>) -> Self {
+        Self {
+            next,
+            marker: None,
+            indent: 2,
+        }
+    }
+
+    fn begin_item(&mut self) {
+        let marker = if let Some(next) = &mut self.next {
+            let marker = format!("{next}. ");
+            *next = next.saturating_add(1);
+            marker
+        } else {
+            "• ".to_string()
+        };
+        self.indent = UnicodeWidthStr::width(marker.as_str());
+        self.marker = Some(marker);
+    }
+}
+
+#[derive(Debug, Default)]
+struct InlineState {
+    strong: usize,
+    emphasis: usize,
+    strikethrough: usize,
+    link: usize,
+    heading: Option<HeadingLevel>,
+}
+
+impl InlineState {
+    fn style(&self, base: Style) -> Style {
+        let mut modifiers = Modifier::empty();
+        if self.strong > 0 || self.heading.is_some() {
+            modifiers.insert(Modifier::BOLD);
+        }
+        if self.emphasis > 0 {
+            modifiers.insert(Modifier::ITALIC);
+        }
+        if self.strikethrough > 0 {
+            modifiers.insert(Modifier::CROSSED_OUT);
+        }
+        if self.link > 0 {
+            modifiers.insert(Modifier::UNDERLINED);
+        }
+        if matches!(self.heading, Some(HeadingLevel::H1)) {
+            modifiers.insert(Modifier::UNDERLINED);
+        }
+        base.add_modifier(modifiers)
+    }
+}
+
+#[derive(Debug)]
+struct LogicalLine {
+    prefix: Vec<Span<'static>>,
+    continuation_prefix: Vec<Span<'static>>,
+    spans: Vec<Span<'static>>,
+    fill: Option<Style>,
+}
+
+#[derive(Debug)]
+struct MarkdownRenderer {
+    width: u16,
+    theme: MarkdownTheme,
+    lines: Vec<Line<'static>>,
+    current: Option<LogicalLine>,
+    inline: InlineState,
+    lists: Vec<ListState>,
+    quote_depth: usize,
+    code_block: Option<CodeBlock>,
+    pending_separator: bool,
+}
+
+impl MarkdownRenderer {
+    fn new(width: u16, theme: MarkdownTheme) -> Self {
+        Self {
+            width,
+            theme,
+            lines: Vec::new(),
+            current: None,
+            inline: InlineState::default(),
+            lists: Vec::new(),
+            quote_depth: 0,
+            code_block: None,
+            pending_separator: false,
+        }
+    }
+
+    fn render<'a>(&mut self, parser: impl Iterator<Item = Event<'a>>) {
+        for event in parser {
+            if let Some(code_block) = self.code_block.as_mut() {
+                match event {
+                    Event::Text(text) | Event::Code(text) => code_block.content.push_str(&text),
+                    Event::SoftBreak | Event::HardBreak => code_block.content.push('\n'),
+                    Event::End(TagEnd::CodeBlock) => self.finish_code_block(),
+                    _ => {}
+                }
+                continue;
+            }
+
+            match event {
+                Event::Start(tag) => self.start_tag(tag),
+                Event::End(tag) => self.end_tag(tag),
+                Event::Text(text) | Event::Html(text) | Event::InlineHtml(text) => self.push_text(&text),
+                Event::Code(code) => {
+                    let style = self.inline.style(self.theme.inline_code);
+                    self.push_span(Span::styled(code.to_string(), style));
+                }
+                Event::SoftBreak => self.push_soft_break(),
+                Event::HardBreak => self.flush_current(),
+                Event::Rule => self.push_rule(),
+                Event::TaskListMarker(checked) => {
+                    self.push_text(if checked { "[x] " } else { "[ ] " });
+                }
+                Event::FootnoteReference(label) => self.push_text(&format!("[{label}]")),
+                Event::InlineMath(math) => self.push_text(&format!("${math}$")),
+                Event::DisplayMath(math) => {
+                    self.start_block();
+                    self.push_text(&math);
+                    self.flush_current();
+                    self.pending_separator = true;
+                }
+            }
+        }
+    }
+
+    fn start_tag(&mut self, tag: Tag<'_>) {
+        match tag {
+            Tag::Paragraph => self.start_block(),
+            Tag::Heading { level, .. } => {
+                self.start_block();
+                self.inline.heading = Some(level);
+            }
+            Tag::BlockQuote(_) => {
+                self.start_block();
+                self.quote_depth = self.quote_depth.saturating_add(1);
+            }
+            Tag::CodeBlock(_) => {
+                self.start_block();
+                self.code_block = Some(CodeBlock { content: String::new() });
+            }
+            Tag::List(next) => {
+                if self.lists.is_empty() {
+                    self.start_block();
+                } else {
+                    self.flush_current();
+                }
+                self.lists.push(ListState::new(next));
+            }
+            Tag::Item => {
+                self.flush_current();
+                if let Some(list) = self.lists.last_mut() {
+                    list.begin_item();
+                }
+            }
+            Tag::Emphasis => self.inline.emphasis = self.inline.emphasis.saturating_add(1),
+            Tag::Strong => self.inline.strong = self.inline.strong.saturating_add(1),
+            Tag::Strikethrough => self.inline.strikethrough = self.inline.strikethrough.saturating_add(1),
+            Tag::Link { .. } => self.inline.link = self.inline.link.saturating_add(1),
+            Tag::Image { .. } => self.inline.emphasis = self.inline.emphasis.saturating_add(1),
+            Tag::HtmlBlock => self.start_block(),
+            _ => {}
+        }
+    }
+
+    fn end_tag(&mut self, tag: TagEnd) {
+        match tag {
+            TagEnd::Paragraph => {
+                self.flush_current();
+                if self.lists.is_empty() {
+                    self.pending_separator = true;
+                }
+            }
+            TagEnd::Heading(_) => {
+                self.flush_current();
+                self.inline.heading = None;
+                self.pending_separator = true;
+            }
+            TagEnd::BlockQuote(_) => {
+                self.flush_current();
+                self.quote_depth = self.quote_depth.saturating_sub(1);
+                self.pending_separator = true;
+            }
+            TagEnd::CodeBlock => self.finish_code_block(),
+            TagEnd::List(_) => {
+                self.flush_current();
+                self.lists.pop();
+                if self.lists.is_empty() {
+                    self.pending_separator = true;
+                }
+            }
+            TagEnd::Item => {
+                self.flush_current();
+                if let Some(list) = self.lists.last_mut() {
+                    list.marker = None;
+                }
+            }
+            TagEnd::Emphasis => self.inline.emphasis = self.inline.emphasis.saturating_sub(1),
+            TagEnd::Strong => self.inline.strong = self.inline.strong.saturating_sub(1),
+            TagEnd::Strikethrough => self.inline.strikethrough = self.inline.strikethrough.saturating_sub(1),
+            TagEnd::Link => self.inline.link = self.inline.link.saturating_sub(1),
+            TagEnd::Image => self.inline.emphasis = self.inline.emphasis.saturating_sub(1),
+            TagEnd::HtmlBlock => {
+                self.flush_current();
+                self.pending_separator = true;
+            }
+            _ => {}
+        }
+    }
+
+    fn start_block(&mut self) {
+        self.flush_current();
+        if self.pending_separator && self.lines.last().is_some_and(|line| !line.spans.is_empty()) {
+            self.lines.push(Line::default());
+        }
+        self.pending_separator = false;
+    }
+
+    fn ensure_current(&mut self) -> &mut LogicalLine {
+        if self.current.is_none() {
+            let (prefix, continuation_prefix) = self.take_prefixes();
+            self.current = Some(LogicalLine {
+                prefix,
+                continuation_prefix,
+                spans: Vec::new(),
+                fill: None,
+            });
+        }
+        self.current.as_mut().expect("current markdown line is initialized")
+    }
+
+    fn take_prefixes(&mut self) -> (Vec<Span<'static>>, Vec<Span<'static>>) {
+        let mut prefix = Vec::new();
+        let mut continuation = Vec::new();
+        for _ in 0..self.quote_depth {
+            prefix.push(Span::styled("│ ", self.theme.marker));
+            continuation.push(Span::styled("│ ", self.theme.marker));
+        }
+        let list_count = self.lists.len();
+        for (index, list) in self.lists.iter_mut().enumerate() {
+            if index + 1 == list_count
+                && let Some(marker) = list.marker.take()
+            {
+                continuation.push(Span::raw(" ".repeat(list.indent)));
+                prefix.push(Span::styled(marker, self.theme.marker));
+            } else {
+                let indent = " ".repeat(list.indent);
+                prefix.push(Span::raw(indent.clone()));
+                continuation.push(Span::raw(indent));
+            }
+        }
+        (prefix, continuation)
+    }
+
+    fn push_text(&mut self, text: &str) {
+        let style = self.inline.style(self.theme.body);
+        let mut parts = text.split('\n').peekable();
+        while let Some(part) = parts.next() {
+            if !part.is_empty() {
+                self.push_span(Span::styled(part.to_string(), style));
+            }
+            if parts.peek().is_some() {
+                self.flush_current();
+            }
+        }
+    }
+
+    fn push_span(&mut self, span: Span<'static>) {
+        self.ensure_current().spans.push(span);
+    }
+
+    fn push_soft_break(&mut self) {
+        let needs_space = self
+            .current
+            .as_ref()
+            .and_then(|line| line.spans.last())
+            .is_some_and(|span| {
+                span.content
+                    .chars()
+                    .last()
+                    .is_some_and(|character| !character.is_whitespace())
+            });
+        if needs_space {
+            self.push_text(" ");
+        }
+    }
+
+    fn push_rule(&mut self) {
+        self.start_block();
+        let width = usize::from(self.width).min(32);
+        self.lines
+            .push(Line::from(Span::styled("─".repeat(width), self.theme.rule)));
+        self.pending_separator = true;
+    }
+
+    fn finish_code_block(&mut self) {
+        let Some(code_block) = self.code_block.take() else {
+            return;
+        };
+        let content = code_block.content.strip_suffix('\n').unwrap_or(&code_block.content);
+        for code_line in content.split('\n') {
+            let (mut prefix, mut continuation_prefix) = self.take_prefixes();
+            prefix.push(Span::styled(" ", self.theme.code_block));
+            continuation_prefix.push(Span::styled(" ", self.theme.code_block));
+            self.push_logical(LogicalLine {
+                prefix,
+                continuation_prefix,
+                spans: vec![Span::styled(code_line.to_string(), self.theme.code_block)],
+                fill: Some(self.theme.code_block),
+            });
+        }
+        self.pending_separator = true;
+    }
+
+    fn flush_current(&mut self) {
+        if let Some(line) = self.current.take() {
+            self.push_logical(line);
+        }
+    }
+
+    fn push_logical(&mut self, line: LogicalLine) {
+        self.lines.extend(wrap_line(line, self.width));
+    }
+
+    fn finish(mut self) -> Vec<Line<'static>> {
+        if self.code_block.is_some() {
+            self.finish_code_block();
+        }
+        self.flush_current();
+        while self.lines.last().is_some_and(|line| line.spans.is_empty()) {
+            self.lines.pop();
+        }
+        self.lines
+    }
+}
+
+fn wrap_line(line: LogicalLine, width: u16) -> Vec<Line<'static>> {
+    let max_width = usize::from(width.max(1));
+    let initial_prefix_width = spans_width(&line.prefix);
+    let continuation_prefix_width = spans_width(&line.continuation_prefix);
+    let mut output = Vec::new();
+    let mut row = line.prefix;
+    let mut row_width = initial_prefix_width;
+    let mut continuation = false;
+
+    for span in line.spans {
+        let style = span.style;
+        let mut fragment = String::new();
+        for character in span.content.chars() {
+            let character_width = character.width().unwrap_or(1).max(1);
+            let content_start = if continuation {
+                continuation_prefix_width
+            } else {
+                initial_prefix_width
+            };
+            if row_width > content_start && row_width.saturating_add(character_width) > max_width {
+                push_fragment(&mut row, &mut fragment, style);
+                finish_row(&mut output, row, row_width, max_width, line.fill);
+                row = line.continuation_prefix.clone();
+                row_width = spans_width(&row);
+                continuation = true;
+            }
+            fragment.push(character);
+            row_width = row_width.saturating_add(character_width);
+        }
+        push_fragment(&mut row, &mut fragment, style);
+    }
+
+    finish_row(&mut output, row, row_width, max_width, line.fill);
+    output
+}
+
+fn push_fragment(row: &mut Vec<Span<'static>>, fragment: &mut String, style: Style) {
+    if !fragment.is_empty() {
+        row.push(Span::styled(std::mem::take(fragment), style));
+    }
+}
+
+fn finish_row(
+    output: &mut Vec<Line<'static>>,
+    mut row: Vec<Span<'static>>,
+    row_width: usize,
+    max_width: usize,
+    fill: Option<Style>,
+) {
+    if let Some(fill) = fill
+        && row_width < max_width
+    {
+        row.push(Span::styled(" ".repeat(max_width - row_width), fill));
+    }
+    output.push(Line::from(row));
+}
+
+fn spans_width(spans: &[Span<'_>]) -> usize {
+    spans.iter().map(|span| span.width()).sum()
+}
+
+#[cfg(test)]
+#[path = "markdown_test.rs"]
+mod markdown_test;

--- a/crates/aion-tui/src/markdown_test.rs
+++ b/crates/aion-tui/src/markdown_test.rs
@@ -1,0 +1,96 @@
+use ratatui::style::{Color, Modifier, Style};
+use unicode_width::UnicodeWidthStr;
+
+use super::{MarkdownTheme, render_markdown};
+
+fn theme() -> MarkdownTheme {
+    MarkdownTheme {
+        body: Style::default().fg(Color::Black),
+        inline_code: Style::default().fg(Color::Black).bg(Color::Rgb(232, 232, 232)),
+        code_block: Style::default().fg(Color::Black).bg(Color::Rgb(245, 245, 245)),
+        marker: Style::default().fg(Color::Rgb(92, 92, 92)),
+        rule: Style::default().fg(Color::Rgb(146, 146, 146)),
+    }
+}
+
+#[test]
+fn inline_markdown_removes_delimiters_and_preserves_semantic_styles() {
+    let lines = render_markdown("Use `cargo check`, **carefully**, with *context*.", 80, theme());
+    let rendered = lines.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n");
+    assert_eq!(rendered, "Use cargo check, carefully, with context.");
+    assert!(!rendered.contains('`'));
+    assert!(!rendered.contains('*'));
+
+    let spans = &lines[0].spans;
+    let code = spans
+        .iter()
+        .find(|span| span.content.contains("cargo check"))
+        .expect("inline code span");
+    assert_eq!(code.style.bg, Some(Color::Rgb(232, 232, 232)));
+    let strong = spans
+        .iter()
+        .find(|span| span.content == "carefully")
+        .expect("strong span");
+    assert!(strong.style.add_modifier.contains(Modifier::BOLD));
+    let emphasis = spans
+        .iter()
+        .find(|span| span.content == "context")
+        .expect("emphasis span");
+    assert!(emphasis.style.add_modifier.contains(Modifier::ITALIC));
+}
+
+#[test]
+fn fenced_code_block_hides_fences_and_fills_each_code_row() {
+    let lines = render_markdown("```rust\nfn main() {\n    println!(\"hi\");\n}\n```", 28, theme());
+    let rendered = lines.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n");
+    assert!(!rendered.contains("rust"));
+    assert!(rendered.contains("fn main()"));
+    assert!(rendered.contains("    println!"));
+    assert!(!rendered.contains("```"));
+
+    for line in &lines {
+        assert_eq!(UnicodeWidthStr::width(line.to_string().as_str()), 28);
+        assert_eq!(
+            line.spans.last().and_then(|span| span.style.bg),
+            Some(Color::Rgb(245, 245, 245))
+        );
+    }
+}
+
+#[test]
+fn lists_quotes_and_headings_render_without_source_markers() {
+    let markdown = "## Summary\n\n- first\n- **second**\n\n> quoted `value`";
+    let lines = render_markdown(markdown, 40, theme());
+    let rendered = lines.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n");
+    assert!(rendered.contains("Summary"));
+    assert!(rendered.contains("• first"));
+    assert!(rendered.contains("• second"));
+    assert!(rendered.contains("│ quoted value"));
+    assert!(!rendered.contains("##"));
+    assert!(!rendered.contains("**"));
+
+    let heading = lines
+        .iter()
+        .flat_map(|line| &line.spans)
+        .find(|span| span.content == "Summary")
+        .expect("heading span");
+    assert!(heading.style.add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn wrapping_respects_cjk_width_and_keeps_code_background() {
+    let lines = render_markdown("```\n中文中文中文中文\n```", 7, theme());
+    assert_eq!(
+        lines.len(),
+        3,
+        "rendered lines: {:?}",
+        lines.iter().map(ToString::to_string).collect::<Vec<_>>()
+    );
+    for line in lines {
+        assert_eq!(UnicodeWidthStr::width(line.to_string().as_str()), 7);
+        assert_eq!(
+            line.spans.last().and_then(|span| span.style.bg),
+            Some(Color::Rgb(245, 245, 245))
+        );
+    }
+}

--- a/crates/aion-tui/src/session_picker.rs
+++ b/crates/aion-tui/src/session_picker.rs
@@ -1,0 +1,103 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TuiSession {
+    id: String,
+    model: String,
+    summary: String,
+    updated_at: String,
+    message_count: usize,
+}
+
+impl TuiSession {
+    pub fn new(id: String, model: String, summary: String, updated_at: String, message_count: usize) -> Self {
+        Self {
+            id,
+            model,
+            summary,
+            updated_at,
+            message_count,
+        }
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub(crate) fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub(crate) fn summary(&self) -> &str {
+        &self.summary
+    }
+
+    pub(crate) fn updated_at(&self) -> &str {
+        &self.updated_at
+    }
+
+    pub(crate) fn message_count(&self) -> usize {
+        self.message_count
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct SessionPicker {
+    sessions: Vec<TuiSession>,
+    selected: usize,
+    visible: bool,
+}
+
+impl SessionPicker {
+    pub(super) fn set_sessions(&mut self, sessions: Vec<TuiSession>) {
+        self.sessions = sessions;
+        self.selected = 0;
+        if self.sessions.is_empty() {
+            self.visible = false;
+        }
+    }
+
+    pub(super) fn open(&mut self) -> bool {
+        self.selected = 0;
+        self.visible = !self.sessions.is_empty();
+        self.visible
+    }
+
+    pub(super) fn close(&mut self) {
+        self.visible = false;
+    }
+
+    pub(super) fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+
+    pub(super) fn sessions(&self) -> &[TuiSession] {
+        &self.sessions
+    }
+
+    pub(super) fn selected(&self) -> usize {
+        self.selected
+    }
+
+    pub(super) fn selected_id(&self) -> Option<String> {
+        self.sessions.get(self.selected).map(|session| session.id.clone())
+    }
+
+    pub(super) fn move_next(&mut self) {
+        if !self.sessions.is_empty() {
+            self.selected = (self.selected + 1) % self.sessions.len();
+        }
+    }
+
+    pub(super) fn move_previous(&mut self) {
+        if !self.sessions.is_empty() {
+            self.selected = self.selected.checked_sub(1).unwrap_or(self.sessions.len() - 1);
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "session_picker_test.rs"]
+mod session_picker_test;

--- a/crates/aion-tui/src/session_picker_test.rs
+++ b/crates/aion-tui/src/session_picker_test.rs
@@ -1,0 +1,30 @@
+use super::{SessionPicker, TuiSession};
+
+fn session(id: &str) -> TuiSession {
+    TuiSession::new(
+        id.to_string(),
+        "model".to_string(),
+        "summary".to_string(),
+        "2026-08-13 12:00 UTC".to_string(),
+        2,
+    )
+}
+
+#[test]
+fn selection_wraps_in_both_directions() {
+    let mut picker = SessionPicker::default();
+    picker.set_sessions(vec![session("first"), session("second")]);
+    assert!(picker.open());
+
+    picker.move_previous();
+    assert_eq!(picker.selected_id().as_deref(), Some("second"));
+    picker.move_next();
+    assert_eq!(picker.selected_id().as_deref(), Some("first"));
+}
+
+#[test]
+fn empty_catalog_cannot_open() {
+    let mut picker = SessionPicker::default();
+    assert!(!picker.open());
+    assert!(!picker.is_visible());
+}

--- a/crates/aion-tui/src/state.rs
+++ b/crates/aion-tui/src/state.rs
@@ -1,12 +1,14 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use aion_agent::commands::CommandSpec;
 use aion_types::message::{Message, TokenUsage};
 
+use crate::app_command::application_command_specs;
 use crate::command_popup::CommandPopup;
 use crate::composer::Composer;
 use crate::event::AgentEvent;
-use crate::transcript::{EntryKind, TranscriptEntry, entries_from_messages};
+use crate::session_picker::SessionPicker;
+use crate::transcript::{EntryKind, ToolStepStatus, TranscriptEntry, entries_from_messages};
 
 #[derive(Debug)]
 pub(super) struct ApprovalRequest {
@@ -25,15 +27,19 @@ pub(super) struct AppState {
     pub(super) no_color: bool,
     pub(super) composer: Composer,
     pub(super) popup: CommandPopup,
+    pub(super) session_picker: SessionPicker,
     pub(super) transcript: Vec<TranscriptEntry>,
+    pub(super) committed_transcript: usize,
+    pub(super) show_welcome: bool,
     pub(super) approval: Option<ApprovalRequest>,
+    pub(super) initializing: bool,
     pub(super) busy: bool,
     pub(super) spinner_frame: usize,
     pub(super) usage: TokenUsage,
     pub(super) turns: usize,
-    pub(super) scroll_back: usize,
     active_assistant: Option<usize>,
     active_thinking: Option<usize>,
+    active_tools: HashMap<String, usize>,
     protocol_results: HashSet<String>,
 }
 
@@ -47,32 +53,107 @@ impl AppState {
             no_color,
             composer: Composer::default(),
             popup: CommandPopup::default(),
+            session_picker: SessionPicker::default(),
             transcript: Vec::new(),
+            committed_transcript: 0,
+            show_welcome: true,
             approval: None,
+            initializing: false,
             busy: false,
             spinner_frame: 0,
             usage: TokenUsage::default(),
             turns: 0,
-            scroll_back: 0,
             active_assistant: None,
             active_thinking: None,
+            active_tools: HashMap::new(),
             protocol_results: HashSet::new(),
         }
     }
 
     pub(super) fn set_commands(&mut self, commands: Vec<CommandSpec>) {
+        let mut commands = commands;
+        commands.extend(application_command_specs());
+        commands.sort_by(|left, right| left.name.cmp(&right.name));
+        commands.dedup_by(|left, right| left.name == right.name);
         self.popup.set_commands(commands);
     }
 
     pub(super) fn set_history(&mut self, messages: &[Message]) {
         self.transcript = entries_from_messages(messages);
+        self.committed_transcript = 0;
+        self.show_welcome = messages.is_empty();
         self.active_assistant = None;
         self.active_thinking = None;
+        self.active_tools.clear();
+    }
+
+    pub(super) fn begin_initialization(&mut self) {
+        self.initializing = true;
+    }
+
+    pub(super) fn reset_session(
+        &mut self,
+        model: String,
+        provider: String,
+        session_id: Option<String>,
+        messages: &[Message],
+    ) {
+        self.model = model;
+        self.provider = provider;
+        self.session_id = session_id;
+        self.set_history(messages);
+        self.approval = None;
+        self.initializing = false;
+        self.busy = false;
+        self.spinner_frame = 0;
+        self.usage = TokenUsage::default();
+        self.turns = 0;
+        self.composer.clear();
+        self.popup.update("");
+        self.session_picker.close();
+        self.active_tools.clear();
+        self.protocol_results.clear();
+    }
+
+    pub(super) fn pending_transcript(&self) -> &[TranscriptEntry] {
+        &self.transcript[self.committed_transcript.min(self.transcript.len())..]
+    }
+
+    pub(super) fn mark_transcript_committed(&mut self) {
+        self.committed_transcript = self.transcript.len();
+    }
+
+    pub(super) fn commit_streaming_prefix(&mut self, complete_entries: usize, active_byte_count: usize) {
+        let pending_count = self.pending_transcript().len();
+        self.committed_transcript = self
+            .committed_transcript
+            .saturating_add(complete_entries.min(pending_count));
+        if active_byte_count > 0
+            && let Some(active) = self.transcript.get_mut(self.committed_transcript)
+        {
+            active.advance_display_offset(active_byte_count);
+        }
+    }
+
+    pub(super) fn can_commit_streaming_lines(&self) -> bool {
+        self.busy
+            && self
+                .pending_transcript()
+                .last()
+                .is_some_and(|entry| matches!(entry.kind, EntryKind::Assistant | EntryKind::Thinking))
+    }
+
+    pub(super) fn push_info(&mut self, label: &str, text: impl Into<String>) {
+        self.transcript.push(TranscriptEntry::new(EntryKind::Info, label, text));
+    }
+
+    pub(super) fn push_error(&mut self, text: impl Into<String>) {
+        self.transcript
+            .push(TranscriptEntry::new(EntryKind::Error, "Error", text));
     }
 
     pub(super) fn begin_turn(&mut self, input: &str) {
         self.busy = true;
-        self.scroll_back = 0;
         self.active_assistant = None;
         self.active_thinking = None;
         if !self.popup.recognizes(input) {
@@ -106,7 +187,6 @@ impl AppState {
     }
 
     pub(super) fn handle_agent_event(&mut self, event: AgentEvent) {
-        self.scroll_back = 0;
         match event {
             AgentEvent::StreamStart => {
                 self.active_assistant = None;
@@ -120,8 +200,8 @@ impl AppState {
             AgentEvent::Error(text) => self
                 .transcript
                 .push(TranscriptEntry::new(EntryKind::Error, "Error", text)),
-            AgentEvent::ToolCall { name, input } => {
-                self.transcript.push(TranscriptEntry::new(EntryKind::Tool, name, input));
+            AgentEvent::ToolCall { call_id, name, input } => {
+                self.update_tool_step(&call_id, &name, ToolStepStatus::Queued, Some(input))
             }
             AgentEvent::ToolResult {
                 call_id,
@@ -132,8 +212,12 @@ impl AppState {
                 if self.protocol_results.remove(&call_id) {
                     return;
                 }
-                let kind = if is_error { EntryKind::Error } else { EntryKind::Tool };
-                self.transcript.push(TranscriptEntry::new(kind, name, content));
+                let status = if is_error {
+                    ToolStepStatus::Error
+                } else {
+                    ToolStepStatus::Success
+                };
+                self.update_tool_step(&call_id, &name, status, Some(content));
             }
             AgentEvent::ProtocolToolResult {
                 call_id,
@@ -141,9 +225,13 @@ impl AppState {
                 is_error,
                 content,
             } => {
+                let status = if is_error {
+                    ToolStepStatus::Error
+                } else {
+                    ToolStepStatus::Success
+                };
+                self.update_tool_step(&call_id, &name, status, Some(content));
                 self.protocol_results.insert(call_id);
-                let kind = if is_error { EntryKind::Error } else { EntryKind::Tool };
-                self.transcript.push(TranscriptEntry::new(kind, name, content));
             }
             AgentEvent::ApprovalRequested {
                 call_id,
@@ -151,6 +239,7 @@ impl AppState {
                 description,
                 input,
             } => {
+                self.update_tool_step(&call_id, &name, ToolStepStatus::Approval, None);
                 self.approval = Some(ApprovalRequest {
                     call_id,
                     name,
@@ -162,20 +251,35 @@ impl AppState {
                 if self.approval.as_ref().is_some_and(|request| request.call_id == call_id) {
                     self.approval = None;
                 }
-                self.transcript
-                    .push(TranscriptEntry::new(EntryKind::Tool, name, "Running…"));
+                self.update_tool_step(&call_id, &name, ToolStepStatus::Running, None);
             }
             AgentEvent::ToolCancelled { call_id, name, reason } => {
                 if self.approval.as_ref().is_some_and(|request| request.call_id == call_id) {
                     self.approval = None;
                 }
-                self.transcript.push(TranscriptEntry::new(
-                    EntryKind::Error,
-                    name,
-                    format!("Cancelled: {reason}"),
-                ));
+                self.update_tool_step(&call_id, &name, ToolStepStatus::Cancelled, Some(reason));
             }
         }
+    }
+
+    fn update_tool_step(&mut self, call_id: &str, name: &str, status: ToolStepStatus, text: Option<String>) {
+        if let Some(index) = self.active_tools.get(call_id).copied()
+            && let Some(entry) = self.transcript.get_mut(index)
+        {
+            if name != "tool" {
+                entry.label = name.to_string();
+            }
+            entry.tool_status = Some(status);
+            if let Some(text) = text {
+                entry.text = text;
+            }
+            return;
+        }
+
+        let index = self.transcript.len();
+        self.transcript
+            .push(TranscriptEntry::tool(name, text.unwrap_or_default(), status));
+        self.active_tools.insert(call_id.to_string(), index);
     }
 
     fn append_stream(&mut self, kind: EntryKind, label: &str, text: String) {

--- a/crates/aion-tui/src/state.rs
+++ b/crates/aion-tui/src/state.rs
@@ -1,0 +1,198 @@
+use std::collections::HashSet;
+
+use aion_agent::commands::CommandSpec;
+use aion_types::message::{Message, TokenUsage};
+
+use crate::command_popup::CommandPopup;
+use crate::composer::Composer;
+use crate::event::AgentEvent;
+use crate::transcript::{EntryKind, TranscriptEntry, entries_from_messages};
+
+#[derive(Debug)]
+pub(super) struct ApprovalRequest {
+    pub(super) call_id: String,
+    pub(super) name: String,
+    pub(super) description: String,
+    pub(super) input: String,
+}
+
+#[derive(Debug)]
+pub(super) struct AppState {
+    pub(super) model: String,
+    pub(super) provider: String,
+    pub(super) cwd: String,
+    pub(super) session_id: Option<String>,
+    pub(super) no_color: bool,
+    pub(super) composer: Composer,
+    pub(super) popup: CommandPopup,
+    pub(super) transcript: Vec<TranscriptEntry>,
+    pub(super) approval: Option<ApprovalRequest>,
+    pub(super) busy: bool,
+    pub(super) spinner_frame: usize,
+    pub(super) usage: TokenUsage,
+    pub(super) turns: usize,
+    pub(super) scroll_back: usize,
+    active_assistant: Option<usize>,
+    active_thinking: Option<usize>,
+    protocol_results: HashSet<String>,
+}
+
+impl AppState {
+    pub(super) fn new(model: String, provider: String, cwd: String, no_color: bool) -> Self {
+        Self {
+            model,
+            provider,
+            cwd,
+            session_id: None,
+            no_color,
+            composer: Composer::default(),
+            popup: CommandPopup::default(),
+            transcript: Vec::new(),
+            approval: None,
+            busy: false,
+            spinner_frame: 0,
+            usage: TokenUsage::default(),
+            turns: 0,
+            scroll_back: 0,
+            active_assistant: None,
+            active_thinking: None,
+            protocol_results: HashSet::new(),
+        }
+    }
+
+    pub(super) fn set_commands(&mut self, commands: Vec<CommandSpec>) {
+        self.popup.set_commands(commands);
+    }
+
+    pub(super) fn set_history(&mut self, messages: &[Message]) {
+        self.transcript = entries_from_messages(messages);
+        self.active_assistant = None;
+        self.active_thinking = None;
+    }
+
+    pub(super) fn begin_turn(&mut self, input: &str) {
+        self.busy = true;
+        self.scroll_back = 0;
+        self.active_assistant = None;
+        self.active_thinking = None;
+        if !self.popup.recognizes(input) {
+            self.transcript.push(TranscriptEntry::new(EntryKind::User, "", input));
+        }
+    }
+
+    pub(super) fn finish_turn(&mut self, turns: usize, usage: TokenUsage) {
+        self.busy = false;
+        self.turns = turns;
+        self.usage = usage;
+        self.active_assistant = None;
+        self.active_thinking = None;
+    }
+
+    pub(super) fn cancel_turn(&mut self) {
+        self.busy = false;
+        self.active_assistant = None;
+        self.active_thinking = None;
+        self.transcript.push(TranscriptEntry::new(
+            EntryKind::Info,
+            "Stopped",
+            "Turn cancelled by user",
+        ));
+    }
+
+    pub(super) fn tick(&mut self) {
+        if self.busy {
+            self.spinner_frame = (self.spinner_frame + 1) % 4;
+        }
+    }
+
+    pub(super) fn handle_agent_event(&mut self, event: AgentEvent) {
+        self.scroll_back = 0;
+        match event {
+            AgentEvent::StreamStart => {
+                self.active_assistant = None;
+                self.active_thinking = None;
+            }
+            AgentEvent::TextDelta(text) => self.append_stream(EntryKind::Assistant, "", text),
+            AgentEvent::Thinking(text) => self.append_stream(EntryKind::Thinking, "Thinking", text),
+            AgentEvent::Info(text) => self
+                .transcript
+                .push(TranscriptEntry::new(EntryKind::Info, "Info", text)),
+            AgentEvent::Error(text) => self
+                .transcript
+                .push(TranscriptEntry::new(EntryKind::Error, "Error", text)),
+            AgentEvent::ToolCall { name, input } => {
+                self.transcript.push(TranscriptEntry::new(EntryKind::Tool, name, input));
+            }
+            AgentEvent::ToolResult {
+                call_id,
+                name,
+                is_error,
+                content,
+            } => {
+                if self.protocol_results.remove(&call_id) {
+                    return;
+                }
+                let kind = if is_error { EntryKind::Error } else { EntryKind::Tool };
+                self.transcript.push(TranscriptEntry::new(kind, name, content));
+            }
+            AgentEvent::ProtocolToolResult {
+                call_id,
+                name,
+                is_error,
+                content,
+            } => {
+                self.protocol_results.insert(call_id);
+                let kind = if is_error { EntryKind::Error } else { EntryKind::Tool };
+                self.transcript.push(TranscriptEntry::new(kind, name, content));
+            }
+            AgentEvent::ApprovalRequested {
+                call_id,
+                name,
+                description,
+                input,
+            } => {
+                self.approval = Some(ApprovalRequest {
+                    call_id,
+                    name,
+                    description,
+                    input,
+                });
+            }
+            AgentEvent::ToolRunning { call_id, name } => {
+                if self.approval.as_ref().is_some_and(|request| request.call_id == call_id) {
+                    self.approval = None;
+                }
+                self.transcript
+                    .push(TranscriptEntry::new(EntryKind::Tool, name, "Running…"));
+            }
+            AgentEvent::ToolCancelled { call_id, name, reason } => {
+                if self.approval.as_ref().is_some_and(|request| request.call_id == call_id) {
+                    self.approval = None;
+                }
+                self.transcript.push(TranscriptEntry::new(
+                    EntryKind::Error,
+                    name,
+                    format!("Cancelled: {reason}"),
+                ));
+            }
+        }
+    }
+
+    fn append_stream(&mut self, kind: EntryKind, label: &str, text: String) {
+        let active = match kind {
+            EntryKind::Assistant => &mut self.active_assistant,
+            EntryKind::Thinking => &mut self.active_thinking,
+            _ => return,
+        };
+        if let Some(index) = *active {
+            self.transcript[index].text.push_str(&text);
+        } else {
+            self.transcript.push(TranscriptEntry::new(kind, label, text));
+            *active = Some(self.transcript.len() - 1);
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "state_test.rs"]
+mod state_test;

--- a/crates/aion-tui/src/state_test.rs
+++ b/crates/aion-tui/src/state_test.rs
@@ -1,8 +1,9 @@
+use aion_agent::commands::CommandSpec;
 use aion_types::message::{ContentBlock, Message, Role};
 
 use super::AppState;
 use crate::event::AgentEvent;
-use crate::transcript::EntryKind;
+use crate::transcript::{EntryKind, ToolStepStatus, TranscriptEntry};
 
 fn state() -> AppState {
     AppState::new(
@@ -51,6 +52,131 @@ fn protocol_result_suppresses_duplicate_sink_result() {
 }
 
 #[test]
+fn tool_lifecycle_updates_one_countable_step() {
+    let mut state = state();
+    state.handle_agent_event(AgentEvent::ToolCall {
+        call_id: "call-1".to_string(),
+        name: "Read".to_string(),
+        input: "{\"path\":\"file.rs\"}".to_string(),
+    });
+    state.handle_agent_event(AgentEvent::ToolRunning {
+        call_id: "call-1".to_string(),
+        name: "Read".to_string(),
+    });
+    state.handle_agent_event(AgentEvent::ProtocolToolResult {
+        call_id: "call-1".to_string(),
+        name: "Read".to_string(),
+        is_error: false,
+        content: "file contents".to_string(),
+    });
+
+    assert_eq!(state.transcript.len(), 1);
+    assert_eq!(state.transcript[0].label, "Read");
+    assert_eq!(state.transcript[0].text, "file contents");
+    assert_eq!(state.transcript[0].tool_status, Some(ToolStepStatus::Success));
+}
+
+#[test]
+fn resumed_tool_use_and_result_merge_into_one_step() {
+    let mut state = state();
+    state.set_history(&[
+        Message::new(
+            Role::Assistant,
+            vec![ContentBlock::ToolUse {
+                id: "call-1".to_string(),
+                name: "Read".to_string(),
+                input: serde_json::json!({"path": "file.rs"}),
+                extra: None,
+            }],
+        ),
+        Message::new(
+            Role::User,
+            vec![ContentBlock::ToolResult {
+                tool_use_id: "call-1".to_string(),
+                content: "file contents".to_string(),
+                is_error: false,
+            }],
+        ),
+    ]);
+
+    assert_eq!(state.transcript.len(), 1);
+    assert_eq!(state.transcript[0].label, "Read");
+    assert_eq!(state.transcript[0].text, "file contents");
+    assert_eq!(state.transcript[0].tool_status, Some(ToolStepStatus::Success));
+    assert!(!state.show_welcome);
+}
+
+#[test]
+fn resumed_history_keeps_conversation_text_across_tool_rounds() {
+    let mut state = state();
+    state.set_history(&[
+        Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "first question".to_string(),
+            }],
+        ),
+        Message::new(
+            Role::Assistant,
+            vec![ContentBlock::Text {
+                text: "first answer".to_string(),
+            }],
+        ),
+        Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "second question".to_string(),
+            }],
+        ),
+        Message::new(
+            Role::Assistant,
+            vec![ContentBlock::ToolUse {
+                id: "call-1".to_string(),
+                name: "Read".to_string(),
+                input: serde_json::json!({"path": "file.rs"}),
+                extra: None,
+            }],
+        ),
+        Message::new(
+            Role::User,
+            vec![ContentBlock::ToolResult {
+                tool_use_id: "call-1".to_string(),
+                content: "file contents".to_string(),
+                is_error: false,
+            }],
+        ),
+        Message::new(
+            Role::Assistant,
+            vec![ContentBlock::Text {
+                text: "complete final answer".to_string(),
+            }],
+        ),
+    ]);
+
+    let conversation = state
+        .transcript
+        .iter()
+        .filter(|entry| matches!(entry.kind, EntryKind::User | EntryKind::Assistant))
+        .map(|entry| entry.text.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        conversation,
+        [
+            "first question",
+            "first answer",
+            "second question",
+            "complete final answer"
+        ]
+    );
+    assert!(state.transcript.iter().any(|entry| {
+        entry.kind == EntryKind::Tool
+            && entry.label == "Read"
+            && entry.text == "file contents"
+            && entry.tool_status == Some(ToolStepStatus::Success)
+    }));
+}
+
+#[test]
 fn streaming_deltas_append_to_one_assistant_entry() {
     let mut state = state();
     state.handle_agent_event(AgentEvent::StreamStart);
@@ -58,4 +184,52 @@ fn streaming_deltas_append_to_one_assistant_entry() {
     state.handle_agent_event(AgentEvent::TextDelta("world".to_string()));
     assert_eq!(state.transcript.len(), 1);
     assert_eq!(state.transcript[0].text, "hello world");
+}
+
+#[test]
+fn command_catalog_merges_agent_and_tui_commands() {
+    let mut state = state();
+    state.set_commands(vec![CommandSpec {
+        name: "compact".to_string(),
+        aliases: Vec::new(),
+        description: "Compress context".to_string(),
+    }]);
+
+    let names = state
+        .popup
+        .commands()
+        .iter()
+        .map(|command| command.name.as_str())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"compact"));
+    assert!(names.contains(&"status"));
+    assert!(names.contains(&"permissions"));
+    assert!(names.contains(&"resume"));
+}
+
+#[test]
+fn reset_session_clears_transient_state() {
+    let mut state = state();
+    state.composer.insert_text("draft");
+    state.begin_initialization();
+    state.busy = true;
+    state.turns = 3;
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::Info, "Info", "old session"));
+
+    state.reset_session(
+        "next-model".to_string(),
+        "next-provider".to_string(),
+        Some("next-session".to_string()),
+        &[],
+    );
+
+    assert_eq!(state.model, "next-model");
+    assert_eq!(state.session_id.as_deref(), Some("next-session"));
+    assert!(state.transcript.is_empty());
+    assert!(state.composer.is_empty());
+    assert!(!state.initializing);
+    assert!(!state.busy);
+    assert_eq!(state.turns, 0);
 }

--- a/crates/aion-tui/src/state_test.rs
+++ b/crates/aion-tui/src/state_test.rs
@@ -1,0 +1,61 @@
+use aion_types::message::{ContentBlock, Message, Role};
+
+use super::AppState;
+use crate::event::AgentEvent;
+use crate::transcript::EntryKind;
+
+fn state() -> AppState {
+    AppState::new(
+        "test-model".to_string(),
+        "test-provider".to_string(),
+        ".".to_string(),
+        true,
+    )
+}
+
+#[test]
+fn resumed_history_is_rendered_by_role() {
+    let mut state = state();
+    state.set_history(&[
+        Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "hello".to_string(),
+            }],
+        ),
+        Message::new(Role::Assistant, vec![ContentBlock::Text { text: "hi".to_string() }]),
+    ]);
+    assert_eq!(state.transcript.len(), 2);
+    assert_eq!(state.transcript[0].kind, EntryKind::User);
+    assert_eq!(state.transcript[1].kind, EntryKind::Assistant);
+    assert!(state.transcript[0].label.is_empty());
+    assert!(state.transcript[1].label.is_empty());
+}
+
+#[test]
+fn protocol_result_suppresses_duplicate_sink_result() {
+    let mut state = state();
+    state.handle_agent_event(AgentEvent::ProtocolToolResult {
+        call_id: "call-1".to_string(),
+        name: "Read".to_string(),
+        is_error: false,
+        content: "done".to_string(),
+    });
+    state.handle_agent_event(AgentEvent::ToolResult {
+        call_id: "call-1".to_string(),
+        name: "Read".to_string(),
+        is_error: false,
+        content: "done".to_string(),
+    });
+    assert_eq!(state.transcript.len(), 1);
+}
+
+#[test]
+fn streaming_deltas_append_to_one_assistant_entry() {
+    let mut state = state();
+    state.handle_agent_event(AgentEvent::StreamStart);
+    state.handle_agent_event(AgentEvent::TextDelta("hello ".to_string()));
+    state.handle_agent_event(AgentEvent::TextDelta("world".to_string()));
+    assert_eq!(state.transcript.len(), 1);
+    assert_eq!(state.transcript[0].text, "hello world");
+}

--- a/crates/aion-tui/src/terminal.rs
+++ b/crates/aion-tui/src/terminal.rs
@@ -1,24 +1,119 @@
-use std::io::{self, Stdout};
+use std::fmt;
+use std::io::{self, BufWriter, Stdout, Write};
 
-use crossterm::cursor::{Hide, Show};
+use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags};
-use crossterm::execute;
-use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode};
+use crossterm::terminal::{
+    BeginSynchronizedUpdate, Clear, ClearType, EndSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen,
+    disable_raw_mode, enable_raw_mode,
+};
+use crossterm::{Command, execute};
+use ratatui::Frame;
 use ratatui::Terminal;
+use ratatui::TerminalOptions;
+use ratatui::Viewport;
 use ratatui::backend::CrosstermBackend;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Text};
+use ratatui::widgets::{Paragraph, Widget};
 
-pub(super) type AppTerminal = Terminal<CrosstermBackend<Stdout>>;
+const INLINE_VIEWPORT_HEIGHT: u16 = 12;
+
+pub(super) type AppTerminal = Terminal<CrosstermBackend<BufWriter<Stdout>>>;
+
+#[derive(Debug, Clone, Copy)]
+struct EnableAlternateScroll;
+
+impl Command for EnableAlternateScroll {
+    fn write_ansi(&self, formatter: &mut impl fmt::Write) -> fmt::Result {
+        write!(formatter, "\x1b[?1007h")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Err(io::Error::other("alternate scroll requires ANSI support"))
+    }
+
+    #[cfg(windows)]
+    fn is_ansi_code_supported(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DisableAlternateScroll;
+
+impl Command for DisableAlternateScroll {
+    fn write_ansi(&self, formatter: &mut impl fmt::Write) -> fmt::Result {
+        write!(formatter, "\x1b[?1007l")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Err(io::Error::other("alternate scroll requires ANSI support"))
+    }
+
+    #[cfg(windows)]
+    fn is_ansi_code_supported(&self) -> bool {
+        true
+    }
+}
+
+pub(super) fn draw_synchronized(terminal: &mut AppTerminal, render: impl FnOnce(&mut Frame<'_>)) -> anyhow::Result<()> {
+    execute!(terminal.backend_mut(), BeginSynchronizedUpdate)?;
+    let draw_result = terminal.draw(render).map(|_| ());
+    let end_result = execute!(terminal.backend_mut(), EndSynchronizedUpdate);
+    draw_result?;
+    end_result?;
+    Ok(())
+}
+
+pub(super) fn clear_synchronized(terminal: &mut AppTerminal) -> anyhow::Result<()> {
+    execute!(terminal.backend_mut(), BeginSynchronizedUpdate)?;
+    let clear_result = terminal.autoresize();
+    let end_result = execute!(terminal.backend_mut(), EndSynchronizedUpdate);
+    clear_result?;
+    end_result?;
+    Ok(())
+}
+
+pub(super) fn insert_history_lines(terminal: &mut AppTerminal, lines: Vec<Line<'static>>) -> anyhow::Result<()> {
+    for chunk in lines.chunks(usize::from(u16::MAX)) {
+        let height = u16::try_from(chunk.len()).unwrap_or(u16::MAX);
+        let text = Text::from(chunk.to_vec());
+        terminal.insert_before(height, move |buffer| {
+            let area = buffer.area;
+            let content = Rect::new(
+                area.x.saturating_add(1),
+                area.y,
+                area.width.saturating_sub(2),
+                area.height,
+            );
+            Paragraph::new(text).render(content, buffer);
+        })?;
+    }
+    Ok(())
+}
 
 pub(super) struct TerminalSession {
-    terminal: AppTerminal,
+    inline_terminal: AppTerminal,
+    picker_terminal: Option<AppTerminal>,
     keyboard_enhancement: bool,
+    picker_mode: bool,
 }
 
 impl TerminalSession {
     pub(super) fn enter() -> anyhow::Result<Self> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        if let Err(error) = execute!(stdout, EnterAlternateScreen, Hide) {
+        if let Err(error) = execute!(
+            stdout,
+            Clear(ClearType::Purge),
+            Clear(ClearType::All),
+            MoveTo(0, 0),
+            Hide
+        ) {
+            let _ = execute!(stdout, Show);
             let _ = disable_raw_mode();
             return Err(error.into());
         }
@@ -27,37 +122,132 @@ impl TerminalSession {
             PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
         )
         .is_ok();
-        let backend = CrosstermBackend::new(stdout);
-        let terminal = match Terminal::new(backend) {
+        let terminal = match inline_terminal(stdout) {
             Ok(terminal) => terminal,
             Err(error) => {
                 let mut stdout = io::stdout();
                 if keyboard_enhancement {
                     let _ = execute!(stdout, PopKeyboardEnhancementFlags);
                 }
-                let _ = execute!(stdout, Show, LeaveAlternateScreen);
+                let _ = execute!(stdout, Show);
                 let _ = disable_raw_mode();
                 return Err(error.into());
             }
         };
         Ok(Self {
-            terminal,
+            inline_terminal: terminal,
+            picker_terminal: None,
             keyboard_enhancement,
+            picker_mode: false,
         })
     }
 
     pub(super) fn terminal(&mut self) -> &mut AppTerminal {
-        &mut self.terminal
+        if self.picker_mode {
+            self.picker_terminal.as_mut().expect("picker terminal is active")
+        } else {
+            &mut self.inline_terminal
+        }
+    }
+
+    pub(super) fn set_picker_mode(&mut self, picker_mode: bool) -> anyhow::Result<()> {
+        if self.picker_mode == picker_mode {
+            return Ok(());
+        }
+
+        if picker_mode {
+            self.inline_terminal.backend_mut().flush()?;
+            execute!(
+                self.inline_terminal.backend_mut(),
+                EnterAlternateScreen,
+                EnableAlternateScroll,
+                Clear(ClearType::All),
+                MoveTo(0, 0),
+                Hide
+            )?;
+            match Terminal::new(CrosstermBackend::new(BufWriter::new(io::stdout()))) {
+                Ok(terminal) => self.picker_terminal = Some(terminal),
+                Err(error) => {
+                    let _ = execute!(
+                        self.inline_terminal.backend_mut(),
+                        DisableAlternateScroll,
+                        LeaveAlternateScreen
+                    );
+                    return Err(error.into());
+                }
+            }
+            self.picker_mode = true;
+        } else {
+            let picker_terminal = self.picker_terminal.as_mut().expect("picker terminal is active");
+            picker_terminal.backend_mut().flush()?;
+            execute!(
+                picker_terminal.backend_mut(),
+                DisableAlternateScroll,
+                LeaveAlternateScreen,
+                Hide
+            )?;
+            self.picker_terminal = None;
+            self.picker_mode = false;
+        }
+        Ok(())
+    }
+
+    pub(super) fn reset_inline(&mut self) -> anyhow::Result<()> {
+        debug_assert!(!self.picker_mode);
+        self.inline_terminal.draw(|frame| frame.buffer_mut().reset())?;
+        self.inline_terminal.backend_mut().flush()?;
+        execute!(
+            self.inline_terminal.backend_mut(),
+            Clear(ClearType::Purge),
+            Clear(ClearType::All),
+            MoveTo(0, 0),
+            Hide
+        )?;
+        Ok(())
     }
 }
 
 impl Drop for TerminalSession {
     fn drop(&mut self) {
-        if self.keyboard_enhancement {
-            let _ = execute!(self.terminal.backend_mut(), PopKeyboardEnhancementFlags);
+        if self.picker_mode {
+            if let Some(picker_terminal) = self.picker_terminal.as_mut() {
+                let _ = execute!(
+                    picker_terminal.backend_mut(),
+                    DisableAlternateScroll,
+                    LeaveAlternateScreen
+                );
+            }
+            self.picker_terminal = None;
+            self.picker_mode = false;
         }
-        let _ = execute!(self.terminal.backend_mut(), Show, LeaveAlternateScreen);
+        if self.keyboard_enhancement {
+            let _ = execute!(self.inline_terminal.backend_mut(), PopKeyboardEnhancementFlags);
+        }
+        let _ = execute!(self.inline_terminal.backend_mut(), Show);
         let _ = disable_raw_mode();
-        let _ = self.terminal.show_cursor();
+        let _ = self.inline_terminal.show_cursor();
+        let _ = finish_terminal_output(self.inline_terminal.backend_mut());
     }
 }
+
+fn finish_terminal_output(output: &mut impl Write) -> io::Result<()> {
+    output.write_all(b"\r\n")?;
+    output.flush()
+}
+
+fn inline_terminal(stdout: Stdout) -> io::Result<AppTerminal> {
+    let backend = CrosstermBackend::new(BufWriter::new(stdout));
+    let viewport_height = crossterm::terminal::size()
+        .map(|(_, height)| height.clamp(1, INLINE_VIEWPORT_HEIGHT))
+        .unwrap_or(INLINE_VIEWPORT_HEIGHT);
+    Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(viewport_height),
+        },
+    )
+}
+
+#[cfg(test)]
+#[path = "terminal_test.rs"]
+mod terminal_test;

--- a/crates/aion-tui/src/terminal.rs
+++ b/crates/aion-tui/src/terminal.rs
@@ -1,0 +1,63 @@
+use std::io::{self, Stdout};
+
+use crossterm::cursor::{Hide, Show};
+use crossterm::event::{KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags};
+use crossterm::execute;
+use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+
+pub(super) type AppTerminal = Terminal<CrosstermBackend<Stdout>>;
+
+pub(super) struct TerminalSession {
+    terminal: AppTerminal,
+    keyboard_enhancement: bool,
+}
+
+impl TerminalSession {
+    pub(super) fn enter() -> anyhow::Result<Self> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        if let Err(error) = execute!(stdout, EnterAlternateScreen, Hide) {
+            let _ = disable_raw_mode();
+            return Err(error.into());
+        }
+        let keyboard_enhancement = execute!(
+            stdout,
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        )
+        .is_ok();
+        let backend = CrosstermBackend::new(stdout);
+        let terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => {
+                let mut stdout = io::stdout();
+                if keyboard_enhancement {
+                    let _ = execute!(stdout, PopKeyboardEnhancementFlags);
+                }
+                let _ = execute!(stdout, Show, LeaveAlternateScreen);
+                let _ = disable_raw_mode();
+                return Err(error.into());
+            }
+        };
+        Ok(Self {
+            terminal,
+            keyboard_enhancement,
+        })
+    }
+
+    pub(super) fn terminal(&mut self) -> &mut AppTerminal {
+        &mut self.terminal
+    }
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        if self.keyboard_enhancement {
+            let _ = execute!(self.terminal.backend_mut(), PopKeyboardEnhancementFlags);
+        }
+        let _ = execute!(self.terminal.backend_mut(), Show, LeaveAlternateScreen);
+        let _ = disable_raw_mode();
+        let _ = self.terminal.show_cursor();
+    }
+}

--- a/crates/aion-tui/src/terminal_test.rs
+++ b/crates/aion-tui/src/terminal_test.rs
@@ -1,0 +1,10 @@
+use super::finish_terminal_output;
+
+#[test]
+fn terminal_cleanup_ends_output_with_a_flushed_newline() {
+    let mut output = Vec::new();
+
+    finish_terminal_output(&mut output).expect("terminal output should finish cleanly");
+
+    assert_eq!(output, b"\r\n");
+}

--- a/crates/aion-tui/src/transcript.rs
+++ b/crates/aion-tui/src/transcript.rs
@@ -1,0 +1,59 @@
+use aion_types::message::{ContentBlock, Message, Role};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum EntryKind {
+    User,
+    Assistant,
+    Thinking,
+    Tool,
+    Info,
+    Error,
+}
+
+#[derive(Debug)]
+pub(super) struct TranscriptEntry {
+    pub(super) kind: EntryKind,
+    pub(super) label: String,
+    pub(super) text: String,
+}
+
+impl TranscriptEntry {
+    pub(super) fn new(kind: EntryKind, label: impl Into<String>, text: impl Into<String>) -> Self {
+        Self {
+            kind,
+            label: label.into(),
+            text: text.into(),
+        }
+    }
+}
+
+pub(super) fn entries_from_messages(messages: &[Message]) -> Vec<TranscriptEntry> {
+    let mut entries = Vec::new();
+    for message in messages {
+        for block in &message.content {
+            match block {
+                ContentBlock::Text { text } => match message.role {
+                    Role::User => entries.push(TranscriptEntry::new(EntryKind::User, "", text)),
+                    Role::Assistant => entries.push(TranscriptEntry::new(EntryKind::Assistant, "", text)),
+                    Role::System => entries.push(TranscriptEntry::new(EntryKind::Info, "System", text)),
+                    Role::Tool => entries.push(TranscriptEntry::new(EntryKind::Tool, "Tool", text)),
+                },
+                ContentBlock::Thinking { thinking, .. } => {
+                    entries.push(TranscriptEntry::new(EntryKind::Thinking, "Thinking", thinking));
+                }
+                ContentBlock::ToolUse { name, input, .. } => {
+                    entries.push(TranscriptEntry::new(EntryKind::Tool, name, input.to_string()));
+                }
+                ContentBlock::ToolResult { content, is_error, .. } => {
+                    let kind = if *is_error { EntryKind::Error } else { EntryKind::Tool };
+                    entries.push(TranscriptEntry::new(kind, "Result", content));
+                }
+                ContentBlock::Image { .. } => {
+                    entries.push(TranscriptEntry::new(EntryKind::Info, "Image", "[attached image]"));
+                }
+                ContentBlock::ProviderItem { .. } => {}
+            }
+        }
+    }
+    entries
+}

--- a/crates/aion-tui/src/transcript.rs
+++ b/crates/aion-tui/src/transcript.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use aion_types::message::{ContentBlock, Message, Role};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10,11 +12,40 @@ pub(super) enum EntryKind {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ToolStepStatus {
+    Queued,
+    Approval,
+    Running,
+    Success,
+    Error,
+    Cancelled,
+}
+
+impl ToolStepStatus {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Approval => "approval",
+            Self::Running => "running",
+            Self::Success => "done",
+            Self::Error => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    fn is_terminal(self) -> bool {
+        matches!(self, Self::Success | Self::Error | Self::Cancelled)
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct TranscriptEntry {
     pub(super) kind: EntryKind,
     pub(super) label: String,
     pub(super) text: String,
+    pub(super) tool_status: Option<ToolStepStatus>,
+    display_offset: usize,
 }
 
 impl TranscriptEntry {
@@ -23,12 +54,37 @@ impl TranscriptEntry {
             kind,
             label: label.into(),
             text: text.into(),
+            tool_status: None,
+            display_offset: 0,
         }
+    }
+
+    pub(super) fn tool(label: impl Into<String>, text: impl Into<String>, status: ToolStepStatus) -> Self {
+        Self {
+            kind: EntryKind::Tool,
+            label: label.into(),
+            text: text.into(),
+            tool_status: Some(status),
+            display_offset: 0,
+        }
+    }
+
+    pub(super) fn visible_text(&self) -> &str {
+        &self.text[self.display_offset.min(self.text.len())..]
+    }
+
+    pub(super) fn advance_display_offset(&mut self, byte_count: usize) {
+        self.display_offset = self.display_offset.saturating_add(byte_count).min(self.text.len());
+    }
+
+    pub(super) fn is_stable_for_history(&self) -> bool {
+        self.kind != EntryKind::Tool || self.tool_status.is_some_and(ToolStepStatus::is_terminal)
     }
 }
 
 pub(super) fn entries_from_messages(messages: &[Message]) -> Vec<TranscriptEntry> {
     let mut entries = Vec::new();
+    let mut tool_entries = HashMap::new();
     for message in messages {
         for block in &message.content {
             match block {
@@ -36,17 +92,31 @@ pub(super) fn entries_from_messages(messages: &[Message]) -> Vec<TranscriptEntry
                     Role::User => entries.push(TranscriptEntry::new(EntryKind::User, "", text)),
                     Role::Assistant => entries.push(TranscriptEntry::new(EntryKind::Assistant, "", text)),
                     Role::System => entries.push(TranscriptEntry::new(EntryKind::Info, "System", text)),
-                    Role::Tool => entries.push(TranscriptEntry::new(EntryKind::Tool, "Tool", text)),
+                    Role::Tool => entries.push(TranscriptEntry::tool("Tool", text, ToolStepStatus::Success)),
                 },
                 ContentBlock::Thinking { thinking, .. } => {
                     entries.push(TranscriptEntry::new(EntryKind::Thinking, "Thinking", thinking));
                 }
-                ContentBlock::ToolUse { name, input, .. } => {
-                    entries.push(TranscriptEntry::new(EntryKind::Tool, name, input.to_string()));
+                ContentBlock::ToolUse { id, name, input, .. } => {
+                    entries.push(TranscriptEntry::tool(name, input.to_string(), ToolStepStatus::Queued));
+                    tool_entries.insert(id.clone(), entries.len() - 1);
                 }
-                ContentBlock::ToolResult { content, is_error, .. } => {
-                    let kind = if *is_error { EntryKind::Error } else { EntryKind::Tool };
-                    entries.push(TranscriptEntry::new(kind, "Result", content));
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    is_error,
+                } => {
+                    let status = if *is_error {
+                        ToolStepStatus::Error
+                    } else {
+                        ToolStepStatus::Success
+                    };
+                    if let Some(index) = tool_entries.get(tool_use_id).copied() {
+                        entries[index].text = content.clone();
+                        entries[index].tool_status = Some(status);
+                    } else {
+                        entries.push(TranscriptEntry::tool("Tool result", content, status));
+                    }
                 }
                 ContentBlock::Image { .. } => {
                     entries.push(TranscriptEntry::new(EntryKind::Info, "Image", "[attached image]"));

--- a/crates/aion-tui/src/ui.rs
+++ b/crates/aion-tui/src/ui.rs
@@ -1,0 +1,414 @@
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::state::AppState;
+use crate::transcript::EntryKind;
+
+const MAX_COMPOSER_HEIGHT: u16 = 8;
+const MAX_POPUP_ITEMS: usize = 7;
+const FOOTER_HEIGHT: u16 = 3;
+const AION_MARK_WIDTH: usize = 32;
+// Quantized from the Aion PNG after removing its black canvas. Each level expands to two
+// terminal columns so the source aspect ratio remains recognizable in monospace cells.
+const AION_MARK_LEVELS: &[&str] = &[
+    "0000000440000000",
+    "0000003553000000",
+    "0000015555200000",
+    "0000045225510000",
+    "0000353003540000",
+    "0003540000353000",
+    "0002200120022000",
+    "0000000550000000",
+    "1410000220000041",
+    "0452000000002540",
+    "0025420000245300",
+    "0001355444531000",
+    "0000001221000000",
+];
+
+pub(super) fn render(frame: &mut Frame<'_>, state: &AppState) {
+    let area = frame.area();
+    let content = Rect::new(
+        area.x.saturating_add(1),
+        area.y,
+        area.width.saturating_sub(2),
+        area.height,
+    );
+
+    if content.width < 20 || content.height < 6 {
+        frame.render_widget(
+            Paragraph::new("Terminal too small\nResize to at least 22×8").style(error(state)),
+            content,
+        );
+        return;
+    }
+
+    let composer_width = content.width.saturating_sub(4).max(1);
+    let composer_height = state
+        .composer
+        .visual_height(composer_width, MAX_COMPOSER_HEIGHT)
+        .saturating_add(1);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),
+            Constraint::Length(composer_height),
+            Constraint::Length(1),
+            Constraint::Length(FOOTER_HEIGHT),
+        ])
+        .split(content);
+
+    render_transcript(frame, chunks[0], state);
+    render_composer(frame, chunks[1], state);
+    render_footer(frame, chunks[3], state);
+
+    if state.approval.is_some() {
+        render_approval(frame, content, state);
+    } else if state.popup.is_visible(&state.composer.text()) {
+        render_command_popup(frame, content, chunks[1], state);
+    }
+}
+
+fn compact_cwd(cwd: &str) -> &str {
+    cwd.rsplit(['/', '\\']).find(|part| !part.is_empty()).unwrap_or(cwd)
+}
+
+fn render_transcript(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    if state.transcript.is_empty() {
+        render_welcome(frame, area, state);
+        return;
+    }
+
+    let mut lines = Vec::new();
+    for (index, entry) in state.transcript.iter().enumerate() {
+        if index > 0 {
+            lines.push(Line::default());
+        }
+        if is_conversation(entry.kind) {
+            for line in conversation_lines(&entry.text, area.width) {
+                lines.push(Line::from(Span::styled(line, entry_style(entry.kind, state))));
+            }
+        } else {
+            lines.push(Line::from(Span::styled(
+                entry.label.as_str(),
+                entry_style(entry.kind, state).add_modifier(Modifier::BOLD),
+            )));
+            for line in entry.text.lines() {
+                lines.push(Line::from(Span::styled(
+                    line.to_string(),
+                    entry_style(entry.kind, state),
+                )));
+            }
+            if entry.text.is_empty() {
+                lines.push(Line::default());
+            }
+        }
+    }
+
+    let line_count = transcript_line_count(state, area.width.max(1));
+    let paragraph = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
+    let bottom = line_count.saturating_sub(area.height as usize);
+    let scroll = bottom.saturating_sub(state.scroll_back).min(u16::MAX as usize) as u16;
+    frame.render_widget(paragraph.scroll((scroll, 0)), area);
+}
+
+fn render_welcome(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    let welcome_height = AION_MARK_LEVELS.len() as u16 + 3;
+    if area.height < welcome_height || area.width < 50 {
+        frame.render_widget(
+            Paragraph::new("Ask about this project, or type / to see commands.")
+                .alignment(Alignment::Center)
+                .style(muted(state)),
+            area,
+        );
+        return;
+    }
+
+    let top_padding = area.height.saturating_sub(welcome_height) / 3;
+    let mut lines = vec![Line::default(); top_padding as usize];
+    lines.extend(aion_mark_lines(state));
+    lines.push(Line::default());
+    lines.push(Line::from(Span::styled(
+        "AionCLI",
+        normal(state).add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(Span::styled(
+        "Ask about this project, or type / to see commands.",
+        muted(state),
+    )));
+    frame.render_widget(Paragraph::new(lines).alignment(Alignment::Center), area);
+}
+
+fn aion_mark_lines(state: &AppState) -> Vec<Line<'static>> {
+    AION_MARK_LEVELS
+        .iter()
+        .map(|levels| {
+            let spans = levels
+                .chars()
+                .map(|level| {
+                    let (glyph, shade) = match level {
+                        '1' => ("..", 178),
+                        '2' => ("::", 146),
+                        '3' => ("**", 110),
+                        '4' => ("##", 70),
+                        '5' => ("@@", 28),
+                        _ => ("  ", 0),
+                    };
+                    let style = if level == '0' || state.no_color {
+                        Style::default()
+                    } else {
+                        Style::default().fg(Color::Rgb(shade, shade, shade))
+                    };
+                    Span::styled(glyph, style)
+                })
+                .collect::<Vec<_>>();
+            debug_assert_eq!(levels.len() * 2, AION_MARK_WIDTH);
+            Line::from(spans)
+        })
+        .collect()
+}
+
+fn transcript_line_count(state: &AppState, width: u16) -> usize {
+    if state.transcript.is_empty() {
+        return 1;
+    }
+    let width = width.max(1) as usize;
+    let mut count = state.transcript.len().saturating_sub(1);
+    for entry in &state.transcript {
+        if is_conversation(entry.kind) {
+            count += conversation_lines(&entry.text, width as u16).len();
+        } else {
+            count += wrapped_height(&entry.label, width);
+            if entry.text.is_empty() {
+                count += 1;
+            } else {
+                count += entry
+                    .text
+                    .lines()
+                    .map(|line| wrapped_height(line, width))
+                    .sum::<usize>();
+            }
+        }
+    }
+    count
+}
+
+fn is_conversation(kind: EntryKind) -> bool {
+    matches!(kind, EntryKind::User | EntryKind::Assistant)
+}
+
+fn conversation_lines(text: &str, width: u16) -> Vec<String> {
+    let line_width = usize::from(width.max(2));
+    let content_width = line_width.saturating_sub(2).max(1);
+    let mut lines = Vec::new();
+
+    for source_line in text.split('\n') {
+        let mut chunk = String::new();
+        let mut chunk_width = 0usize;
+        for character in source_line.chars() {
+            let character_width = character.width().unwrap_or(1);
+            if chunk_width > 0 && chunk_width + character_width > content_width {
+                lines.push(padded_message_line(&chunk, chunk_width, content_width));
+                chunk.clear();
+                chunk_width = 0;
+            }
+            chunk.push(character);
+            chunk_width += character_width;
+        }
+        if chunk_width > 0 || source_line.is_empty() {
+            lines.push(padded_message_line(&chunk, chunk_width, content_width));
+        }
+    }
+    lines
+}
+
+fn padded_message_line(text: &str, text_width: usize, content_width: usize) -> String {
+    format!(" {text}{} ", " ".repeat(content_width.saturating_sub(text_width)))
+}
+
+fn wrapped_height(text: &str, width: usize) -> usize {
+    UnicodeWidthStr::width(text).max(1).div_ceil(width)
+}
+
+fn render_composer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    let block = Block::default().borders(Borders::TOP).border_style(divider(state));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let text = state.composer.text();
+    let placeholder = text.is_empty() && !state.busy;
+    let displayed = if placeholder {
+        "Type a message…".to_string()
+    } else {
+        text
+    };
+    let (cursor_column, cursor_row) = state.composer.visual_cursor(inner.width.max(1));
+    let vertical_scroll = cursor_row.saturating_sub(inner.height.saturating_sub(1));
+    let style = if placeholder { muted(state) } else { normal(state) };
+    frame.render_widget(
+        Paragraph::new(displayed)
+            .style(style)
+            .wrap(Wrap { trim: false })
+            .scroll((vertical_scroll, 0)),
+        inner,
+    );
+    if !state.busy && state.approval.is_none() {
+        frame.set_cursor_position((
+            inner.x.saturating_add(cursor_column),
+            inner.y.saturating_add(cursor_row.saturating_sub(vertical_scroll)),
+        ));
+    }
+}
+
+fn render_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    let hints = if state.approval.is_some() {
+        " y allow once · a always allow · n/esc deny "
+    } else if state.busy {
+        " Ctrl+C stop · PgUp/PgDn scroll "
+    } else if area.width >= 70 {
+        " Enter send · Shift+Enter newline · / commands · Tab complete · Ctrl+C quit "
+    } else {
+        " Enter send · / commands · Ctrl+C quit "
+    };
+    let status = if state.busy {
+        ["·", "••", "•••", "••"]
+            .get(state.spinner_frame)
+            .copied()
+            .unwrap_or("·")
+    } else {
+        "ready"
+    };
+    let metadata = format!(
+        " AionCLI · {} · {} · {} · {} ",
+        state.provider,
+        state.model,
+        status,
+        compact_cwd(&state.cwd)
+    );
+    let session = format!(" session {} ", state.session_id.as_deref().unwrap_or("new"));
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(hints, accent(state))),
+            Line::from(Span::styled(metadata, muted(state))),
+            Line::from(Span::styled(session, muted(state))),
+        ]),
+        area,
+    );
+}
+
+fn render_command_popup(frame: &mut Frame<'_>, bounds: Rect, composer: Rect, state: &AppState) {
+    let matches = state.popup.matches();
+    let visible = matches.len().min(MAX_POPUP_ITEMS);
+    let height = visible as u16;
+    let width = bounds.width;
+    let x = bounds.x;
+    let y = composer.y.saturating_sub(height);
+    let area = Rect::new(x, y, width, height);
+    let mut lines = Vec::with_capacity(visible);
+    for (index, command) in matches.iter().take(visible).enumerate() {
+        let selected = index == state.popup.selected();
+        let marker = if selected { "›" } else { " " };
+        let line = format!("{marker} /{:<12} {}", command.name, command.description);
+        let line_width = UnicodeWidthStr::width(line.as_str());
+        let line = format!("{line}{}", " ".repeat(width as usize - line_width.min(width as usize)));
+        let style = if selected { selected_style(state) } else { normal(state) };
+        lines.push(Line::from(Span::styled(line, style)));
+    }
+    frame.render_widget(Clear, area);
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn render_approval(frame: &mut Frame<'_>, bounds: Rect, state: &AppState) {
+    let Some(request) = &state.approval else {
+        return;
+    };
+    let width = bounds.width.saturating_sub(4).clamp(20, 88);
+    let height = bounds.height.saturating_sub(2).clamp(6, 12);
+    let area = centered_rect(width, height, bounds);
+    let description = if request.description.trim().is_empty() {
+        "This tool needs your approval."
+    } else {
+        request.description.as_str()
+    };
+    let content = format!("{}\n\n{}\n\n{}", request.name, description, request.input);
+    frame.render_widget(Clear, area);
+    frame.render_widget(
+        Paragraph::new(content).wrap(Wrap { trim: false }).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Tool approval ")
+                .border_style(warning(state)),
+        ),
+        area,
+    );
+}
+
+fn centered_rect(width: u16, height: u16, bounds: Rect) -> Rect {
+    let x = bounds.x + bounds.width.saturating_sub(width) / 2;
+    let y = bounds.y + bounds.height.saturating_sub(height) / 2;
+    Rect::new(x, y, width.min(bounds.width), height.min(bounds.height))
+}
+
+fn entry_style(kind: EntryKind, state: &AppState) -> Style {
+    match kind {
+        EntryKind::User if state.no_color => normal(state).add_modifier(Modifier::BOLD),
+        EntryKind::User => Style::default()
+            .fg(Color::White)
+            .bg(Color::Black)
+            .add_modifier(Modifier::BOLD),
+        EntryKind::Assistant if state.no_color => normal(state),
+        EntryKind::Assistant => Style::default().fg(Color::DarkGray),
+        EntryKind::Thinking => muted(state).add_modifier(Modifier::ITALIC),
+        EntryKind::Tool => success(state),
+        EntryKind::Info => muted(state),
+        EntryKind::Error => error(state),
+    }
+}
+
+fn normal(_state: &AppState) -> Style {
+    Style::default()
+}
+
+fn accent(state: &AppState) -> Style {
+    color(state, Color::Black)
+}
+
+fn success(state: &AppState) -> Style {
+    color(state, Color::DarkGray)
+}
+
+fn warning(state: &AppState) -> Style {
+    color(state, Color::Black).add_modifier(Modifier::BOLD)
+}
+
+fn error(state: &AppState) -> Style {
+    color(state, Color::Black).add_modifier(Modifier::BOLD)
+}
+
+fn muted(state: &AppState) -> Style {
+    color(state, Color::DarkGray)
+}
+
+fn selected_style(_state: &AppState) -> Style {
+    Style::default().add_modifier(Modifier::REVERSED)
+}
+
+fn divider(state: &AppState) -> Style {
+    color(state, Color::DarkGray)
+}
+
+fn color(state: &AppState, color: Color) -> Style {
+    if state.no_color {
+        Style::default()
+    } else {
+        Style::default().fg(color)
+    }
+}
+
+#[cfg(test)]
+#[path = "ui_test.rs"]
+mod ui_test;

--- a/crates/aion-tui/src/ui.rs
+++ b/crates/aion-tui/src/ui.rs
@@ -5,29 +5,28 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+use crate::markdown::{MarkdownTheme, render_markdown};
 use crate::state::AppState;
-use crate::transcript::EntryKind;
+use crate::transcript::{EntryKind, ToolStepStatus, TranscriptEntry};
 
 const MAX_COMPOSER_HEIGHT: u16 = 8;
 const MAX_POPUP_ITEMS: usize = 7;
-const FOOTER_HEIGHT: u16 = 3;
-const AION_MARK_WIDTH: usize = 32;
-// Quantized from the Aion PNG after removing its black canvas. Each level expands to two
-// terminal columns so the source aspect ratio remains recognizable in monospace cells.
-const AION_MARK_LEVELS: &[&str] = &[
-    "0000000440000000",
-    "0000003553000000",
-    "0000015555200000",
-    "0000045225510000",
-    "0000353003540000",
-    "0003540000353000",
-    "0002200120022000",
-    "0000000550000000",
-    "1410000220000041",
-    "0452000000002540",
-    "0025420000245300",
-    "0001355444531000",
-    "0000001221000000",
+const FOOTER_HEIGHT: u16 = 2;
+const MAX_VISIBLE_TOOLS: usize = 3;
+const TRANSCRIPT_BOTTOM_GAP: u16 = 1;
+const AION_MARK_WIDTH: usize = 24;
+// A mirror-symmetric line interpretation of the Aion mark using colons and spaces only.
+const AION_MARK_LINES: &[&str] = &[
+    "          ::::          ",
+    "        :::  :::        ",
+    "      :::      :::      ",
+    "    :::          :::    ",
+    "                        ",
+    "          ::::          ",
+    "                        ",
+    " :::                ::: ",
+    "   :::            :::   ",
+    "      ::::::::::::      ",
 ];
 
 pub(super) fn render(frame: &mut Frame<'_>, state: &AppState) {
@@ -47,18 +46,27 @@ pub(super) fn render(frame: &mut Frame<'_>, state: &AppState) {
         return;
     }
 
+    if state.session_picker.is_visible() {
+        render_session_picker(frame, area, state);
+        return;
+    }
+
     let composer_width = content.width.saturating_sub(4).max(1);
     let composer_height = state
         .composer
         .visual_height(composer_width, MAX_COMPOSER_HEIGHT)
         .saturating_add(1);
+    let reserved_height = composer_height.saturating_add(1).saturating_add(FOOTER_HEIGHT);
+    let max_transcript_height = content.height.saturating_sub(reserved_height);
+    let transcript_height = desired_transcript_height(state, content.width, max_transcript_height);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(1),
+            Constraint::Length(transcript_height),
             Constraint::Length(composer_height),
             Constraint::Length(1),
             Constraint::Length(FOOTER_HEIGHT),
+            Constraint::Min(0),
         ])
         .split(content);
 
@@ -77,58 +85,242 @@ fn compact_cwd(cwd: &str) -> &str {
     cwd.rsplit(['/', '\\']).find(|part| !part.is_empty()).unwrap_or(cwd)
 }
 
+fn desired_transcript_height(state: &AppState, width: u16, max_height: u16) -> u16 {
+    if state.pending_transcript().is_empty() && state.show_welcome {
+        return max_height;
+    }
+    let line_count = pending_transcript_lines(state, width).len();
+    let transcript_height = if line_count == 0 {
+        0
+    } else {
+        (line_count.min(u16::MAX as usize) as u16).saturating_add(TRANSCRIPT_BOTTOM_GAP)
+    };
+    let popup_height = if state.popup.is_visible(&state.composer.text()) {
+        state.popup.matches().len().min(MAX_POPUP_ITEMS) as u16
+    } else {
+        0
+    };
+    let desired = transcript_height.max(popup_height);
+    desired.min(max_height)
+}
+
 fn render_transcript(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
-    if state.transcript.is_empty() {
-        render_welcome(frame, area, state);
+    let entries = state.pending_transcript();
+    if entries.is_empty() {
+        if state.show_welcome {
+            render_welcome(frame, area, state);
+        }
         return;
     }
 
-    let mut lines = Vec::new();
-    for (index, entry) in state.transcript.iter().enumerate() {
-        if index > 0 {
+    let lines = pending_transcript_lines(state, area.width);
+    let line_count = lines.len();
+    if line_count == 0 {
+        return;
+    }
+    let paragraph = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
+    let bottom = line_count.saturating_sub(area.height as usize);
+    let render_area = bottom_aligned_area(area, line_count, TRANSCRIPT_BOTTOM_GAP);
+    frame.render_widget(paragraph.scroll((bottom.min(u16::MAX as usize) as u16, 0)), render_area);
+}
+
+pub(super) fn pending_history_lines(state: &AppState, width: u16) -> Vec<Line<'static>> {
+    transcript_lines(state.pending_transcript(), width.max(1), state)
+}
+
+pub(super) struct StreamingHistoryCommit {
+    pub(super) lines: Vec<Line<'static>>,
+    pub(super) complete_entries: usize,
+    pub(super) active_byte_count: usize,
+}
+
+pub(super) fn streaming_history_commit(state: &AppState, width: u16) -> Option<StreamingHistoryCommit> {
+    if !state.can_commit_streaming_lines() {
+        return None;
+    }
+
+    let pending = state.pending_transcript();
+    let (active, complete) = pending.split_last()?;
+    let stable_count = complete
+        .iter()
+        .take_while(|entry| entry.is_stable_for_history())
+        .count();
+    if stable_count != complete.len() {
+        return None;
+    }
+    let mut lines = transcript_lines(complete, width.max(1), state);
+    if !complete.is_empty() {
+        lines.push(Line::default());
+    }
+
+    let visible_text = active.visible_text();
+    let active_byte_count = match active.kind {
+        EntryKind::Assistant => markdown_commit_boundary(visible_text),
+        EntryKind::Thinking => line_commit_boundary(visible_text),
+        _ => 0,
+    };
+    if active_byte_count > 0 {
+        let prefix = &visible_text[..active_byte_count];
+        let prefix_entry = TranscriptEntry::new(active.kind, active.label.as_str(), prefix);
+        lines.extend(transcript_lines(&[prefix_entry], width.max(1), state));
+        if active.kind == EntryKind::Assistant {
             lines.push(Line::default());
-        }
-        if is_conversation(entry.kind) {
-            for line in conversation_lines(&entry.text, area.width) {
-                lines.push(Line::from(Span::styled(line, entry_style(entry.kind, state))));
-            }
-        } else {
-            lines.push(Line::from(Span::styled(
-                entry.label.as_str(),
-                entry_style(entry.kind, state).add_modifier(Modifier::BOLD),
-            )));
-            for line in entry.text.lines() {
-                lines.push(Line::from(Span::styled(
-                    line.to_string(),
-                    entry_style(entry.kind, state),
-                )));
-            }
-            if entry.text.is_empty() {
-                lines.push(Line::default());
-            }
         }
     }
 
-    let line_count = transcript_line_count(state, area.width.max(1));
-    let paragraph = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
-    let bottom = line_count.saturating_sub(area.height as usize);
-    let scroll = bottom.saturating_sub(state.scroll_back).min(u16::MAX as usize) as u16;
-    frame.render_widget(paragraph.scroll((scroll, 0)), area);
+    (!lines.is_empty()).then_some(StreamingHistoryCommit {
+        lines,
+        complete_entries: complete.len(),
+        active_byte_count,
+    })
+}
+
+pub(super) fn welcome_history_lines(state: &AppState, width: u16) -> Vec<Line<'static>> {
+    welcome_transcript_lines(state, width.max(1))
+}
+
+fn transcript_lines(entries: &[TranscriptEntry], width: u16, state: &AppState) -> Vec<Line<'static>> {
+    if entries.is_empty() {
+        return Vec::new();
+    }
+
+    let mut lines = Vec::new();
+    let mut index = 0;
+    while index < entries.len() {
+        if index > 0 {
+            lines.push(Line::default());
+        }
+        let entry = &entries[index];
+        let tool_group_end = consecutive_tool_end(entries, index);
+        if tool_group_end.saturating_sub(index) > 1 {
+            lines.extend(tool_group_lines(&entries[index..tool_group_end], width, state));
+            index = tool_group_end;
+            continue;
+        }
+        match entry.kind {
+            EntryKind::User => {
+                lines.extend(user_message_lines(entry.visible_text(), width, state));
+            }
+            EntryKind::Assistant => {
+                lines.extend(render_markdown(entry.visible_text(), width, markdown_theme(state)));
+            }
+            _ => {
+                for label in wrapped_lines(&entry_label(entry), width) {
+                    lines.push(Line::from(Span::styled(label, entry_label_style(entry, state))));
+                }
+                if entry.kind == EntryKind::Tool {
+                    if let Some(preview) = tool_preview(entry.visible_text(), width) {
+                        lines.push(Line::from(Span::styled(preview, entry_style(entry.kind, state))));
+                    }
+                } else if entry.visible_text().is_empty() {
+                    lines.push(Line::default());
+                } else {
+                    for line in entry
+                        .visible_text()
+                        .split('\n')
+                        .flat_map(|line| wrapped_lines(line, width))
+                    {
+                        lines.push(Line::from(Span::styled(line, entry_style(entry.kind, state))));
+                    }
+                }
+            }
+        }
+        index += 1;
+    }
+    lines
+}
+
+fn pending_transcript_lines(state: &AppState, width: u16) -> Vec<Line<'static>> {
+    transcript_lines(state.pending_transcript(), width, state)
+}
+
+fn line_commit_boundary(text: &str) -> usize {
+    text.rfind('\n')
+        .map(|index| index + '\n'.len_utf8())
+        .filter(|boundary| *boundary < text.len())
+        .unwrap_or(0)
+}
+
+fn markdown_commit_boundary(text: &str) -> usize {
+    let mut in_fence = false;
+    let mut offset = 0;
+    let mut boundary = 0;
+    for line in text.split_inclusive('\n') {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fence = !in_fence;
+        }
+        offset += line.len();
+        if !in_fence && trimmed.is_empty() && offset < text.len() {
+            boundary = offset;
+        }
+    }
+    boundary
+}
+
+fn wrapped_lines(text: &str, width: u16) -> Vec<String> {
+    let width = usize::from(width.max(1));
+    let mut lines = Vec::new();
+    let mut line = String::new();
+    let mut line_width = 0;
+    for character in text.chars() {
+        let character_width = character.width().unwrap_or(1).max(1);
+        if line_width > 0 && line_width + character_width > width {
+            lines.push(line);
+            line = String::new();
+            line_width = 0;
+        }
+        line.push(character);
+        line_width += character_width;
+    }
+    if !line.is_empty() || text.is_empty() {
+        lines.push(line);
+    }
+    lines
+}
+
+fn welcome_transcript_lines(state: &AppState, width: u16) -> Vec<Line<'static>> {
+    let mut lines = if width >= 50 {
+        aion_mark_lines(state)
+            .into_iter()
+            .map(|line| line.alignment(Alignment::Center))
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if !lines.is_empty() {
+        lines.push(Line::default());
+    }
+    lines.push(
+        Line::from(Span::styled("AionCLI", normal(state).add_modifier(Modifier::BOLD))).alignment(Alignment::Center),
+    );
+    lines.push(
+        Line::from(Span::styled(
+            truncate_line("Ask about this project, or type / to see commands.", width.max(1)),
+            muted(state),
+        ))
+        .alignment(Alignment::Center),
+    );
+    lines.push(Line::default());
+    lines
 }
 
 fn render_welcome(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
-    let welcome_height = AION_MARK_LEVELS.len() as u16 + 3;
+    let welcome_height = AION_MARK_LINES.len() as u16 + 3;
     if area.height < welcome_height || area.width < 50 {
+        let render_area = bottom_aligned_area(area, 1, TRANSCRIPT_BOTTOM_GAP);
         frame.render_widget(
             Paragraph::new("Ask about this project, or type / to see commands.")
                 .alignment(Alignment::Center)
                 .style(muted(state)),
-            area,
+            render_area,
         );
         return;
     }
 
-    let top_padding = area.height.saturating_sub(welcome_height) / 3;
+    let top_padding = area
+        .height
+        .saturating_sub(welcome_height.saturating_add(TRANSCRIPT_BOTTOM_GAP));
     let mut lines = vec![Line::default(); top_padding as usize];
     lines.extend(aion_mark_lines(state));
     lines.push(Line::default());
@@ -143,62 +335,77 @@ fn render_welcome(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
     frame.render_widget(Paragraph::new(lines).alignment(Alignment::Center), area);
 }
 
+fn bottom_aligned_area(area: Rect, content_height: usize, preferred_gap: u16) -> Rect {
+    let content_height = content_height.min(u16::MAX as usize) as u16;
+    if content_height >= area.height {
+        return area;
+    }
+    let available_gap = area.height.saturating_sub(content_height);
+    let gap = preferred_gap.min(available_gap);
+    Rect::new(
+        area.x,
+        area.bottom().saturating_sub(content_height).saturating_sub(gap),
+        area.width,
+        content_height,
+    )
+}
+
 fn aion_mark_lines(state: &AppState) -> Vec<Line<'static>> {
-    AION_MARK_LEVELS
+    AION_MARK_LINES
         .iter()
-        .map(|levels| {
-            let spans = levels
+        .map(|source| {
+            debug_assert_eq!(source.len(), AION_MARK_WIDTH);
+            let spans = source
                 .chars()
-                .map(|level| {
-                    let (glyph, shade) = match level {
-                        '1' => ("..", 178),
-                        '2' => ("::", 146),
-                        '3' => ("**", 110),
-                        '4' => ("##", 70),
-                        '5' => ("@@", 28),
-                        _ => ("  ", 0),
-                    };
-                    let style = if level == '0' || state.no_color {
+                .map(|glyph| {
+                    let style = if glyph == ' ' || state.no_color {
                         Style::default()
                     } else {
-                        Style::default().fg(Color::Rgb(shade, shade, shade))
+                        Style::default().fg(Color::Rgb(28, 28, 28))
                     };
-                    Span::styled(glyph, style)
+                    Span::styled(glyph.to_string(), style)
                 })
                 .collect::<Vec<_>>();
-            debug_assert_eq!(levels.len() * 2, AION_MARK_WIDTH);
             Line::from(spans)
         })
         .collect()
 }
 
-fn transcript_line_count(state: &AppState, width: u16) -> usize {
-    if state.transcript.is_empty() {
-        return 1;
+fn consecutive_tool_end(entries: &[TranscriptEntry], start: usize) -> usize {
+    if entries.get(start).is_none_or(|entry| entry.kind != EntryKind::Tool) {
+        return start.saturating_add(1).min(entries.len());
     }
-    let width = width.max(1) as usize;
-    let mut count = state.transcript.len().saturating_sub(1);
-    for entry in &state.transcript {
-        if is_conversation(entry.kind) {
-            count += conversation_lines(&entry.text, width as u16).len();
-        } else {
-            count += wrapped_height(&entry.label, width);
-            if entry.text.is_empty() {
-                count += 1;
-            } else {
-                count += entry
-                    .text
-                    .lines()
-                    .map(|line| wrapped_height(line, width))
-                    .sum::<usize>();
-            }
-        }
-    }
-    count
+    entries[start..]
+        .iter()
+        .position(|entry| entry.kind != EntryKind::Tool)
+        .map_or(entries.len(), |offset| start + offset)
 }
 
-fn is_conversation(kind: EntryKind) -> bool {
-    matches!(kind, EntryKind::User | EntryKind::Assistant)
+fn tool_group_lines(entries: &[TranscriptEntry], width: u16, state: &AppState) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        "• Tools",
+        muted(state).add_modifier(Modifier::BOLD),
+    ))];
+    let hidden = entries.len().saturating_sub(MAX_VISIBLE_TOOLS);
+    if hidden > 0 {
+        lines.push(Line::from(Span::styled(
+            truncate_line(&format!("  … {hidden} earlier tools"), width),
+            muted(state),
+        )));
+    }
+    let visible = &entries[hidden..];
+    for (index, entry) in visible.iter().enumerate() {
+        let last = index + 1 == visible.len();
+        let branch = if last { "└─" } else { "├─" };
+        let status = entry.tool_status.unwrap_or(ToolStepStatus::Queued).label();
+        let label = truncate_line(&format!("  {branch} {}  {status}", entry.label), width);
+        lines.push(Line::from(Span::styled(label, entry_label_style(entry, state))));
+        let indent = if last { "     " } else { "  │  " };
+        if let Some(preview) = tool_preview_with_indent(&entry.text, width, indent) {
+            lines.push(Line::from(Span::styled(preview, entry_style(entry.kind, state))));
+        }
+    }
+    lines
 }
 
 fn conversation_lines(text: &str, width: u16) -> Vec<String> {
@@ -226,12 +433,31 @@ fn conversation_lines(text: &str, width: u16) -> Vec<String> {
     lines
 }
 
-fn padded_message_line(text: &str, text_width: usize, content_width: usize) -> String {
-    format!(" {text}{} ", " ".repeat(content_width.saturating_sub(text_width)))
+fn user_message_lines(text: &str, width: u16, state: &AppState) -> Vec<Line<'static>> {
+    let content = conversation_lines(text, width);
+    let mut lines = Vec::with_capacity(content.len().saturating_add(2));
+    if !state.no_color {
+        lines.push(Line::from(Span::styled(
+            "▄".repeat(usize::from(width)),
+            Style::default().fg(Color::Black),
+        )));
+    }
+    lines.extend(
+        content
+            .into_iter()
+            .map(|line| Line::from(Span::styled(line, entry_style(EntryKind::User, state)))),
+    );
+    if !state.no_color {
+        lines.push(Line::from(Span::styled(
+            "▀".repeat(usize::from(width)),
+            Style::default().fg(Color::Black),
+        )));
+    }
+    lines
 }
 
-fn wrapped_height(text: &str, width: usize) -> usize {
-    UnicodeWidthStr::width(text).max(1).div_ceil(width)
+fn padded_message_line(text: &str, text_width: usize, content_width: usize) -> String {
+    format!(" {text}{} ", " ".repeat(content_width.saturating_sub(text_width)))
 }
 
 fn render_composer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
@@ -240,8 +466,10 @@ fn render_composer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
     frame.render_widget(block, area);
 
     let text = state.composer.text();
-    let placeholder = text.is_empty() && !state.busy;
-    let displayed = if placeholder {
+    let placeholder = text.is_empty() && !state.busy && !state.initializing;
+    let displayed = if state.initializing {
+        "Starting AionCLI…".to_string()
+    } else if placeholder {
         "Type a message…".to_string()
     } else {
         text
@@ -256,7 +484,7 @@ fn render_composer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
             .scroll((vertical_scroll, 0)),
         inner,
     );
-    if !state.busy && state.approval.is_none() {
+    if !state.initializing && !state.busy && state.approval.is_none() && !state.session_picker.is_visible() {
         frame.set_cursor_position((
             inner.x.saturating_add(cursor_column),
             inner.y.saturating_add(cursor_row.saturating_sub(vertical_scroll)),
@@ -265,16 +493,9 @@ fn render_composer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
 }
 
 fn render_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
-    let hints = if state.approval.is_some() {
-        " y allow once · a always allow · n/esc deny "
+    let status = if state.initializing {
+        "starting"
     } else if state.busy {
-        " Ctrl+C stop · PgUp/PgDn scroll "
-    } else if area.width >= 70 {
-        " Enter send · Shift+Enter newline · / commands · Tab complete · Ctrl+C quit "
-    } else {
-        " Enter send · / commands · Ctrl+C quit "
-    };
-    let status = if state.busy {
         ["·", "••", "•••", "••"]
             .get(state.spinner_frame)
             .copied()
@@ -292,7 +513,6 @@ fn render_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
     let session = format!(" session {} ", state.session_id.as_deref().unwrap_or("new"));
     frame.render_widget(
         Paragraph::new(vec![
-            Line::from(Span::styled(hints, accent(state))),
             Line::from(Span::styled(metadata, muted(state))),
             Line::from(Span::styled(session, muted(state))),
         ]),
@@ -320,6 +540,118 @@ fn render_command_popup(frame: &mut Frame<'_>, bounds: Rect, composer: Rect, sta
     }
     frame.render_widget(Clear, area);
     frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn render_session_picker(frame: &mut Frame<'_>, bounds: Rect, state: &AppState) {
+    let sessions = state.session_picker.sessions();
+    if sessions.is_empty() {
+        return;
+    }
+
+    let available_height = bounds.height;
+    let visible = usize::from(available_height.saturating_sub(3) / 2)
+        .max(1)
+        .min(sessions.len());
+    let area = bounds;
+    let block = Block::default()
+        .borders(Borders::TOP | Borders::BOTTOM)
+        .title(format!(" Resume session · {} ", sessions.len()))
+        .border_style(divider(state));
+    let inner = block.inner(area);
+    let selected = state.session_picker.selected();
+    let start = selected
+        .saturating_sub(visible.saturating_sub(1))
+        .min(sessions.len().saturating_sub(visible));
+    let mut lines = Vec::with_capacity(visible * 2 + 1);
+
+    for (index, session) in sessions.iter().enumerate().skip(start).take(visible) {
+        let is_selected = index == selected;
+        let marker = if is_selected { "›" } else { " " };
+        let summary = fit_line(&format!("{marker} {}", session.summary()), inner.width);
+        let details = fit_line(
+            &format!(
+                "  {} · {} · {} · {} messages",
+                session.id(),
+                session.model(),
+                session.updated_at(),
+                session.message_count()
+            ),
+            inner.width,
+        );
+        let summary_style = if is_selected {
+            selected_style(state)
+        } else {
+            normal(state)
+        };
+        let detail_style = if is_selected {
+            selected_style(state)
+        } else {
+            muted(state)
+        };
+        lines.push(Line::from(Span::styled(summary, summary_style)));
+        lines.push(Line::from(Span::styled(details, detail_style)));
+    }
+    lines.push(Line::from(Span::styled(
+        fit_line(" ↑/↓ select · Enter resume · Esc close", inner.width),
+        muted(state),
+    )));
+
+    frame.render_widget(Clear, bounds);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn fit_line(text: &str, width: u16) -> String {
+    let width = usize::from(width);
+    if width == 0 {
+        return String::new();
+    }
+    let text_width = UnicodeWidthStr::width(text);
+    if text_width <= width {
+        return format!("{text}{}", " ".repeat(width - text_width));
+    }
+    truncate_line(text, width as u16)
+}
+
+fn tool_preview(text: &str, width: u16) -> Option<String> {
+    tool_preview_with_indent(text, width, "  ")
+}
+
+fn tool_preview_with_indent(text: &str, width: u16, indent: &str) -> Option<String> {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let indent_width = UnicodeWidthStr::width(indent);
+    if normalized.is_empty() || usize::from(width) <= indent_width {
+        return None;
+    }
+    let preview_width = width
+        .saturating_sub(indent_width.min(u16::MAX as usize) as u16)
+        .min(120);
+    let preview = truncate_line(&normalized, preview_width);
+    Some(format!("{indent}{preview}"))
+}
+
+fn truncate_line(text: &str, width: u16) -> String {
+    let width = usize::from(width);
+    if UnicodeWidthStr::width(text) <= width {
+        return text.to_string();
+    }
+    if width == 0 {
+        return String::new();
+    }
+
+    let content_width = width.saturating_sub(1);
+    let mut truncated = String::new();
+    let mut current_width = 0;
+    for character in text.chars() {
+        let character_width = character.width().unwrap_or(1);
+        if current_width + character_width > content_width {
+            break;
+        }
+        truncated.push(character);
+        current_width += character_width;
+    }
+    truncated.push('…');
+    truncated
 }
 
 fn render_approval(frame: &mut Frame<'_>, bounds: Rect, state: &AppState) {
@@ -355,30 +687,75 @@ fn centered_rect(width: u16, height: u16, bounds: Rect) -> Rect {
 
 fn entry_style(kind: EntryKind, state: &AppState) -> Style {
     match kind {
-        EntryKind::User if state.no_color => normal(state).add_modifier(Modifier::BOLD),
-        EntryKind::User => Style::default()
-            .fg(Color::White)
-            .bg(Color::Black)
-            .add_modifier(Modifier::BOLD),
+        EntryKind::User if state.no_color => normal(state),
+        EntryKind::User => Style::default().fg(Color::White).bg(Color::Black),
         EntryKind::Assistant if state.no_color => normal(state),
-        EntryKind::Assistant => Style::default().fg(Color::DarkGray),
+        EntryKind::Assistant => Style::default().fg(Color::Black),
         EntryKind::Thinking => muted(state).add_modifier(Modifier::ITALIC),
-        EntryKind::Tool => success(state),
+        EntryKind::Tool => muted(state),
         EntryKind::Info => muted(state),
         EntryKind::Error => error(state),
     }
 }
 
+fn markdown_theme(state: &AppState) -> MarkdownTheme {
+    let body = entry_style(EntryKind::Assistant, state);
+    if state.no_color {
+        return MarkdownTheme {
+            body,
+            inline_code: body.add_modifier(Modifier::REVERSED),
+            code_block: body,
+            marker: muted(state),
+            rule: muted(state),
+        };
+    }
+    MarkdownTheme {
+        body,
+        inline_code: Style::default().fg(Color::Black).bg(Color::Rgb(232, 232, 232)),
+        code_block: Style::default().fg(Color::Black).bg(Color::Rgb(245, 245, 245)),
+        marker: Style::default().fg(Color::Rgb(92, 92, 92)),
+        rule: Style::default().fg(Color::Rgb(146, 146, 146)),
+    }
+}
+
+fn entry_label(entry: &TranscriptEntry) -> String {
+    match entry.kind {
+        EntryKind::Thinking => "• Thinking".to_string(),
+        EntryKind::Tool => {
+            let status = entry.tool_status.unwrap_or(ToolStepStatus::Queued).label();
+            format!("• {}  {status}", entry.label)
+        }
+        _ => entry.label.clone(),
+    }
+}
+
+fn entry_label_style(entry: &TranscriptEntry, state: &AppState) -> Style {
+    match entry.kind {
+        EntryKind::Thinking => muted(state).add_modifier(Modifier::BOLD),
+        EntryKind::Tool => {
+            tool_status_style(entry.tool_status.unwrap_or(ToolStepStatus::Queued), state).add_modifier(Modifier::BOLD)
+        }
+        _ => entry_style(entry.kind, state).add_modifier(Modifier::BOLD),
+    }
+}
+
+fn tool_status_style(status: ToolStepStatus, state: &AppState) -> Style {
+    if state.no_color {
+        return Style::default();
+    }
+    let color = match status {
+        ToolStepStatus::Queued => Color::Rgb(92, 92, 92),
+        ToolStepStatus::Approval => Color::Rgb(146, 89, 0),
+        ToolStepStatus::Running => Color::Rgb(29, 78, 216),
+        ToolStepStatus::Success => Color::Rgb(21, 128, 61),
+        ToolStepStatus::Error => Color::Rgb(185, 28, 28),
+        ToolStepStatus::Cancelled => Color::Rgb(109, 40, 217),
+    };
+    Style::default().fg(color)
+}
+
 fn normal(_state: &AppState) -> Style {
     Style::default()
-}
-
-fn accent(state: &AppState) -> Style {
-    color(state, Color::Black)
-}
-
-fn success(state: &AppState) -> Style {
-    color(state, Color::DarkGray)
 }
 
 fn warning(state: &AppState) -> Style {

--- a/crates/aion-tui/src/ui_test.rs
+++ b/crates/aion-tui/src/ui_test.rs
@@ -1,11 +1,14 @@
 use aion_agent::commands::CommandSpec;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
-use ratatui::style::Color;
+use ratatui::style::{Color, Modifier};
 
-use super::{aion_mark_lines, entry_style, render};
+use super::{
+    aion_mark_lines, entry_style, pending_history_lines, render, streaming_history_commit, welcome_history_lines,
+};
+use crate::session_picker::TuiSession;
 use crate::state::AppState;
-use crate::transcript::{EntryKind, TranscriptEntry};
+use crate::transcript::{EntryKind, ToolStepStatus, TranscriptEntry};
 
 #[test]
 fn slash_command_popup_renders_an_unframed_selected_command() {
@@ -46,7 +49,54 @@ fn slash_command_popup_renders_an_unframed_selected_command() {
         .buffer()
         .cell((78, command_row))
         .expect("selected command should fill the content width");
-    assert!(final_content_cell.modifier.contains(ratatui::style::Modifier::REVERSED));
+    assert!(final_content_cell.modifier.contains(Modifier::REVERSED));
+}
+
+#[test]
+fn slash_command_space_is_released_when_the_popup_closes() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    state.set_commands(
+        (0..7)
+            .map(|index| CommandSpec {
+                name: format!("command{index}"),
+                aliases: Vec::new(),
+                description: "Description".to_string(),
+            })
+            .collect(),
+    );
+    state.composer.insert_text("/");
+    state.popup.update("/");
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+    let open = terminal.backend().to_string();
+    let open_divider = open
+        .lines()
+        .position(|line| line.contains("────"))
+        .expect("composer divider should be visible");
+    assert_eq!(open_divider, 7);
+
+    state.composer.clear();
+    state.popup.update("");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+    let closed = terminal.backend().to_string();
+    let closed_divider = closed
+        .lines()
+        .position(|line| line.contains("────"))
+        .expect("composer divider should be visible");
+    assert_eq!(closed_divider, 0);
+    assert!(!closed.contains("/command"));
 }
 
 #[test]
@@ -90,8 +140,20 @@ fn runtime_metadata_is_rendered_in_the_footer_not_the_top_row() {
     let lines = terminal.backend().to_string();
     let lines = lines.lines().collect::<Vec<_>>();
     assert!(!lines[0].contains("openai"));
-    assert!(lines[22].contains("openai"));
-    assert!(lines[23].contains("session session-id"));
+    let composer_row = lines
+        .iter()
+        .position(|line| line.contains("Type a message"))
+        .expect("composer should be visible");
+    let metadata_row = lines
+        .iter()
+        .position(|line| line.contains("openai"))
+        .expect("metadata should be visible");
+    let session_row = lines
+        .iter()
+        .position(|line| line.contains("session session-id"))
+        .expect("session should be visible");
+    assert!(metadata_row > composer_row);
+    assert_eq!(session_row, metadata_row + 1);
 }
 
 #[test]
@@ -109,9 +171,35 @@ fn welcome_renders_ascii_aion_mark() {
         .expect("render should succeed");
 
     let rendered = terminal.backend().to_string();
-    assert!(rendered.contains("**@@@@**"));
-    assert!(rendered.contains("**@@@@######@@**"));
+    assert!(rendered.contains("::::::::"));
     assert!(rendered.contains("AionCLI"));
+}
+
+#[test]
+fn welcome_header_stays_close_to_the_composer() {
+    let state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    let lines = rendered.lines().collect::<Vec<_>>();
+    let subtitle_row = lines
+        .iter()
+        .position(|line| line.contains("Ask about this project"))
+        .expect("welcome subtitle should be visible");
+    let composer_divider_row = lines
+        .iter()
+        .position(|line| line.contains("────"))
+        .expect("composer divider should be visible");
+    assert_eq!(composer_divider_row.saturating_sub(subtitle_row), 2);
 }
 
 #[test]
@@ -126,10 +214,490 @@ fn welcome_ascii_uses_truecolor_grayscale_without_a_background() {
     let colored = mark
         .iter()
         .flat_map(|line| &line.spans)
-        .find(|span| span.content.contains('@'))
+        .find(|span| span.style.fg == Some(Color::Rgb(28, 28, 28)))
         .expect("mark should contain a dense colored cell");
     assert_eq!(colored.style.fg, Some(Color::Rgb(28, 28, 28)));
     assert_eq!(colored.style.bg, None);
+    assert!(
+        mark.iter()
+            .flat_map(|line| &line.spans)
+            .flat_map(|span| span.content.chars())
+            .all(|character| matches!(character, ':' | ' '))
+    );
+    for line in mark {
+        let rendered = line.to_string();
+        assert_eq!(rendered.chars().count(), 24);
+        assert_eq!(rendered, rendered.chars().rev().collect::<String>());
+    }
+}
+
+#[test]
+fn welcome_mark_is_committed_separately_from_the_first_message() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    let welcome = welcome_history_lines(&state, 78)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(welcome.contains("::::::::"));
+
+    state.show_welcome = false;
+    state.begin_turn("first message");
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    assert!(!rendered.contains("::::::::"));
+    assert!(rendered.contains("first message"));
+}
+
+#[test]
+fn resumed_history_replay_contains_the_entire_session() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::User, "", "old question"));
+    state.transcript.push(TranscriptEntry::new(
+        EntryKind::Assistant,
+        "",
+        (0..30).map(|index| format!("old answer {index}\n")).collect::<String>(),
+    ));
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::User, "", "latest question"));
+    state.transcript.push(TranscriptEntry::new(
+        EntryKind::Assistant,
+        "",
+        (0..30)
+            .map(|index| format!("latest answer {index}\n"))
+            .collect::<String>(),
+    ));
+    let rendered = pending_history_lines(&state, 80)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("old question"));
+    assert!(rendered.contains("old answer 0"));
+    assert!(rendered.contains("latest question"));
+    assert!(rendered.contains("latest answer 29"));
+}
+
+#[test]
+fn committed_history_leaves_only_new_transcript_pending() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::User, "", "first question"));
+    state.transcript.push(TranscriptEntry::new(
+        EntryKind::Assistant,
+        "",
+        (0..80)
+            .map(|index| format!("answer line {index}\n"))
+            .collect::<String>(),
+    ));
+    let history = pending_history_lines(&state, 80);
+    assert!(history.iter().any(|line| line.to_string().contains("first question")));
+    assert!(history.iter().any(|line| line.to_string().contains("answer line 79")));
+
+    state.mark_transcript_committed();
+    assert!(pending_history_lines(&state, 80).is_empty());
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::User, "", "next question"));
+    let pending = pending_history_lines(&state, 80);
+    assert_eq!(pending.len(), 1);
+    assert!(pending[0].to_string().contains("next question"));
+}
+
+#[test]
+fn streaming_markdown_commits_complete_paragraphs_and_keeps_the_active_tail() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    state.begin_turn("question");
+    state.mark_transcript_committed();
+    state.handle_agent_event(crate::event::AgentEvent::TextDelta(
+        "first paragraph\n\nsecond paragraph is still streaming".to_string(),
+    ));
+
+    let commit = streaming_history_commit(&state, 32).expect("the completed paragraph should be committed");
+    let committed = commit
+        .lines
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(committed.contains("first paragraph"));
+    assert!(!committed.contains("second paragraph"));
+
+    state.commit_streaming_prefix(commit.complete_entries, commit.active_byte_count);
+    for width in [24, 48] {
+        let pending = pending_history_lines(&state, width)
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!pending.contains("first paragraph"));
+        assert!(pending.contains("second paragraph"));
+    }
+}
+
+#[test]
+fn streaming_markdown_does_not_commit_an_unclosed_code_fence() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    state.begin_turn("question");
+    state.mark_transcript_committed();
+    state.handle_agent_event(crate::event::AgentEvent::TextDelta(
+        "```rust\nfn main() {\n\n    println!(\"hello\");\n".to_string(),
+    ));
+
+    assert!(streaming_history_commit(&state, 32).is_none());
+}
+
+#[test]
+fn streaming_history_moves_completed_tool_steps_before_the_active_answer() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    state.begin_turn("question");
+    state.mark_transcript_committed();
+    state
+        .transcript
+        .push(TranscriptEntry::tool("Read", "file contents", ToolStepStatus::Success));
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::Assistant, "", "answer in progress"));
+
+    let commit = streaming_history_commit(&state, 48).expect("the completed tool should be committed");
+    assert_eq!(commit.complete_entries, 1);
+    assert_eq!(commit.active_byte_count, 0);
+    assert!(commit.lines.iter().any(|line| line.to_string().contains("Read")));
+    assert!(
+        !commit
+            .lines
+            .iter()
+            .any(|line| line.to_string().contains("answer in progress"))
+    );
+}
+
+#[test]
+fn streaming_history_keeps_a_running_tool_mutable() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    state.begin_turn("question");
+    state.mark_transcript_committed();
+    state
+        .transcript
+        .push(TranscriptEntry::tool("Read", "request", ToolStepStatus::Running));
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::Assistant, "", "answer in progress"));
+
+    assert!(streaming_history_commit(&state, 48).is_none());
+}
+
+#[test]
+fn committed_history_does_not_leave_a_blank_transcript_viewport() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::Assistant, "", "completed answer"));
+    state.mark_transcript_committed();
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+    let rendered = terminal.backend().to_string();
+    let lines = rendered.lines().collect::<Vec<_>>();
+    let composer_divider_row = lines
+        .iter()
+        .position(|line| line.contains("────"))
+        .expect("composer divider should be visible");
+    assert_eq!(composer_divider_row, 0);
+}
+
+#[test]
+fn thinking_and_tools_render_countable_step_markers() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        false,
+    );
+    state.show_welcome = false;
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::Thinking, "Thinking", "checking"));
+    state
+        .transcript
+        .push(TranscriptEntry::tool("Read", "file contents", ToolStepStatus::Success));
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    assert!(rendered.contains("• Thinking"));
+    assert!(rendered.contains("• Read  done"));
+}
+
+#[test]
+fn consecutive_tools_render_as_one_appended_group() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        false,
+    );
+    state.show_welcome = false;
+    state
+        .transcript
+        .push(TranscriptEntry::tool("Read", "src/main.rs", ToolStepStatus::Success));
+    state.transcript.push(TranscriptEntry::tool(
+        "Grep",
+        "matched two files",
+        ToolStepStatus::Success,
+    ));
+
+    let backend = TestBackend::new(80, 18);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    assert!(rendered.contains("• Tools"));
+    assert!(rendered.contains("├─ Read  done"));
+    assert!(rendered.contains("└─ Grep  done"));
+    assert!(rendered.contains("src/main.rs"));
+    assert!(rendered.contains("matched two files"));
+    assert!(!rendered.contains("• Read"));
+    assert!(!rendered.contains("• Grep"));
+    assert!(
+        rendered.find("├─ Read").expect("Read should be visible")
+            < rendered.find("└─ Grep").expect("Grep should be visible")
+    );
+}
+
+#[test]
+fn tool_group_keeps_only_the_three_most_recent_calls() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    for index in 1..=5 {
+        state.transcript.push(TranscriptEntry::tool(
+            format!("Tool{index}"),
+            format!("output {index}"),
+            ToolStepStatus::Success,
+        ));
+    }
+
+    let rendered = pending_history_lines(&state, 80)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("… 2 earlier tools"));
+    assert!(!rendered.contains("Tool1"));
+    assert!(!rendered.contains("output 2"));
+    assert!(rendered.contains("Tool3"));
+    assert!(rendered.contains("Tool4"));
+    assert!(rendered.contains("Tool5"));
+}
+
+#[test]
+fn assistant_markdown_is_rendered_but_user_markdown_stays_literal() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        false,
+    );
+    state.show_welcome = false;
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::User, "", "**literal** `input`"));
+    state.transcript.push(TranscriptEntry::new(
+        EntryKind::Assistant,
+        "",
+        "Use `cargo check` and **review**.\n\n```rust\nfn main() {}\n```",
+    ));
+
+    let lines = pending_history_lines(&state, 48);
+    let rendered = lines.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n");
+    assert!(rendered.contains("**literal** `input`"));
+    assert!(rendered.contains("Use cargo check and review."));
+    assert!(!rendered.contains("```"));
+    assert!(!rendered.contains("rust"));
+
+    let code = lines
+        .iter()
+        .flat_map(|line| &line.spans)
+        .find(|span| span.content == "cargo check")
+        .expect("inline code should be rendered as a styled span");
+    assert_eq!(code.style.bg, Some(Color::Rgb(232, 232, 232)));
+    let strong = lines
+        .iter()
+        .flat_map(|line| &line.spans)
+        .find(|span| span.content == "review")
+        .expect("strong text should be rendered as a styled span");
+    assert!(strong.style.add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn assistant_code_block_refills_after_resize() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        false,
+    );
+    state.show_welcome = false;
+    state.transcript.push(TranscriptEntry::new(
+        EntryKind::Assistant,
+        "",
+        "```text\nresponsive code\n```",
+    ));
+
+    for width in [40, 64] {
+        let lines = pending_history_lines(&state, width);
+        let code_line = lines
+            .iter()
+            .find(|line| line.to_string().contains("responsive code"))
+            .expect("code line should be present");
+        assert_eq!(
+            unicode_width::UnicodeWidthStr::width(code_line.to_string().as_str()),
+            width as usize
+        );
+    }
+}
+
+#[test]
+fn tool_states_use_distinct_semantic_colors_and_text() {
+    let status_rows = [
+        ("Queued", ToolStepStatus::Queued),
+        ("Approval", ToolStepStatus::Approval),
+        ("Running", ToolStepStatus::Running),
+        ("Success", ToolStepStatus::Success),
+        ("Error", ToolStepStatus::Error),
+        ("Cancelled", ToolStepStatus::Cancelled),
+    ];
+    let expected_colors = [
+        Color::Rgb(92, 92, 92),
+        Color::Rgb(146, 89, 0),
+        Color::Rgb(29, 78, 216),
+        Color::Rgb(21, 128, 61),
+        Color::Rgb(185, 28, 28),
+        Color::Rgb(109, 40, 217),
+    ];
+    for ((name, status), color) in status_rows.into_iter().zip(expected_colors) {
+        let mut state = AppState::new(
+            "model".to_string(),
+            "provider".to_string(),
+            "/workspace".to_string(),
+            false,
+        );
+        state.show_welcome = false;
+        state.transcript.push(TranscriptEntry::tool(name, "preview", status));
+        let backend = TestBackend::new(80, 12);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| render(frame, &state))
+            .expect("render should succeed");
+        let rendered = terminal.backend().to_string();
+        let row = rendered
+            .lines()
+            .position(|line| line.contains(name))
+            .expect("tool status should be visible") as u16;
+        let marker = terminal
+            .backend()
+            .buffer()
+            .cell((1, row))
+            .expect("tool marker should exist");
+        assert_eq!(marker.fg, color);
+    }
+}
+
+#[test]
+fn tool_output_is_a_responsive_single_line_preview() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.show_welcome = false;
+    state.transcript.push(TranscriptEntry::tool(
+        "Read",
+        "first line\nsecond line with a very long result that should not take over the terminal window",
+        ToolStepStatus::Success,
+    ));
+
+    let backend = TestBackend::new(44, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    assert!(rendered.contains("first line second line"));
+    assert!(rendered.contains('…'));
+    assert!(!rendered.contains("terminal window"));
 }
 
 #[test]
@@ -143,6 +711,8 @@ fn user_and_assistant_messages_have_distinct_backgrounds() {
     let user = entry_style(EntryKind::User, &state);
     let assistant = entry_style(EntryKind::Assistant, &state);
     assert_eq!(user.bg, Some(Color::Black));
+    assert!(!user.add_modifier.contains(Modifier::BOLD));
+    assert_eq!(assistant.fg, Some(Color::Black));
     assert_eq!(assistant.bg, None);
 }
 
@@ -180,7 +750,61 @@ fn message_background_fills_the_current_render_width() {
 }
 
 #[test]
-fn composer_and_footer_have_a_blank_row_between_them() {
+fn user_message_background_has_half_row_vertical_padding() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        false,
+    );
+    state.show_welcome = false;
+    state
+        .transcript
+        .push(TranscriptEntry::new(EntryKind::User, "", "message"));
+
+    let lines = pending_history_lines(&state, 24);
+    assert_eq!(lines.len(), 3);
+    assert_eq!(lines[0].to_string(), "▄".repeat(24));
+    assert_eq!(lines[2].to_string(), "▀".repeat(24));
+    assert_eq!(lines[0].spans[0].style.fg, Some(Color::Black));
+    assert_eq!(lines[2].spans[0].style.fg, Some(Color::Black));
+}
+
+#[test]
+fn short_transcript_stays_close_to_the_composer_after_resize() {
+    for height in [16, 30] {
+        let mut state = AppState::new(
+            "model".to_string(),
+            "provider".to_string(),
+            "/workspace".to_string(),
+            true,
+        );
+        state.show_welcome = false;
+        state
+            .transcript
+            .push(TranscriptEntry::new(EntryKind::Assistant, "", "short answer"));
+        let backend = TestBackend::new(80, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| render(frame, &state))
+            .expect("render should succeed");
+
+        let rendered = terminal.backend().to_string();
+        let lines = rendered.lines().collect::<Vec<_>>();
+        let answer_row = lines
+            .iter()
+            .position(|line| line.contains("short answer"))
+            .expect("answer should be visible");
+        let composer_divider_row = lines
+            .iter()
+            .position(|line| line.contains("────"))
+            .expect("composer divider should be visible");
+        assert_eq!(composer_divider_row.saturating_sub(answer_row), 2);
+    }
+}
+
+#[test]
+fn footer_contains_only_runtime_metadata() {
     let state = AppState::new(
         "model".to_string(),
         "provider".to_string(),
@@ -195,15 +819,12 @@ fn composer_and_footer_have_a_blank_row_between_them() {
 
     let rendered = terminal.backend().to_string();
     let lines: Vec<_> = rendered.lines().collect();
-    let composer_row = lines
-        .iter()
-        .position(|line| line.contains("Type a message"))
-        .expect("composer should be visible");
-    let footer_row = lines
-        .iter()
-        .position(|line| line.contains("Enter send"))
-        .expect("footer should be visible");
-    assert!(footer_row >= composer_row + 2);
+    assert!(lines.iter().any(|line| line.contains("AionCLI")));
+    assert!(lines.iter().any(|line| line.contains("session new")));
+    assert!(!rendered.contains("Enter send"));
+    assert!(!rendered.contains("Shift+Enter"));
+    assert!(!rendered.contains("mouse wheel"));
+    assert!(!rendered.contains("drag to select"));
 }
 
 #[test]
@@ -220,4 +841,82 @@ fn undersized_terminal_shows_resize_message() {
         .draw(|frame| render(frame, &state))
         .expect("render should succeed");
     assert!(terminal.backend().to_string().contains("Terminal too small"));
+}
+
+#[test]
+fn initialization_state_replaces_the_terminal_before_bootstrap() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.begin_initialization();
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    assert!(rendered.contains("Starting AionCLI"));
+    assert!(rendered.contains("starting"));
+    assert!(!rendered.contains("Type a message"));
+}
+
+#[test]
+fn resume_picker_renders_a_full_screen_divider_window() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        false,
+    );
+    state.session_picker.set_sessions(vec![
+        TuiSession::new(
+            "session-one".to_string(),
+            "gpt-5.5".to_string(),
+            "First task".to_string(),
+            "2026-08-13 12:00 UTC".to_string(),
+            4,
+        ),
+        TuiSession::new(
+            "session-two".to_string(),
+            "gpt-5.5".to_string(),
+            "Second task".to_string(),
+            "2026-08-13 13:00 UTC".to_string(),
+            8,
+        ),
+    ]);
+    state.session_picker.open();
+    state.session_picker.move_next();
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    assert!(rendered.contains("Resume session · 2"));
+    assert!(rendered.contains("First task"));
+    assert!(rendered.contains("Second task"));
+    assert!(!rendered.contains("Type a message"));
+    assert!(!rendered.contains("AionCLI ·"));
+    assert!(!rendered.contains('│'));
+
+    let selected_row = rendered
+        .lines()
+        .position(|line| line.contains("Second task"))
+        .expect("selected session should be visible") as u16;
+    let selected_width = (0..80)
+        .filter(|column| {
+            terminal
+                .backend()
+                .buffer()
+                .cell((*column, selected_row))
+                .is_some_and(|cell| cell.modifier.contains(Modifier::REVERSED))
+        })
+        .count();
+    assert!(selected_width >= 70, "selected row should fill the picker width");
 }

--- a/crates/aion-tui/src/ui_test.rs
+++ b/crates/aion-tui/src/ui_test.rs
@@ -1,0 +1,223 @@
+use aion_agent::commands::CommandSpec;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::style::Color;
+
+use super::{aion_mark_lines, entry_style, render};
+use crate::state::AppState;
+use crate::transcript::{EntryKind, TranscriptEntry};
+
+#[test]
+fn slash_command_popup_renders_an_unframed_selected_command() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.set_commands(vec![CommandSpec {
+        name: "help".to_string(),
+        aliases: Vec::new(),
+        description: "List commands".to_string(),
+    }]);
+    state.composer.insert_text("/");
+    state.popup.update("/");
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+    let rendered = terminal.backend().to_string();
+    assert!(rendered.contains("/help"));
+    assert!(!rendered.contains("Commands"));
+    assert!(
+        !['│', '┌', '┐', '└', '┘']
+            .iter()
+            .any(|character| rendered.contains(*character))
+    );
+
+    let command_row = rendered
+        .lines()
+        .position(|line| line.contains("/help"))
+        .expect("selected command should be visible") as u16;
+    let final_content_cell = terminal
+        .backend()
+        .buffer()
+        .cell((78, command_row))
+        .expect("selected command should fill the content width");
+    assert!(final_content_cell.modifier.contains(ratatui::style::Modifier::REVERSED));
+}
+
+#[test]
+fn conversation_is_not_wrapped_in_an_outer_border() {
+    let state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    assert!(
+        !['│', '┌', '┐', '└', '┘']
+            .iter()
+            .any(|character| rendered.contains(*character))
+    );
+    assert!(rendered.contains("────"));
+}
+
+#[test]
+fn runtime_metadata_is_rendered_in_the_footer_not_the_top_row() {
+    let mut state = AppState::new(
+        "gpt-5.5".to_string(),
+        "openai".to_string(),
+        "/workspace/project".to_string(),
+        true,
+    );
+    state.session_id = Some("session-id".to_string());
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let lines = terminal.backend().to_string();
+    let lines = lines.lines().collect::<Vec<_>>();
+    assert!(!lines[0].contains("openai"));
+    assert!(lines[22].contains("openai"));
+    assert!(lines[23].contains("session session-id"));
+}
+
+#[test]
+fn welcome_renders_ascii_aion_mark() {
+    let state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    assert!(rendered.contains("**@@@@**"));
+    assert!(rendered.contains("**@@@@######@@**"));
+    assert!(rendered.contains("AionCLI"));
+}
+
+#[test]
+fn welcome_ascii_uses_truecolor_grayscale_without_a_background() {
+    let state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        false,
+    );
+    let mark = aion_mark_lines(&state);
+    let colored = mark
+        .iter()
+        .flat_map(|line| &line.spans)
+        .find(|span| span.content.contains('@'))
+        .expect("mark should contain a dense colored cell");
+    assert_eq!(colored.style.fg, Some(Color::Rgb(28, 28, 28)));
+    assert_eq!(colored.style.bg, None);
+}
+
+#[test]
+fn user_and_assistant_messages_have_distinct_backgrounds() {
+    let state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        false,
+    );
+    let user = entry_style(EntryKind::User, &state);
+    let assistant = entry_style(EntryKind::Assistant, &state);
+    assert_eq!(user.bg, Some(Color::Black));
+    assert_eq!(assistant.bg, None);
+}
+
+#[test]
+fn message_background_fills_the_current_render_width() {
+    for width in [40, 64] {
+        let mut state = AppState::new(
+            "model".to_string(),
+            "provider".to_string(),
+            "/workspace".to_string(),
+            false,
+        );
+        state
+            .transcript
+            .push(TranscriptEntry::new(EntryKind::User, "", "short message"));
+        let backend = TestBackend::new(width, 16);
+        let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+        terminal
+            .draw(|frame| render(frame, &state))
+            .expect("render should succeed");
+
+        let rendered = terminal.backend().to_string();
+        let message_row = rendered
+            .lines()
+            .position(|line| line.contains("short message"))
+            .expect("message should be visible") as u16;
+        let final_content_column = width - 2;
+        let cell = terminal
+            .backend()
+            .buffer()
+            .cell((final_content_column, message_row))
+            .expect("last message cell should exist");
+        assert_eq!(cell.bg, Color::Black);
+    }
+}
+
+#[test]
+fn composer_and_footer_have_a_blank_row_between_them() {
+    let state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    let lines: Vec<_> = rendered.lines().collect();
+    let composer_row = lines
+        .iter()
+        .position(|line| line.contains("Type a message"))
+        .expect("composer should be visible");
+    let footer_row = lines
+        .iter()
+        .position(|line| line.contains("Enter send"))
+        .expect("footer should be visible");
+    assert!(footer_row >= composer_row + 2);
+}
+
+#[test]
+fn undersized_terminal_shows_resize_message() {
+    let state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    let backend = TestBackend::new(21, 7);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+    assert!(terminal.backend().to_string().contains("Terminal too small"));
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -240,26 +240,60 @@ aionrs "Read and explain crates/aion-agent/src/engine.rs"
 aionrs
 ```
 
-When stdin and stdout are attached to a terminal, `aionrs` opens a full-screen
-conversation UI with streaming responses, tool activity, an editable composer,
-and in-place approval prompts. Type `/` at the beginning of the composer to
+When stdin and stdout are attached to a terminal, `aionrs` keeps finalized
+conversation in native terminal scrollback and renders an inline composer at
+the bottom, with streaming responses, tool activity, and in-place approval
+prompts. Type `/` at the beginning of the composer to
 open the command popup, continue typing to filter it, use Up/Down to move, and
 press Tab to complete or Enter to run the selected command.
+
+Each thinking segment starts with `•`. Consecutive tool calls are collected
+under a single `• Tools` step and appended as nested rows, so a batch remains
+easy to scan without losing its individual calls. Tool rows update in place as
+`queued`, `approval`, `running`, `done`, `failed`, or `cancelled`; the status
+label and semantic color change together. Tool input and output are displayed
+as a responsive one-line preview, while the full value remains in the saved
+conversation.
 
 | Key | Action |
 |-----|--------|
 | Enter | Send the current message |
 | Shift+Enter | Insert a newline (Ctrl+J is available as a fallback) |
-| Up/Down | Select a slash command, or recall message history |
-| PageUp/PageDown | Scroll the conversation |
+| Up/Down | Select a slash command |
+| Mouse wheel | Scroll finalized conversation in the terminal's native scrollback |
 | Ctrl+C | Stop the active turn; clear a draft or quit while idle |
 | Ctrl+D | Quit while the composer is empty |
 
-Available commands are `/compact`, `/context`, `/clear`, `/help`, and `/quit`.
-`/exit` is an alias for `/quit`. Empty messages no longer exit interactive mode.
+Mouse capture is deliberately disabled. Drag across any visible conversation
+text and use the terminal's normal copy shortcut (`Cmd+C` on macOS or usually
+`Ctrl+Shift+C` on Linux/Windows terminals).
+
+Agent commands are `/compact`, `/context`, `/clear`, `/help`, and `/quit`.
+The interactive UI also provides:
+
+| Command | Description |
+|---------|-------------|
+| `/status` | Show provider, model, session, permission mode, and context usage |
+| `/model [name]` | Show the current model or switch to a model ID |
+| `/permissions [default\|auto_edit\|yolo]` | Show or change the tool approval mode |
+| `/new` | Start a new session without exiting the interactive UI |
+| `/resume [id\|latest]` | Open the session picker or resume an ID in place |
+| `/mcp` | Show connected MCP servers and tool counts |
+| `/skills` | Show model-visible skills loaded for the current runtime |
+
+The session picker replaces the conversation with a focused full-screen list.
+Use the mouse wheel or Up/Down to move, Enter to resume, and Esc to close it.
+All saved sessions are shown in last-update order; the number retained on disk
+is controlled by `session.max_sessions` (20 by default).
+Resumed conversations are restored into the terminal's native scrollback. Use
+the mouse wheel to move between the earliest and latest turns.
+
+`/help` combines both command groups. `/exit` is an alias for `/quit`. Empty
+messages no longer exit interactive mode. Model switching accepts an explicit
+model ID; an interactive model candidate picker is not available yet.
 
 When input or output is redirected, `aionrs` keeps the plain line-oriented REPL
-for compatibility with scripts and terminals that do not support full-screen UI.
+for compatibility with scripts and terminals that do not support the interactive UI.
 
 ### 4. Switching Profiles
 
@@ -303,7 +337,10 @@ Allow? [y]es / [n]o / [a]lways / [q]uit > y
 
 ## Session Management
 
-Sessions auto-save to `.aionrs/sessions/`.
+Sessions auto-save to `.aionrs/sessions/<session-id>/state.json`. Sessions
+created by versions that used the duplicated
+`.aionrs/sessions/sessions/<session-id>/state.json` layout remain readable and
+are copied to the normalized location when resumed.
 
 ```bash
 # List saved sessions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -234,27 +234,32 @@ aionrs config init
 aionrs "Read and explain crates/aion-agent/src/engine.rs"
 ```
 
-### 3. Interactive REPL
+### 3. Interactive terminal UI
 
-```
-$ aionrs
-
-> Read the file Cargo.toml
-     1  [package]
-     2  name = "aionrs"
-     ...
-[turns: 1 | tokens: 1234 in / 567 out]
-
-> Add serde_yaml to dependencies
-[tool] Write({"file_path":"Cargo.toml","content":"..."})
-Allow? [y]es / [n]o / [a]lways / [q]uit > y
-[Write] OK
-[turns: 2 | tokens: 2345 in / 890 out]
-
-> /quit
+```bash
+aionrs
 ```
 
-REPL commands: `/quit`, `/exit`, or empty line to exit.
+When stdin and stdout are attached to a terminal, `aionrs` opens a full-screen
+conversation UI with streaming responses, tool activity, an editable composer,
+and in-place approval prompts. Type `/` at the beginning of the composer to
+open the command popup, continue typing to filter it, use Up/Down to move, and
+press Tab to complete or Enter to run the selected command.
+
+| Key | Action |
+|-----|--------|
+| Enter | Send the current message |
+| Shift+Enter | Insert a newline (Ctrl+J is available as a fallback) |
+| Up/Down | Select a slash command, or recall message history |
+| PageUp/PageDown | Scroll the conversation |
+| Ctrl+C | Stop the active turn; clear a draft or quit while idle |
+| Ctrl+D | Quit while the composer is empty |
+
+Available commands are `/compact`, `/context`, `/clear`, `/help`, and `/quit`.
+`/exit` is an alias for `/quit`. Empty messages no longer exit interactive mode.
+
+When input or output is redirected, `aionrs` keeps the plain line-oriented REPL
+for compatibility with scripts and terminals that do not support full-screen UI.
 
 ### 4. Switching Profiles
 
@@ -274,7 +279,9 @@ aionrs "List all Rust files in this project"
 
 ## Tool Confirmation
 
-Destructive tools (Write, Edit, ExecCommand) prompt for confirmation before execution:
+Tools that require approval are displayed in an in-place dialog in the terminal
+UI. Press `y` or Enter to allow once, `a` to allow the category for the rest of
+the session, or `n`/Esc to deny. The plain REPL uses the equivalent text prompt:
 
 ```
 [tool] Write({"file_path": "/tmp/test.rs", "content": "..."})

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -14,11 +14,14 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
+bitflags = { version = "2", default-features = false, features = ["std"] }
+either = { version = "1", default-features = false, features = ["use_std"] }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+hashbrown = { version = "0.16" }
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "http2", "server"] }
 memchr = { version = "2" }
@@ -39,20 +42,21 @@ uuid = { version = "1", features = ["v7"] }
 winnow = { version = "1" }
 
 [build-dependencies]
+hashbrown = { version = "0.16" }
 memchr = { version = "2" }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
 serde_core = { version = "1", default-features = false, features = ["alloc", "result", "std"] }
-syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn-7b89eefb6aaa9bf3 = { package = "syn", version = "3", features = ["extra-traits", "full", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 toml_datetime = { version = "1", features = ["serde"] }
 toml_parser = { version = "1" }
 winnow = { version = "1" }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-bitflags = { version = "2", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 mio = { version = "1", features = ["net", "os-ext"] }
@@ -68,8 +72,7 @@ zeroize = { version = "1", features = ["derive"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 
 [target.x86_64-apple-darwin.dependencies]
-bitflags = { version = "2", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 mio = { version = "1", features = ["net", "os-ext"] }
@@ -85,8 +88,7 @@ zeroize = { version = "1", features = ["derive"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 
 [target.aarch64-apple-darwin.dependencies]
-bitflags = { version = "2", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 mio = { version = "1", features = ["net", "os-ext"] }
@@ -102,20 +104,17 @@ zeroize = { version = "1", features = ["derive"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 rustls = { version = "0.23", default-features = false, features = ["prefer-post-quantum", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 subtle = { version = "2" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
-windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60", features = ["Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
-windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys = { version = "0.61", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 zeroize = { version = "1", features = ["derive"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 cc = { version = "1", default-features = false, features = ["parallel"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
## Summary

- replace the legacy prompt loop with a Codex-style inline TUI that keeps finalized conversation content in native terminal scrollback
- add Markdown rendering, compact grouped tool activity, unframed slash-command discovery, and a full-screen session picker
- add `/status`, `/model`, `/permissions`, `/new`, `/resume`, `/mcp`, and `/skills`, with lazy session creation and runtime session switching
- flatten session persistence to `<session-root>/<id>/state.json` while reading and migrating the previous nested layout
- preserve the embedded AionCore SDK path; AionCore does not depend on the TUI or CLI crates

## Motivation

The standalone AionCLI REPL previously behaved like a basic prompt loop and did not provide durable scrollback, discoverable commands, structured Markdown and tool rendering, or complete resume navigation.

## Compatibility

- existing non-interactive prompt and JSON stream flows remain available
- existing nested session data remains readable and is migrated on load
- AionCore continues to embed `aion-agent` rather than `aion-tui` or `aion-cli`

## Validation

- `just push -u origin jiahe/feat/tui-repl` — workspace formatting, Clippy, 2,341 nextest tests, and Hakari checks passed
- `cargo build -p aion-cli`
- AionCore `cargo check -p aionui-ai-agent` against this worktree
- AionCore `cargo test -p aionui-ai-agent resolve_build_session` — 6 passed
- PTY exit check confirms terminal cleanup emits a final CRLF
