### PR TITLE
fix(cli): stabilize tool context and terminal rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,6 @@ dependencies = [
  "aion-types",
  "anyhow",
  "crossterm",
- "futures",
  "pulldown-cmark",
  "ratatui",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Rust-based LLM tool-use agent for the command line. It connects to LLM APIs, a
 - **Session persistence** — Save and resume conversation history
 - **Persistent memory** — Project-specific memory with auto-indexing across sessions (see [docs/advanced.md](docs/advanced.md#memory-system))
 - **Plan mode** — Read-only exploration mode for designing implementation plans before coding (see [docs/advanced.md](docs/advanced.md#plan-mode))
-- **Context compression** — Three-tier automatic compaction: microcompact, autocompact, emergency (see [docs/advanced.md](docs/advanced.md#context-compression))
+- **Context compression** — Stable tool-output limits, token-based autocompact, and an emergency guard (see [docs/advanced.md](docs/advanced.md#context-compression))
 - **Output compaction** — Configurable output compression (off/safe/full) with TOON encoding (see [docs/advanced.md](docs/advanced.md#output-compaction))
 - **File state cache** — LRU cache with read deduplication and write tracking
 - **Prompt caching** — Anthropic cache_control for up to 90% cost reduction

--- a/crates/aion-agent/src/commands/compact_test.rs
+++ b/crates/aion-agent/src/commands/compact_test.rs
@@ -28,7 +28,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LlmProvider for SuccessfulProvider {
-        async fn stream(&self, _: &LlmRequest) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+        async fn stream(&self, request: &LlmRequest) -> Result<mpsc::Receiver<LlmEvent>, ProviderError> {
+            assert!(
+                request.thinking.is_none(),
+                "compact requests must omit provider thinking parameters"
+            );
             let (tx, rx) = mpsc::channel(4);
             tx.send(LlmEvent::TextDelta("<summary>manual summary</summary>".into()))
                 .await

--- a/crates/aion-agent/src/compact/auto.rs
+++ b/crates/aion-agent/src/compact/auto.rs
@@ -8,7 +8,7 @@
 use aion_config::compact::CompactConfig;
 use aion_providers::{LlmProvider, ProviderError};
 use aion_types::compact::{CompactMetadata, CompactTrigger};
-use aion_types::llm::{LlmEvent, LlmRequest, ThinkingConfig};
+use aion_types::llm::{LlmEvent, LlmRequest};
 use aion_types::message::{ContentBlock, Message, Role, TokenUsage};
 use tokio::sync::mpsc;
 
@@ -115,7 +115,7 @@ pub async fn autocompact(
             messages: conv_messages.clone(),
             tools: vec![],
             max_tokens: Some(COMPACT_MAX_OUTPUT_TOKENS),
-            thinking: Some(ThinkingConfig::Disabled),
+            thinking: None,
             reasoning_effort: None,
         };
 

--- a/crates/aion-agent/src/compact/mod.rs
+++ b/crates/aion-agent/src/compact/mod.rs
@@ -1,7 +1,8 @@
-//! Multi-level context compaction for long conversations.
+//! Context compaction guards for long conversations.
 //!
-//! Three levels, from lightest to heaviest:
-//! - **Microcompact**: clears old tool result content (no LLM call)
+//! Model-facing tool results are bounded once before entering history. The
+//! remaining guards, from lightest to heaviest, are:
+//! - **Legacy microcompact**: optionally clears old tool result content
 //! - **Autocompact**: context-threshold-triggered LLM summarization
 //! - **Emergency**: blocks API calls when near the context window limit
 

--- a/crates/aion-agent/src/engine.rs
+++ b/crates/aion-agent/src/engine.rs
@@ -16,7 +16,9 @@ use crate::context_usage::{
     estimate_tool_definitions_tokens,
 };
 use crate::error::AgentError;
-use crate::orchestration::{ExecutionControl, execute_tool_calls, execute_tool_calls_with_approval};
+use crate::orchestration::{
+    ExecutionControl, execute_tool_calls_with_approval_and_output_limit, execute_tool_calls_with_output_limit,
+};
 use crate::output::OutputSink;
 use crate::plan::prompt::plan_mode_instructions;
 use crate::plan::state::PlanState;
@@ -758,7 +760,7 @@ impl AgentEngine {
                 .as_ref()
                 .expect("protocol writer required for approval");
             let auto_approve = self.confirmer.lock().unwrap().is_auto_approve();
-            match execute_tool_calls_with_approval(
+            match execute_tool_calls_with_approval_and_output_limit(
                 &self.tools,
                 &executable_tool_calls,
                 approval_mgr,
@@ -769,6 +771,7 @@ impl AgentEngine {
                 self.hooks.as_mut(),
                 self.compact_level,
                 self.toon_enabled,
+                self.compact_config.tool_output_max_bytes,
             )
             .await
             {
@@ -780,13 +783,14 @@ impl AgentEngine {
             }
         } else {
             // Terminal mode: use interactive confirmation
-            match execute_tool_calls(
+            match execute_tool_calls_with_output_limit(
                 &self.tools,
                 &executable_tool_calls,
                 &self.confirmer,
                 self.hooks.as_mut(),
                 self.compact_level,
                 self.toon_enabled,
+                self.compact_config.tool_output_max_bytes,
             )
             .await
             {
@@ -1127,14 +1131,14 @@ impl AgentEngine {
         }
     }
 
-    /// Run the multi-level compaction pipeline before each API call.
+    /// Run context compaction guards before each API call.
     ///
-    /// Execution order: microcompact → autocompact → emergency check.
+    /// Execution order: optional legacy microcompact → autocompact → emergency check.
     /// After a successful autocompact the emergency check is skipped
     /// because the context has been significantly reduced.
     async fn run_compaction(&mut self) -> Result<(), AgentError> {
         // 1. Microcompact (lightweight, no LLM call)
-        if should_microcompact(&self.messages, &self.compact_config) {
+        if self.compact_config.microcompact_enabled && should_microcompact(&self.messages, &self.compact_config) {
             let result = microcompact(&mut self.messages, &self.compact_config);
             if result.cleared_count > 0 {
                 self.output.emit_info(&format!(

--- a/crates/aion-agent/src/engine_test.rs
+++ b/crates/aion-agent/src/engine_test.rs
@@ -1188,6 +1188,36 @@ mod tests_compact {
     // -- Microcompact runs when count trigger fires --
 
     #[tokio::test]
+    async fn microcompact_is_disabled_by_default() {
+        let mut messages = Vec::new();
+        for i in 0..12 {
+            let id = format!("t{i}");
+            messages.push(tool_use_msg(&id, "Read"));
+            messages.push(tool_result_msg(&id, &format!("data-{i}")));
+        }
+
+        let config = CompactConfig {
+            micro_keep_recent: 3,
+            ..Default::default()
+        };
+        let state = CompactState::new();
+        let mut engine = make_compact_engine(config, state, messages);
+
+        engine.run_compaction().await.unwrap();
+
+        let cleared_count = engine
+            .messages
+            .iter()
+            .flat_map(|message| &message.content)
+            .filter(
+                |block| matches!(block, ContentBlock::ToolResult { content, .. } if content == "[Tool result cleared]"),
+            )
+            .count();
+        assert_eq!(cleared_count, 0);
+        assert_eq!(engine.context_state.microcompact_count, 0);
+    }
+
+    #[tokio::test]
     async fn microcompact_clears_old_results() {
         // 12 tool results with keep_recent=3 (threshold=6) → should clear 9
         let mut messages = Vec::new();
@@ -1198,6 +1228,7 @@ mod tests_compact {
         }
 
         let config = CompactConfig {
+            microcompact_enabled: true,
             micro_keep_recent: 3,
             ..Default::default()
         };
@@ -1236,6 +1267,7 @@ mod tests_compact {
             context_window: 200_000,
             emergency_buffer: 3_000,
             max_failures: 3,
+            microcompact_enabled: true,
             micro_keep_recent: 1,
             ..Default::default()
         };
@@ -1320,6 +1352,7 @@ mod tests_compact {
 
         let config = CompactConfig {
             enabled: false,
+            microcompact_enabled: true,
             micro_keep_recent: 3,
             ..Default::default()
         };

--- a/crates/aion-agent/src/orchestration.rs
+++ b/crates/aion-agent/src/orchestration.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use crate::confirm::{ConfirmResult, ToolConfirmer};
+use aion_config::compact::CompactConfig;
 use aion_config::hooks::HookEngine;
 use aion_protocol::events::{OutputType, ProtocolEvent, ToolCategory, ToolInfo, ToolStatus};
 use aion_protocol::writer::ProtocolEmitter;
@@ -9,7 +10,7 @@ use aion_types::message::ContentBlock;
 use aion_types::skill_types::ContextModifier;
 use aion_types::tool::ToolResult;
 
-use aion_tools::registry::ToolRegistry;
+use aion_tools::{registry::ToolRegistry, truncate_utf8};
 
 /// The combined output of a tool execution batch: protocol content blocks
 /// paired with per-call context modifiers (None for non-skill tools).
@@ -37,9 +38,31 @@ pub async fn execute_tool_calls(
     registry: &ToolRegistry,
     tool_calls: &[ContentBlock],
     confirmer: &Arc<Mutex<ToolConfirmer>>,
+    hooks: Option<&mut HookEngine>,
+    compaction_level: aion_compact::CompactLevel,
+    toon_enabled: bool,
+) -> Result<ToolCallOutcome, ExecutionControl> {
+    execute_tool_calls_with_output_limit(
+        registry,
+        tool_calls,
+        confirmer,
+        hooks,
+        compaction_level,
+        toon_enabled,
+        CompactConfig::default().tool_output_max_bytes,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn execute_tool_calls_with_output_limit(
+    registry: &ToolRegistry,
+    tool_calls: &[ContentBlock],
+    confirmer: &Arc<Mutex<ToolConfirmer>>,
     mut hooks: Option<&mut HookEngine>,
     compaction_level: aion_compact::CompactLevel,
     toon_enabled: bool,
+    tool_output_max_bytes: usize,
 ) -> Result<ToolCallOutcome, ExecutionControl> {
     let mut results = Vec::new();
     let mut modifiers = Vec::new();
@@ -64,7 +87,16 @@ pub async fn execute_tool_calls(
             let hooks_shared: Option<&HookEngine> = hooks.as_deref();
             let futures: Vec<_> = approved
                 .iter()
-                .map(|call| execute_single(registry, call, hooks_shared, compaction_level, toon_enabled))
+                .map(|call| {
+                    execute_single(
+                        registry,
+                        call,
+                        hooks_shared,
+                        compaction_level,
+                        toon_enabled,
+                        tool_output_max_bytes,
+                    )
+                })
                 .collect();
             let batch_results = futures::future::join_all(futures).await;
             for (block, modifier, blocks) in batch_results {
@@ -86,8 +118,15 @@ pub async fn execute_tool_calls(
                         let blocks;
                         {
                             let hooks_shared: Option<&HookEngine> = hooks.as_deref();
-                            (block, modifier, blocks) =
-                                execute_single(registry, call, hooks_shared, compaction_level, toon_enabled).await;
+                            (block, modifier, blocks) = execute_single(
+                                registry,
+                                call,
+                                hooks_shared,
+                                compaction_level,
+                                toon_enabled,
+                                tool_output_max_bytes,
+                            )
+                            .await;
                         }
                         // Merge skill hooks after a successful sequential execution.
                         if !block_is_error(&block) {
@@ -101,6 +140,8 @@ pub async fn execute_tool_calls(
             }
         }
     }
+
+    truncate_tool_result_blocks(&mut results, tool_output_max_bytes);
 
     Ok(ToolCallOutcome {
         results,
@@ -147,6 +188,7 @@ async fn execute_single(
     hooks: Option<&HookEngine>,
     compaction_level: aion_compact::CompactLevel,
     toon_enabled: bool,
+    tool_output_max_bytes: usize,
 ) -> (ContentBlock, Option<ContextModifier>, Vec<ContentBlock>) {
     let ContentBlock::ToolUse { id, name, input, .. } = call else {
         unreachable!("execute_single called with non-ToolUse block")
@@ -190,13 +232,25 @@ async fn execute_single(
             } else {
                 r.content.clone()
             };
-            let content = truncate_result(&error_content, max_size);
-            let content = aion_compact::compact_output(&content, compaction_level);
+            let content = aion_compact::compact_output(&error_content, compaction_level);
             let content = if toon_enabled {
                 aion_compact::compact_output_toon(&content)
             } else {
                 content
             };
+            let original_bytes = content.len();
+            let output_limit = max_size.min(tool_output_max_bytes);
+            let content = truncate_result(&content, output_limit);
+            if content.len() < original_bytes {
+                tracing::debug!(
+                    target: "aion_agent",
+                    tool = %name,
+                    original_bytes,
+                    output_bytes = content.len(),
+                    output_limit,
+                    "tool result truncated for model context"
+                );
+            }
             (
                 ToolResult {
                     content,
@@ -248,9 +302,39 @@ pub async fn execute_tool_calls_with_approval(
     msg_id: &str,
     auto_approve: bool,
     allow_list: &[String],
+    hooks: Option<&mut HookEngine>,
+    compaction_level: aion_compact::CompactLevel,
+    toon_enabled: bool,
+) -> Result<ToolCallOutcome, ExecutionControl> {
+    execute_tool_calls_with_approval_and_output_limit(
+        registry,
+        tool_calls,
+        approval_manager,
+        writer,
+        msg_id,
+        auto_approve,
+        allow_list,
+        hooks,
+        compaction_level,
+        toon_enabled,
+        CompactConfig::default().tool_output_max_bytes,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn execute_tool_calls_with_approval_and_output_limit(
+    registry: &ToolRegistry,
+    tool_calls: &[ContentBlock],
+    approval_manager: &Arc<ToolApprovalManager>,
+    writer: &Arc<dyn ProtocolEmitter>,
+    msg_id: &str,
+    auto_approve: bool,
+    allow_list: &[String],
     mut hooks: Option<&mut HookEngine>,
     compaction_level: aion_compact::CompactLevel,
     toon_enabled: bool,
+    tool_output_max_bytes: usize,
 ) -> Result<ToolCallOutcome, ExecutionControl> {
     let mut results = Vec::new();
     let mut modifiers = Vec::new();
@@ -320,8 +404,15 @@ pub async fn execute_tool_calls_with_approval(
         let blocks;
         {
             let hooks_shared: Option<&HookEngine> = hooks.as_deref();
-            (result, modifier, blocks) =
-                execute_single(registry, call, hooks_shared, compaction_level, toon_enabled).await;
+            (result, modifier, blocks) = execute_single(
+                registry,
+                call,
+                hooks_shared,
+                compaction_level,
+                toon_enabled,
+                tool_output_max_bytes,
+            )
+            .await;
         }
 
         // Emit tool_result event
@@ -351,6 +442,8 @@ pub async fn execute_tool_calls_with_approval(
         modifiers.push(modifier);
         follow_up_blocks.extend(blocks);
     }
+
+    truncate_tool_result_blocks(&mut results, tool_output_max_bytes);
 
     Ok(ToolCallOutcome {
         results,
@@ -413,26 +506,43 @@ fn maybe_append_deferred_hint(original_error: &str, schema: serde_json::Value, i
     )
 }
 
-fn truncate_result(content: &str, max_chars: usize) -> String {
-    if content.len() <= max_chars {
+fn truncate_tool_result_blocks(results: &mut [ContentBlock], max_bytes: usize) {
+    for result in results {
+        if let ContentBlock::ToolResult { content, .. } = result
+            && content.len() > max_bytes
+        {
+            *content = truncate_result(content, max_bytes);
+        }
+    }
+}
+
+fn truncate_result(content: &str, max_bytes: usize) -> String {
+    if content.len() <= max_bytes {
         return content.to_string();
     }
-    let half = max_chars / 2;
-    // Find char boundaries to avoid panicking on multi-byte characters
-    let head_end = content
-        .char_indices()
-        .nth(half)
-        .map(|(i, _)| i)
-        .unwrap_or(content.len());
-    let tail_start = content.char_indices().rev().nth(half - 1).map(|(i, _)| i).unwrap_or(0);
+
+    let marker = format!("\n\n... [truncated output: original {} bytes] ...\n\n", content.len());
+    if marker.len() >= max_bytes {
+        return truncate_utf8(&marker, max_bytes).to_string();
+    }
+
+    let content_budget = max_bytes - marker.len();
+    let head_budget = content_budget.div_ceil(2);
+    let tail_budget = content_budget / 2;
+
+    let mut head_end = head_budget;
+    while head_end > 0 && !content.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+
+    let mut tail_start = content.len() - tail_budget;
+    while tail_start < content.len() && !content.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+
     let head = &content[..head_end];
     let tail = &content[tail_start..];
-    format!(
-        "{}\n\n... [truncated {} chars] ...\n\n{}",
-        head,
-        content.len() - max_chars,
-        tail
-    )
+    format!("{head}{marker}{tail}")
 }
 
 fn truncate_display(s: &str, max: usize) -> String {

--- a/crates/aion-agent/src/orchestration_test.rs
+++ b/crates/aion-agent/src/orchestration_test.rs
@@ -47,6 +47,8 @@ mod tests {
         let cjk: String = "这是一段较长的中文内容用于测试截断功能".repeat(50);
         let result = truncate_result(&cjk, 100);
         assert!(result.contains("truncated"));
+        assert!(result.len() <= 100);
+        assert!(result.is_char_boundary(result.len()));
     }
 
     #[test]
@@ -54,6 +56,23 @@ mod tests {
         let mixed = "Hello你好World世界Test测试".repeat(100);
         let result = truncate_result(&mixed, 200);
         assert!(result.contains("truncated"));
+        assert!(result.len() <= 200);
+    }
+
+    #[test]
+    fn truncate_result_preserves_head_and_tail_with_strict_byte_limit() {
+        let content = format!("HEAD{}TAIL", "middle".repeat(100));
+        let result = truncate_result(&content, 100);
+
+        assert!(result.starts_with("HEAD"));
+        assert!(result.ends_with("TAIL"));
+        assert!(result.len() <= 100);
+        assert!(result.contains(&format!("original {} bytes", content.len())));
+    }
+
+    #[test]
+    fn truncate_result_zero_budget_returns_empty_output() {
+        assert_eq!(truncate_result("content", 0), "");
     }
 
     // -- maybe_append_deferred_hint -------------------------------------------
@@ -225,7 +244,7 @@ mod tests {
             extra: None,
         };
         let (result, _, follow_up_blocks) =
-            execute_single(&registry, &call, None, aion_compact::CompactLevel::Off, false).await;
+            execute_single(&registry, &call, None, aion_compact::CompactLevel::Off, false, 10_000).await;
         assert!(follow_up_blocks.is_empty());
         if let ContentBlock::ToolResult { content, is_error, .. } = &result {
             assert!(is_error);
@@ -247,7 +266,7 @@ mod tests {
             extra: None,
         };
         let (result, _, follow_up_blocks) =
-            execute_single(&registry, &call, None, aion_compact::CompactLevel::Off, false).await;
+            execute_single(&registry, &call, None, aion_compact::CompactLevel::Off, false, 10_000).await;
         assert!(follow_up_blocks.is_empty());
         if let ContentBlock::ToolResult { content, is_error, .. } = &result {
             // Tool succeeds because input.get("tasks") is Some
@@ -268,7 +287,7 @@ mod tests {
             extra: None,
         };
         let (result, _, follow_up_blocks) =
-            execute_single(&registry, &call, None, aion_compact::CompactLevel::Off, false).await;
+            execute_single(&registry, &call, None, aion_compact::CompactLevel::Off, false, 10_000).await;
         assert!(follow_up_blocks.is_empty());
         if let ContentBlock::ToolResult { content, is_error, .. } = &result {
             assert!(!is_error);
@@ -288,7 +307,7 @@ mod tests {
             extra: None,
         };
         let (result, _, follow_up_blocks) =
-            execute_single(&registry, &call, None, aion_compact::CompactLevel::Off, false).await;
+            execute_single(&registry, &call, None, aion_compact::CompactLevel::Off, false, 10_000).await;
         assert!(follow_up_blocks.is_empty());
         if let ContentBlock::ToolResult { content, is_error, .. } = &result {
             assert!(is_error);

--- a/crates/aion-agent/tests/engine_compact_test.rs
+++ b/crates/aion-agent/tests/engine_compact_test.rs
@@ -508,6 +508,7 @@ async fn tc_2_6_02_micro_before_auto_execution_order() {
 
     let mut config = test_config();
     config.compact = CompactConfig {
+        microcompact_enabled: true,
         micro_keep_recent: 3,
         compactable_tools: vec!["mock_tool".into()],
         context_window: 200_000,
@@ -656,6 +657,7 @@ async fn tc_2_6_e2e_02_micro_and_auto_cooperative() {
 
     let mut config = test_config();
     config.compact = CompactConfig {
+        microcompact_enabled: true,
         micro_keep_recent: 3,
         compactable_tools: vec!["mock_tool".into()],
         context_window: 200_000,

--- a/crates/aion-agent/tests/orchestration_test.rs
+++ b/crates/aion-agent/tests/orchestration_test.rs
@@ -262,11 +262,10 @@ async fn test_post_hook_runs_after_tool() {
     }
 }
 
-/// Results that exceed max_result_size are truncated with a "[truncated N chars]" marker
+/// Results that exceed the default model-facing byte limit preserve their head and tail.
 #[tokio::test]
 async fn test_tool_result_truncation() {
-    // Default max_result_size is 50_000; build a result that exceeds it
-    let long_result: String = "x".repeat(60_000);
+    let long_result = format!("HEAD{}TAIL", "x".repeat(60_000));
 
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(MockTool::new("big_tool", &long_result, false)));
@@ -283,15 +282,46 @@ async fn test_tool_result_truncation() {
         ContentBlock::ToolResult { content, is_error, .. } => {
             assert!(!is_error);
             assert!(
-                content.len() < long_result.len(),
-                "truncated result should be shorter than the original"
+                content.len() <= 10_000,
+                "truncated result must respect the configured byte limit"
             );
             assert!(
                 content.contains("truncated"),
                 "truncated result should contain the word 'truncated', got length {}",
                 content.len()
             );
+            assert!(content.starts_with("HEAD"));
+            assert!(content.ends_with("TAIL"));
         }
         other => panic!("expected ToolResult, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_tool_error_truncation_uses_the_same_limit() {
+    let long_error = format!("ERROR_HEAD{}ERROR_TAIL", "failure".repeat(10_000));
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(MockTool::new("failing_tool", &long_error, true)));
+
+    let tool_calls = vec![make_tool_use("id-error", "failing_tool")];
+    let results = execute_tool_calls(
+        &registry,
+        &tool_calls,
+        &auto_approve_confirmer(),
+        None,
+        CompactLevel::Off,
+        false,
+    )
+    .await
+    .expect("execution should succeed");
+
+    match &results[0] {
+        ContentBlock::ToolResult { content, is_error, .. } => {
+            assert!(is_error);
+            assert!(content.len() <= 10_000);
+            assert!(content.starts_with("ERROR_HEAD"));
+            assert!(content.ends_with("ERROR_TAIL"));
+        }
+        other => panic!("expected ToolResult, got {other:?}"),
     }
 }

--- a/crates/aion-config/src/compact.rs
+++ b/crates/aion-config/src/compact.rs
@@ -29,11 +29,25 @@ pub struct CompactConfig {
     #[serde(default = "default_max_failures")]
     pub max_failures: u32,
 
-    /// Microcompact: keep the N most recent compactable tool results.
+    /// Maximum UTF-8 byte length of one model-facing tool result.
+    ///
+    /// Oversized results are truncated once, preserving their beginning and
+    /// end. This keeps stored history stable for prompt caching.
+    #[serde(default = "default_tool_output_max_bytes")]
+    pub tool_output_max_bytes: usize,
+
+    /// Whether to enable the legacy history-rewriting microcompact pass.
+    ///
+    /// Disabled by default because rewriting old tool results invalidates the
+    /// stable prompt prefix. Prefer the per-result output limit instead.
+    #[serde(default)]
+    pub microcompact_enabled: bool,
+
+    /// Legacy microcompact: keep the N most recent compactable tool results.
     #[serde(default = "default_micro_keep_recent")]
     pub micro_keep_recent: usize,
 
-    /// Microcompact: gap threshold in seconds for time-based trigger.
+    /// Legacy microcompact: gap threshold in seconds for time-based trigger.
     /// When the last assistant message is older than this, microcompact fires.
     #[serde(default = "default_micro_gap_seconds")]
     pub micro_gap_seconds: u64,
@@ -49,7 +63,7 @@ pub struct CompactConfig {
     pub autocompact_threshold_pct: Option<u8>,
 
     /// Whether the compaction system is enabled.
-    /// When false, microcompact and autocompact are skipped
+    /// When false, legacy microcompact and autocompact are skipped
     /// (emergency truncation still applies).
     #[serde(default = "default_true")]
     pub enabled: bool,
@@ -75,6 +89,8 @@ impl Default for CompactConfig {
             autocompact_buffer: default_autocompact_buffer(),
             emergency_buffer: default_emergency_buffer(),
             max_failures: default_max_failures(),
+            tool_output_max_bytes: default_tool_output_max_bytes(),
+            microcompact_enabled: false,
             micro_keep_recent: default_micro_keep_recent(),
             micro_gap_seconds: default_micro_gap_seconds(),
             compactable_tools: default_compactable_tools(),
@@ -103,6 +119,9 @@ fn default_emergency_buffer() -> usize {
 }
 fn default_max_failures() -> u32 {
     3
+}
+fn default_tool_output_max_bytes() -> usize {
+    10_000
 }
 fn default_micro_keep_recent() -> usize {
     5

--- a/crates/aion-config/src/compact_test.rs
+++ b/crates/aion-config/src/compact_test.rs
@@ -12,6 +12,8 @@ mod tests {
         assert_eq!(cfg.autocompact_buffer, 13_000);
         assert_eq!(cfg.emergency_buffer, 3_000);
         assert_eq!(cfg.max_failures, 3);
+        assert_eq!(cfg.tool_output_max_bytes, 10_000);
+        assert!(!cfg.microcompact_enabled);
         assert_eq!(cfg.micro_keep_recent, 5);
         assert_eq!(cfg.micro_gap_seconds, 3600);
         assert!(cfg.enabled);
@@ -30,6 +32,8 @@ output_reserve = 10000
 autocompact_buffer = 8000
 emergency_buffer = 2000
 max_failures = 5
+tool_output_max_bytes = 16000
+microcompact_enabled = true
 micro_keep_recent = 3
 micro_gap_seconds = 1800
 compactable_tools = ["Read", "ExecCommand"]
@@ -41,6 +45,8 @@ enabled = false
         assert_eq!(cfg.autocompact_buffer, 8_000);
         assert_eq!(cfg.emergency_buffer, 2_000);
         assert_eq!(cfg.max_failures, 5);
+        assert_eq!(cfg.tool_output_max_bytes, 16_000);
+        assert!(cfg.microcompact_enabled);
         assert_eq!(cfg.micro_keep_recent, 3);
         assert_eq!(cfg.micro_gap_seconds, 1800);
         assert_eq!(cfg.compactable_tools, vec!["Read", "ExecCommand"]);
@@ -59,6 +65,8 @@ context_window = 128000
         assert_eq!(cfg.autocompact_buffer, 13_000);
         assert_eq!(cfg.emergency_buffer, 3_000);
         assert_eq!(cfg.max_failures, 3);
+        assert_eq!(cfg.tool_output_max_bytes, 10_000);
+        assert!(!cfg.microcompact_enabled);
         assert_eq!(cfg.micro_keep_recent, 5);
         assert_eq!(cfg.micro_gap_seconds, 3600);
         assert!(cfg.enabled);
@@ -73,6 +81,8 @@ context_window = 128000
         assert_eq!(cfg.autocompact_buffer, default.autocompact_buffer);
         assert_eq!(cfg.emergency_buffer, default.emergency_buffer);
         assert_eq!(cfg.max_failures, default.max_failures);
+        assert_eq!(cfg.tool_output_max_bytes, default.tool_output_max_bytes);
+        assert_eq!(cfg.microcompact_enabled, default.microcompact_enabled);
         assert_eq!(cfg.micro_keep_recent, default.micro_keep_recent);
         assert_eq!(cfg.micro_gap_seconds, default.micro_gap_seconds);
         assert_eq!(cfg.enabled, default.enabled);

--- a/crates/aion-config/src/config.rs
+++ b/crates/aion-config/src/config.rs
@@ -1010,9 +1010,8 @@ allow_list = ["Read", "Grep", "Glob"]
 # autocompact_buffer = 13000     # buffer below effective window for autocompact trigger
 # emergency_buffer = 3000        # tokens from limit for emergency block
 # max_failures = 3               # consecutive failures before circuit-breaker trips
-# micro_keep_recent = 5          # keep N most recent tool results
-# micro_gap_seconds = 3600       # gap threshold for time-based microcompact
-# compactable_tools = ["Read", "ExecCommand", "Grep", "Glob", "Write", "Edit"]
+# tool_output_max_bytes = 10000  # maximum model-facing UTF-8 bytes per tool result
+# microcompact_enabled = false   # legacy history rewriting; disabled by default
 # enabled = true
 
 # File state cache (dedup repeated reads, staleness detection)

--- a/crates/aion-config/tests/compact_config_test.rs
+++ b/crates/aion-config/tests/compact_config_test.rs
@@ -16,6 +16,8 @@ fn tc_2_2_01_compact_config_defaults() {
     assert_eq!(cfg.autocompact_buffer, 13_000);
     assert_eq!(cfg.emergency_buffer, 3_000);
     assert_eq!(cfg.max_failures, 3);
+    assert_eq!(cfg.tool_output_max_bytes, 10_000);
+    assert!(!cfg.microcompact_enabled);
     assert_eq!(cfg.micro_keep_recent, 5);
     assert_eq!(cfg.micro_gap_seconds, 3600);
     assert!(cfg.enabled);
@@ -31,6 +33,8 @@ output_reserve = 15000
 autocompact_buffer = 10000
 emergency_buffer = 2000
 max_failures = 5
+tool_output_max_bytes = 16000
+microcompact_enabled = true
 micro_keep_recent = 3
 micro_gap_seconds = 1800
 compactable_tools = ["Read", "ExecCommand"]
@@ -42,6 +46,8 @@ enabled = false
     assert_eq!(config.compact.autocompact_buffer, 10_000);
     assert_eq!(config.compact.emergency_buffer, 2_000);
     assert_eq!(config.compact.max_failures, 5);
+    assert_eq!(config.compact.tool_output_max_bytes, 16_000);
+    assert!(config.compact.microcompact_enabled);
     assert_eq!(config.compact.micro_keep_recent, 3);
     assert_eq!(config.compact.micro_gap_seconds, 1800);
     assert_eq!(config.compact.compactable_tools, vec!["Read", "ExecCommand"]);
@@ -62,6 +68,8 @@ context_window = 128000
     assert_eq!(config.compact.autocompact_buffer, 13_000);
     assert_eq!(config.compact.emergency_buffer, 3_000);
     assert_eq!(config.compact.max_failures, 3);
+    assert_eq!(config.compact.tool_output_max_bytes, 10_000);
+    assert!(!config.compact.microcompact_enabled);
     assert_eq!(config.compact.micro_keep_recent, 5);
     assert_eq!(config.compact.micro_gap_seconds, 3600);
     assert!(config.compact.enabled);

--- a/crates/aion-tools/src/tool.rs
+++ b/crates/aion-tools/src/tool.rs
@@ -87,7 +87,9 @@ pub trait Tool: Send + Sync {
         None
     }
 
-    /// Max result size in chars before truncation
+    /// Per-tool maximum result size in UTF-8 bytes before truncation.
+    ///
+    /// The agent-level output limit may impose a smaller bound.
     fn max_result_size(&self) -> usize {
         50_000
     }

--- a/crates/aion-tui/Cargo.toml
+++ b/crates/aion-tui/Cargo.toml
@@ -13,7 +13,6 @@ aion-types.workspace    = true
 
 anyhow.workspace        = true
 crossterm.workspace     = true
-futures.workspace       = true
 pulldown-cmark.workspace = true
 ratatui.workspace       = true
 serde_json.workspace    = true

--- a/crates/aion-tui/src/app.rs
+++ b/crates/aion-tui/src/app.rs
@@ -10,16 +10,19 @@ use aion_protocol::commands::{ApprovalScope, SessionMode};
 use aion_protocol::writer::ProtocolEmitter;
 use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
 use aion_types::message::Message;
-use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use futures::StreamExt;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::time;
 
 use crate::app_command::ApplicationCommand;
 use crate::event::{AgentEvent, TuiProtocolEmitter, TuiSink};
 use crate::session_picker::TuiSession;
-use crate::state::AppState;
-use crate::terminal::{AppTerminal, TerminalSession, clear_synchronized, draw_synchronized, insert_history_lines};
+use crate::state::{AppState, ApprovalChoice};
+use crate::terminal::{
+    AppTerminal, TerminalSession, clear_synchronized, draw_synchronized, insert_history_lines,
+    reset_inline_synchronized,
+};
+use crate::terminal_event_reader::TerminalEventReader;
 use crate::ui;
 
 static MESSAGE_SEQUENCE: AtomicU64 = AtomicU64::new(1);
@@ -151,7 +154,7 @@ impl TuiRuntime {
             self.commit_pending_history(terminal_session.terminal())?;
             self.history_replay_pending = false;
         }
-        let mut terminal_events = EventStream::new();
+        let mut terminal_events = TerminalEventReader::new();
         let mut ticker = time::interval(Duration::from_millis(120));
         ticker.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
@@ -196,7 +199,11 @@ impl TuiRuntime {
                             }
                         }
                         Event::Resize(_, _) => {
-                            clear_synchronized(terminal_session.terminal())?;
+                            if self.state.session_picker.is_visible() {
+                                clear_synchronized(terminal_session.terminal())?;
+                            } else {
+                                self.reflow_history(terminal_session.terminal())?;
+                            }
                         }
                         _ => {}
                     }
@@ -329,7 +336,7 @@ impl TuiRuntime {
         engine: &mut AgentEngine,
         input: String,
         terminal: &mut AppTerminal,
-        terminal_events: &mut EventStream,
+        terminal_events: &mut TerminalEventReader,
         ticker: &mut time::Interval,
     ) -> anyhow::Result<bool> {
         if self.session_initialization_pending && starts_conversation(&input) {
@@ -375,7 +382,7 @@ impl TuiRuntime {
                                 cancelled = true;
                                 break None;
                             }
-                            Event::Resize(_, _) => clear_synchronized(terminal)?,
+                            Event::Resize(_, _) => self.reflow_history(terminal)?,
                             _ => {}
                         }
                     }
@@ -491,32 +498,58 @@ impl TuiRuntime {
 
     /// Returns true when the active turn should be cancelled.
     fn handle_running_key(&mut self, key: KeyEvent) -> bool {
-        if let Some(request) = &self.state.approval {
-            let call_id = request.call_id.clone();
-            match key.code {
-                KeyCode::Char('y') | KeyCode::Enter => {
-                    self.approval_manager.approve(&call_id, ApprovalScope::Once);
-                    self.state.approval = None;
+        if self.state.approval.is_some() {
+            if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+                self.deny_pending_approval("Turn cancelled by user");
+                return true;
+            }
+
+            let shortcut = match key.code {
+                KeyCode::Char(character) => Some(character.to_ascii_lowercase()),
+                _ => None,
+            };
+            let choice = match (key.code, shortcut) {
+                (KeyCode::Left | KeyCode::Up | KeyCode::BackTab, _) => {
+                    if let Some(request) = self.state.approval.as_mut() {
+                        request.choice = request.choice.previous();
+                    }
+                    None
                 }
-                KeyCode::Char('a') => {
-                    self.approval_manager.approve(&call_id, ApprovalScope::Always);
-                    self.state.approval = None;
+                (KeyCode::Right | KeyCode::Down | KeyCode::Tab, _) => {
+                    if let Some(request) = self.state.approval.as_mut() {
+                        request.choice = request.choice.next();
+                    }
+                    None
                 }
-                KeyCode::Char('n') | KeyCode::Esc => {
-                    self.approval_manager.resolve(
-                        &call_id,
-                        ToolApprovalResult::Denied {
-                            reason: "Denied by user".to_string(),
-                        },
-                    );
-                    self.state.approval = None;
-                }
-                _ => {}
+                (KeyCode::Enter, _) => self.state.approval.as_ref().map(|request| request.choice),
+                (_, Some('y')) => Some(ApprovalChoice::Once),
+                (_, Some('a')) => Some(ApprovalChoice::Always),
+                (_, Some('n')) | (KeyCode::Esc, _) => Some(ApprovalChoice::Deny),
+                _ => None,
+            };
+            if let Some(choice) = choice {
+                self.resolve_pending_approval(choice);
             }
             return false;
         }
 
         key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c')
+    }
+
+    fn resolve_pending_approval(&mut self, choice: ApprovalChoice) {
+        let Some(request) = self.state.approval.take() else {
+            return;
+        };
+        match choice {
+            ApprovalChoice::Once => self.approval_manager.approve(&request.call_id, ApprovalScope::Once),
+            ApprovalChoice::Always => self.approval_manager.approve(&request.call_id, ApprovalScope::Always),
+            ApprovalChoice::Deny => self.approval_manager.resolve(
+                &request.call_id,
+                ToolApprovalResult::Denied {
+                    reason: "Denied by user".to_string(),
+                },
+            ),
+        }
     }
 
     fn deny_pending_approval(&mut self, reason: &str) {
@@ -544,6 +577,23 @@ impl TuiRuntime {
 
     fn draw(&self, terminal: &mut AppTerminal) -> anyhow::Result<()> {
         draw_synchronized(terminal, |frame| ui::render(frame, &self.state))
+    }
+
+    fn reflow_history(&mut self, terminal: &mut AppTerminal) -> anyhow::Result<()> {
+        let replayable_count = self.state.prepare_history_replay();
+        reset_inline_synchronized(terminal)?;
+        let width = terminal.size()?.width.saturating_sub(2).max(1);
+        let lines = if self.state.transcript.is_empty() && self.state.show_welcome {
+            self.state.show_welcome = false;
+            ui::welcome_history_lines(&self.state, width)
+        } else {
+            ui::history_prefix_lines(&self.state, replayable_count, width)
+        };
+        if !lines.is_empty() {
+            insert_history_lines(terminal, lines)?;
+        }
+        self.state.mark_transcript_prefix_committed(replayable_count);
+        clear_synchronized(terminal)
     }
 
     fn commit_pending_history(&mut self, terminal: &mut AppTerminal) -> anyhow::Result<()> {

--- a/crates/aion-tui/src/app.rs
+++ b/crates/aion-tui/src/app.rs
@@ -200,9 +200,9 @@ impl TuiRuntime {
                         }
                         Event::Resize(_, _) => {
                             if self.state.session_picker.is_visible() {
-                                clear_synchronized(terminal_session.terminal())?;
+                                resize_terminal(terminal_session.terminal(), &mut terminal_events)?;
                             } else {
-                                self.reflow_history(terminal_session.terminal())?;
+                                self.reflow_history(terminal_session.terminal(), &mut terminal_events)?;
                             }
                         }
                         _ => {}
@@ -382,7 +382,7 @@ impl TuiRuntime {
                                 cancelled = true;
                                 break None;
                             }
-                            Event::Resize(_, _) => self.reflow_history(terminal)?,
+                            Event::Resize(_, _) => self.reflow_history(terminal, terminal_events)?,
                             _ => {}
                         }
                     }
@@ -579,21 +579,27 @@ impl TuiRuntime {
         draw_synchronized(terminal, |frame| ui::render(frame, &self.state))
     }
 
-    fn reflow_history(&mut self, terminal: &mut AppTerminal) -> anyhow::Result<()> {
-        let replayable_count = self.state.prepare_history_replay();
-        reset_inline_synchronized(terminal)?;
-        let width = terminal.size()?.width.saturating_sub(2).max(1);
-        let lines = if self.state.transcript.is_empty() && self.state.show_welcome {
-            self.state.show_welcome = false;
-            ui::welcome_history_lines(&self.state, width)
-        } else {
-            ui::history_prefix_lines(&self.state, replayable_count, width)
-        };
-        if !lines.is_empty() {
-            insert_history_lines(terminal, lines)?;
-        }
-        self.state.mark_transcript_prefix_committed(replayable_count);
-        clear_synchronized(terminal)
+    fn reflow_history(
+        &mut self,
+        terminal: &mut AppTerminal,
+        terminal_events: &mut TerminalEventReader,
+    ) -> anyhow::Result<()> {
+        with_terminal_events_paused(terminal_events, || {
+            let replayable_count = self.state.prepare_history_replay();
+            reset_inline_synchronized(terminal)?;
+            let width = terminal.size()?.width.saturating_sub(2).max(1);
+            let lines = if self.state.transcript.is_empty() && self.state.show_welcome {
+                self.state.show_welcome = false;
+                ui::welcome_history_lines(&self.state, width)
+            } else {
+                ui::history_prefix_lines(&self.state, replayable_count, width)
+            };
+            if !lines.is_empty() {
+                insert_history_lines(terminal, lines)?;
+            }
+            self.state.mark_transcript_prefix_committed(replayable_count);
+            clear_synchronized(terminal)
+        })
     }
 
     fn commit_pending_history(&mut self, terminal: &mut AppTerminal) -> anyhow::Result<()> {
@@ -627,6 +633,20 @@ impl TuiRuntime {
             .commit_streaming_prefix(commit.complete_entries, commit.active_byte_count);
         Ok(())
     }
+}
+
+fn resize_terminal(terminal: &mut AppTerminal, terminal_events: &mut TerminalEventReader) -> anyhow::Result<()> {
+    with_terminal_events_paused(terminal_events, || clear_synchronized(terminal))
+}
+
+fn with_terminal_events_paused<T>(
+    terminal_events: &mut TerminalEventReader,
+    operation: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    terminal_events.stop();
+    let result = operation();
+    terminal_events.restart();
+    result
 }
 
 fn application_help(commands: &[CommandSpec]) -> String {

--- a/crates/aion-tui/src/app_test.rs
+++ b/crates/aion-tui/src/app_test.rs
@@ -1,5 +1,8 @@
+use aion_protocol::ToolApprovalResult;
 use aion_protocol::commands::SessionMode;
-use crossterm::event::{KeyCode, KeyEvent};
+use aion_protocol::events::ToolCategory;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tokio::sync::oneshot;
 
 use super::{IdleAction, TuiMetadata, TuiOutcome, TuiRuntime, application_help, permission_mode, starts_conversation};
 use crate::event::AgentEvent;
@@ -31,6 +34,17 @@ fn session(id: &str) -> TuiSession {
         "2026-08-13 12:00 UTC".to_string(),
         2,
     )
+}
+
+fn request_approval(runtime: &mut TuiRuntime) -> oneshot::Receiver<ToolApprovalResult> {
+    let receiver = runtime.approval_manager.request_approval("call-1", &ToolCategory::Exec);
+    runtime.state.handle_agent_event(AgentEvent::ApprovalRequested {
+        call_id: "call-1".to_string(),
+        name: "shell".to_string(),
+        description: "Run a command".to_string(),
+        input: "cargo test".to_string(),
+    });
+    receiver
 }
 
 #[test]
@@ -111,4 +125,47 @@ fn help_contains_input_and_navigation_guidance() {
     assert!(output.contains("Shift+Enter   Insert newline"));
     assert!(output.contains("Mouse wheel   Scroll conversation"));
     assert!(output.contains("Drag          Select terminal text"));
+}
+
+#[test]
+fn approval_navigation_selects_always_and_confirms_with_enter() {
+    let mut runtime = runtime();
+    let mut receiver = request_approval(&mut runtime);
+
+    assert!(!runtime.handle_running_key(KeyEvent::from(KeyCode::Right)));
+    assert_eq!(
+        runtime.state.approval.as_ref().map(|request| request.choice),
+        Some(crate::state::ApprovalChoice::Always)
+    );
+    assert!(!runtime.handle_running_key(KeyEvent::from(KeyCode::Enter)));
+
+    assert!(matches!(receiver.try_recv(), Ok(ToolApprovalResult::Approved)));
+    assert!(runtime.state.approval.is_none());
+    assert!(runtime.approval_manager.is_auto_approved("exec"));
+}
+
+#[test]
+fn approval_shortcuts_accept_uppercase_characters() {
+    let mut runtime = runtime();
+    let mut receiver = request_approval(&mut runtime);
+
+    let key = KeyEvent::new(KeyCode::Char('Y'), KeyModifiers::SHIFT);
+    assert!(!runtime.handle_running_key(key));
+
+    assert!(matches!(receiver.try_recv(), Ok(ToolApprovalResult::Approved)));
+}
+
+#[test]
+fn control_c_during_approval_denies_the_request_and_cancels_the_turn() {
+    let mut runtime = runtime();
+    let mut receiver = request_approval(&mut runtime);
+
+    let key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+    assert!(runtime.handle_running_key(key));
+
+    assert!(matches!(
+        receiver.try_recv(),
+        Ok(ToolApprovalResult::Denied { reason }) if reason == "Turn cancelled by user"
+    ));
+    assert!(runtime.state.approval.is_none());
 }

--- a/crates/aion-tui/src/lib.rs
+++ b/crates/aion-tui/src/lib.rs
@@ -7,6 +7,7 @@ mod markdown;
 mod session_picker;
 mod state;
 mod terminal;
+mod terminal_event_reader;
 mod transcript;
 mod ui;
 

--- a/crates/aion-tui/src/markdown.rs
+++ b/crates/aion-tui/src/markdown.rs
@@ -1,4 +1,4 @@
-use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{Alignment as TableAlignment, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -16,6 +16,7 @@ pub(super) fn render_markdown(input: &str, width: u16, theme: MarkdownTheme) -> 
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TASKLISTS);
+    options.insert(Options::ENABLE_TABLES);
     let parser = Parser::new_ext(input, options);
     let mut renderer = MarkdownRenderer::new(width.max(1), theme);
     renderer.render(parser);
@@ -95,6 +96,65 @@ struct LogicalLine {
     fill: Option<Style>,
 }
 
+#[derive(Debug, Default)]
+struct TableCell {
+    spans: Vec<Span<'static>>,
+}
+
+#[derive(Debug)]
+struct TableRow {
+    cells: Vec<TableCell>,
+    header: bool,
+}
+
+#[derive(Debug)]
+struct TableState {
+    alignments: Vec<TableAlignment>,
+    rows: Vec<TableRow>,
+    current_row: Option<TableRow>,
+    current_cell: Option<TableCell>,
+}
+
+impl TableState {
+    fn new(alignments: Vec<TableAlignment>) -> Self {
+        Self {
+            alignments,
+            rows: Vec::new(),
+            current_row: None,
+            current_cell: None,
+        }
+    }
+
+    fn begin_row(&mut self, header: bool) {
+        self.finish_row();
+        self.current_row = Some(TableRow {
+            cells: Vec::new(),
+            header,
+        });
+    }
+
+    fn begin_cell(&mut self) {
+        self.finish_cell();
+        self.current_cell = Some(TableCell::default());
+    }
+
+    fn finish_cell(&mut self) {
+        let Some(cell) = self.current_cell.take() else {
+            return;
+        };
+        if let Some(row) = self.current_row.as_mut() {
+            row.cells.push(cell);
+        }
+    }
+
+    fn finish_row(&mut self) {
+        self.finish_cell();
+        if let Some(row) = self.current_row.take() {
+            self.rows.push(row);
+        }
+    }
+}
+
 #[derive(Debug)]
 struct MarkdownRenderer {
     width: u16,
@@ -105,6 +165,7 @@ struct MarkdownRenderer {
     lists: Vec<ListState>,
     quote_depth: usize,
     code_block: Option<CodeBlock>,
+    table: Option<TableState>,
     pending_separator: bool,
 }
 
@@ -119,6 +180,7 @@ impl MarkdownRenderer {
             lists: Vec::new(),
             quote_depth: 0,
             code_block: None,
+            table: None,
             pending_separator: false,
         }
     }
@@ -132,6 +194,11 @@ impl MarkdownRenderer {
                     Event::End(TagEnd::CodeBlock) => self.finish_code_block(),
                     _ => {}
                 }
+                continue;
+            }
+
+            if self.table.is_some() {
+                self.render_table_event(event);
                 continue;
             }
 
@@ -175,6 +242,10 @@ impl MarkdownRenderer {
             Tag::CodeBlock(_) => {
                 self.start_block();
                 self.code_block = Some(CodeBlock { content: String::new() });
+            }
+            Tag::Table(alignments) => {
+                self.start_block();
+                self.table = Some(TableState::new(alignments));
             }
             Tag::List(next) => {
                 if self.lists.is_empty() {
@@ -242,6 +313,200 @@ impl MarkdownRenderer {
                 self.pending_separator = true;
             }
             _ => {}
+        }
+    }
+
+    fn render_table_event(&mut self, event: Event<'_>) {
+        match event {
+            Event::Start(tag) => self.start_table_tag(tag),
+            Event::End(tag) => self.end_table_tag(tag),
+            Event::Text(text) | Event::Html(text) | Event::InlineHtml(text) => {
+                self.push_table_text(&text);
+            }
+            Event::Code(code) => {
+                let style = self.inline.style(self.theme.inline_code);
+                self.push_table_span(Span::styled(code.to_string(), style));
+            }
+            Event::SoftBreak | Event::HardBreak => self.push_table_text(" "),
+            Event::Rule => self.push_table_text("──"),
+            Event::TaskListMarker(checked) => {
+                self.push_table_text(if checked { "[x] " } else { "[ ] " });
+            }
+            Event::FootnoteReference(label) => self.push_table_text(&format!("[{label}]")),
+            Event::InlineMath(math) => self.push_table_text(&format!("${math}$")),
+            Event::DisplayMath(math) => self.push_table_text(&math),
+        }
+    }
+
+    fn start_table_tag(&mut self, tag: Tag<'_>) {
+        match tag {
+            Tag::TableHead => {
+                if let Some(table) = self.table.as_mut() {
+                    table.begin_row(true);
+                }
+            }
+            Tag::TableRow => {
+                if let Some(table) = self.table.as_mut() {
+                    table.begin_row(false);
+                }
+            }
+            Tag::TableCell => {
+                if let Some(table) = self.table.as_mut() {
+                    table.begin_cell();
+                }
+            }
+            Tag::Emphasis => self.inline.emphasis = self.inline.emphasis.saturating_add(1),
+            Tag::Strong => self.inline.strong = self.inline.strong.saturating_add(1),
+            Tag::Strikethrough => self.inline.strikethrough = self.inline.strikethrough.saturating_add(1),
+            Tag::Link { .. } => self.inline.link = self.inline.link.saturating_add(1),
+            Tag::Image { .. } => self.inline.emphasis = self.inline.emphasis.saturating_add(1),
+            _ => {}
+        }
+    }
+
+    fn end_table_tag(&mut self, tag: TagEnd) {
+        match tag {
+            TagEnd::Table => self.finish_table(),
+            TagEnd::TableHead | TagEnd::TableRow => {
+                if let Some(table) = self.table.as_mut() {
+                    table.finish_row();
+                }
+            }
+            TagEnd::TableCell => {
+                if let Some(table) = self.table.as_mut() {
+                    table.finish_cell();
+                }
+            }
+            TagEnd::Emphasis => self.inline.emphasis = self.inline.emphasis.saturating_sub(1),
+            TagEnd::Strong => self.inline.strong = self.inline.strong.saturating_sub(1),
+            TagEnd::Strikethrough => self.inline.strikethrough = self.inline.strikethrough.saturating_sub(1),
+            TagEnd::Link => self.inline.link = self.inline.link.saturating_sub(1),
+            TagEnd::Image => self.inline.emphasis = self.inline.emphasis.saturating_sub(1),
+            _ => {}
+        }
+    }
+
+    fn push_table_text(&mut self, text: &str) {
+        let normalized = text.replace('\n', " ");
+        let style = self.inline.style(self.theme.body);
+        self.push_table_span(Span::styled(normalized, style));
+    }
+
+    fn push_table_span(&mut self, span: Span<'static>) {
+        if let Some(cell) = self.table.as_mut().and_then(|table| table.current_cell.as_mut()) {
+            cell.spans.push(span);
+        }
+    }
+
+    fn finish_table(&mut self) {
+        let Some(mut table) = self.table.take() else {
+            return;
+        };
+        table.finish_row();
+        let column_count = table
+            .rows
+            .iter()
+            .map(|row| row.cells.len())
+            .max()
+            .unwrap_or(0)
+            .max(table.alignments.len());
+        if column_count == 0 {
+            return;
+        }
+
+        let border_width = column_count.saturating_mul(3).saturating_add(1);
+        let content_budget = usize::from(self.width).saturating_sub(border_width);
+        if content_budget < column_count.saturating_mul(3) {
+            self.render_stacked_table(&table, column_count);
+        } else {
+            self.render_bordered_table(&table, column_count, content_budget);
+        }
+        self.pending_separator = true;
+    }
+
+    fn render_bordered_table(&mut self, table: &TableState, column_count: usize, content_budget: usize) {
+        let mut natural_widths = vec![1; column_count];
+        for row in &table.rows {
+            for (index, cell) in row.cells.iter().enumerate() {
+                natural_widths[index] = natural_widths[index].max(spans_width(&cell.spans));
+            }
+        }
+        let mut widths = vec![1; column_count];
+        let mut remaining = content_budget.saturating_sub(column_count);
+        while remaining > 0 {
+            let mut grew = false;
+            for index in 0..column_count {
+                if remaining == 0 {
+                    break;
+                }
+                if widths[index] < natural_widths[index] {
+                    widths[index] += 1;
+                    remaining -= 1;
+                    grew = true;
+                }
+            }
+            if !grew {
+                break;
+            }
+        }
+
+        self.lines.push(table_border("┌", "┬", "┐", &widths, self.theme.marker));
+        for row in &table.rows {
+            self.lines.extend(table_row_lines(
+                row,
+                &table.alignments,
+                &widths,
+                self.theme.body,
+                self.theme.marker,
+            ));
+            if row.header {
+                self.lines.push(table_border("├", "┼", "┤", &widths, self.theme.marker));
+            }
+        }
+        self.lines.push(table_border("└", "┴", "┘", &widths, self.theme.marker));
+    }
+
+    fn render_stacked_table(&mut self, table: &TableState, column_count: usize) {
+        let header = table.rows.iter().find(|row| row.header);
+        let data_rows = table.rows.iter().filter(|row| !row.header).collect::<Vec<_>>();
+        if data_rows.is_empty() {
+            if let Some(header) = header {
+                for cell in &header.cells {
+                    self.push_logical(LogicalLine {
+                        prefix: Vec::new(),
+                        continuation_prefix: Vec::new(),
+                        spans: bold_spans(&cell.spans, self.theme.body),
+                        fill: None,
+                    });
+                }
+            }
+            return;
+        }
+
+        for (row_index, row) in data_rows.into_iter().enumerate() {
+            if row_index > 0 {
+                self.lines.push(Line::default());
+            }
+            for index in 0..column_count {
+                let label = header
+                    .and_then(|header| header.cells.get(index))
+                    .map(|cell| cell.spans.iter().map(|span| span.content.as_ref()).collect::<String>())
+                    .filter(|label| !label.trim().is_empty())
+                    .unwrap_or_else(|| format!("Column {}", index + 1));
+                let mut spans = vec![Span::styled(
+                    format!("{label}: "),
+                    self.theme.body.add_modifier(Modifier::BOLD),
+                )];
+                if let Some(cell) = row.cells.get(index) {
+                    spans.extend(cell.spans.clone());
+                }
+                self.push_logical(LogicalLine {
+                    prefix: Vec::new(),
+                    continuation_prefix: vec![Span::raw("  ")],
+                    spans,
+                    fill: None,
+                });
+            }
         }
     }
 
@@ -363,12 +628,94 @@ impl MarkdownRenderer {
         if self.code_block.is_some() {
             self.finish_code_block();
         }
+        if self.table.is_some() {
+            self.finish_table();
+        }
         self.flush_current();
         while self.lines.last().is_some_and(|line| line.spans.is_empty()) {
             self.lines.pop();
         }
         self.lines
     }
+}
+
+fn table_border(left: &str, separator: &str, right: &str, widths: &[usize], style: Style) -> Line<'static> {
+    let mut border = String::from(left);
+    for (index, width) in widths.iter().enumerate() {
+        border.push_str(&"─".repeat(width.saturating_add(2)));
+        border.push_str(if index + 1 == widths.len() { right } else { separator });
+    }
+    Line::from(Span::styled(border, style))
+}
+
+fn table_row_lines(
+    row: &TableRow,
+    alignments: &[TableAlignment],
+    widths: &[usize],
+    body_style: Style,
+    border_style: Style,
+) -> Vec<Line<'static>> {
+    let wrapped = widths
+        .iter()
+        .enumerate()
+        .map(|(index, width)| {
+            let spans = row.cells.get(index).map(|cell| cell.spans.clone()).unwrap_or_default();
+            let spans = if row.header {
+                bold_spans(&spans, body_style)
+            } else {
+                spans
+            };
+            wrap_line(
+                LogicalLine {
+                    prefix: Vec::new(),
+                    continuation_prefix: Vec::new(),
+                    spans,
+                    fill: None,
+                },
+                (*width).min(u16::MAX as usize) as u16,
+            )
+        })
+        .collect::<Vec<_>>();
+    let row_height = wrapped.iter().map(Vec::len).max().unwrap_or(1);
+    let mut output = Vec::with_capacity(row_height);
+    for line_index in 0..row_height {
+        let mut spans = vec![Span::styled("│", border_style)];
+        for (column, width) in widths.iter().enumerate() {
+            let content = wrapped
+                .get(column)
+                .and_then(|lines| lines.get(line_index))
+                .map(|line| line.spans.clone())
+                .unwrap_or_default();
+            let content_width = spans_width(&content).min(*width);
+            let free = width.saturating_sub(content_width);
+            let alignment = alignments.get(column).copied().unwrap_or(TableAlignment::None);
+            let (left_padding, right_padding) = match alignment {
+                TableAlignment::Center => (free / 2, free.saturating_sub(free / 2)),
+                TableAlignment::Right => (free, 0),
+                TableAlignment::None | TableAlignment::Left => (0, free),
+            };
+            spans.push(Span::styled(format!(" {}", " ".repeat(left_padding)), body_style));
+            spans.extend(content);
+            spans.push(Span::styled(format!("{} ", " ".repeat(right_padding)), body_style));
+            spans.push(Span::styled("│", border_style));
+        }
+        output.push(Line::from(spans));
+    }
+    output
+}
+
+fn bold_spans(spans: &[Span<'static>], fallback_style: Style) -> Vec<Span<'static>> {
+    if spans.is_empty() {
+        return vec![Span::styled(String::new(), fallback_style.add_modifier(Modifier::BOLD))];
+    }
+    spans
+        .iter()
+        .cloned()
+        .map(|mut span| {
+            span.style = span.style.add_modifier(Modifier::BOLD);
+            span
+        })
+        .collect()
 }
 
 fn wrap_line(line: LogicalLine, width: u16) -> Vec<Line<'static>> {

--- a/crates/aion-tui/src/markdown_test.rs
+++ b/crates/aion-tui/src/markdown_test.rs
@@ -58,6 +58,48 @@ fn fenced_code_block_hides_fences_and_fills_each_code_row() {
 }
 
 #[test]
+fn markdown_table_renders_borders_columns_and_alignment() {
+    let markdown = "| Name | Value |\n| :--- | ----: |\n| alpha | 42 |";
+    let lines = render_markdown(markdown, 32, theme());
+    let rendered = lines.iter().map(ToString::to_string).collect::<Vec<_>>();
+
+    assert!(rendered.first().is_some_and(|line| line.starts_with('┌')));
+    assert!(rendered.last().is_some_and(|line| line.starts_with('└')));
+    let header = rendered
+        .iter()
+        .position(|line| line.contains("Name") && line.contains("Value"))
+        .expect("table header should preserve separate columns");
+    assert!(rendered.get(header + 1).is_some_and(|line| line.starts_with('├')));
+    let data = rendered
+        .iter()
+        .find(|line| line.contains("alpha"))
+        .expect("table row should be rendered");
+    let cells = data.split('│').collect::<Vec<_>>();
+    assert_eq!(cells[1].trim(), "alpha");
+    assert_eq!(cells[2].trim(), "42");
+    assert!(cells[2].ends_with("42 "), "right-aligned cell: {data}");
+    assert!(
+        lines[header]
+            .spans
+            .iter()
+            .any(|span| span.content.contains("Name") && span.style.add_modifier.contains(Modifier::BOLD))
+    );
+    assert!(rendered.iter().all(|line| UnicodeWidthStr::width(line.as_str()) <= 32));
+}
+
+#[test]
+fn narrow_table_falls_back_to_stacked_rows_without_overflowing() {
+    let markdown = "| 名称 | 说明 |\n| --- | --- |\n| 微压缩 | 保留上下文 |";
+    let lines = render_markdown(markdown, 12, theme());
+    let rendered = lines.iter().map(ToString::to_string).collect::<Vec<_>>();
+    let compact = rendered.join("").replace(' ', "");
+
+    assert!(compact.contains("名称:微压缩"));
+    assert!(compact.contains("说明:保留上下文"));
+    assert!(rendered.iter().all(|line| UnicodeWidthStr::width(line.as_str()) <= 12));
+}
+
+#[test]
 fn lists_quotes_and_headings_render_without_source_markers() {
     let markdown = "## Summary\n\n- first\n- **second**\n\n> quoted `value`";
     let lines = render_markdown(markdown, 40, theme());

--- a/crates/aion-tui/src/state.rs
+++ b/crates/aion-tui/src/state.rs
@@ -10,12 +10,38 @@ use crate::event::AgentEvent;
 use crate::session_picker::SessionPicker;
 use crate::transcript::{EntryKind, ToolStepStatus, TranscriptEntry, entries_from_messages};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ApprovalChoice {
+    Once,
+    Always,
+    Deny,
+}
+
+impl ApprovalChoice {
+    pub(super) fn previous(self) -> Self {
+        match self {
+            Self::Once => Self::Deny,
+            Self::Always => Self::Once,
+            Self::Deny => Self::Always,
+        }
+    }
+
+    pub(super) fn next(self) -> Self {
+        match self {
+            Self::Once => Self::Always,
+            Self::Always => Self::Deny,
+            Self::Deny => Self::Once,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct ApprovalRequest {
     pub(super) call_id: String,
     pub(super) name: String,
     pub(super) description: String,
     pub(super) input: String,
+    pub(super) choice: ApprovalChoice,
 }
 
 #[derive(Debug)]
@@ -121,6 +147,25 @@ impl AppState {
 
     pub(super) fn mark_transcript_committed(&mut self) {
         self.committed_transcript = self.transcript.len();
+    }
+
+    pub(super) fn prepare_history_replay(&mut self) -> usize {
+        self.committed_transcript = 0;
+        for entry in &mut self.transcript {
+            entry.reset_display_offset();
+        }
+        self.show_welcome = self.transcript.is_empty();
+
+        let first_unstable_tool = self.transcript.iter().position(|entry| !entry.is_stable_for_history());
+        [self.active_assistant, self.active_thinking, first_unstable_tool]
+            .into_iter()
+            .flatten()
+            .min()
+            .unwrap_or(self.transcript.len())
+    }
+
+    pub(super) fn mark_transcript_prefix_committed(&mut self, count: usize) {
+        self.committed_transcript = count.min(self.transcript.len());
     }
 
     pub(super) fn commit_streaming_prefix(&mut self, complete_entries: usize, active_byte_count: usize) {
@@ -245,6 +290,7 @@ impl AppState {
                     name,
                     description,
                     input,
+                    choice: ApprovalChoice::Once,
                 });
             }
             AgentEvent::ToolRunning { call_id, name } => {

--- a/crates/aion-tui/src/state_test.rs
+++ b/crates/aion-tui/src/state_test.rs
@@ -1,4 +1,5 @@
 use aion_agent::commands::CommandSpec;
+use aion_types::compact::{CompactMetadata, CompactTrigger};
 use aion_types::message::{ContentBlock, Message, Role};
 
 use super::AppState;
@@ -31,6 +32,52 @@ fn resumed_history_is_rendered_by_role() {
     assert_eq!(state.transcript[1].kind, EntryKind::Assistant);
     assert!(state.transcript[0].label.is_empty());
     assert!(state.transcript[1].label.is_empty());
+}
+
+#[test]
+fn resumed_history_hides_compact_context_messages() {
+    let metadata = CompactMetadata {
+        trigger: CompactTrigger::Manual,
+        pre_compact_tokens: 42_000,
+        messages_summarized: 12,
+    };
+    let mut state = state();
+    state.set_history(&[
+        Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: format!(
+                    "[Conversation compacted]\n{}",
+                    serde_json::to_string(&metadata).unwrap()
+                ),
+            }],
+        ),
+        Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "This session is being continued from a previous conversation.\n\nSummary: internal summary"
+                    .to_string(),
+            }],
+        ),
+        Message::new(
+            Role::User,
+            vec![ContentBlock::Text {
+                text: "visible question".to_string(),
+            }],
+        ),
+        Message::new(
+            Role::Assistant,
+            vec![ContentBlock::Text {
+                text: "visible answer".to_string(),
+            }],
+        ),
+    ]);
+
+    assert_eq!(state.transcript.len(), 2);
+    assert_eq!(state.transcript[0].kind, EntryKind::User);
+    assert_eq!(state.transcript[0].text, "visible question");
+    assert_eq!(state.transcript[1].kind, EntryKind::Assistant);
+    assert_eq!(state.transcript[1].text, "visible answer");
 }
 
 #[test]
@@ -184,6 +231,23 @@ fn streaming_deltas_append_to_one_assistant_entry() {
     state.handle_agent_event(AgentEvent::TextDelta("world".to_string()));
     assert_eq!(state.transcript.len(), 1);
     assert_eq!(state.transcript[0].text, "hello world");
+}
+
+#[test]
+fn history_replay_resets_stream_offsets_and_keeps_active_content_pending() {
+    let mut state = state();
+    state.begin_turn("question");
+    state.handle_agent_event(AgentEvent::TextDelta("first\n\nsecond".to_string()));
+    state.commit_streaming_prefix(1, "first\n\n".len());
+    assert_eq!(state.transcript[1].visible_text(), "second");
+
+    let replayable_count = state.prepare_history_replay();
+
+    assert_eq!(replayable_count, 1);
+    assert_eq!(state.committed_transcript, 0);
+    assert_eq!(state.transcript[1].visible_text(), "first\n\nsecond");
+    state.mark_transcript_prefix_committed(replayable_count);
+    assert_eq!(state.pending_transcript().len(), 1);
 }
 
 #[test]

--- a/crates/aion-tui/src/terminal.rs
+++ b/crates/aion-tui/src/terminal.rs
@@ -82,14 +82,13 @@ pub(super) fn reset_inline_synchronized(terminal: &mut AppTerminal) -> anyhow::R
     let reset_result = (|| -> anyhow::Result<()> {
         terminal.autoresize()?;
         terminal.clear()?;
+        // Keep this as one ordered sequence. Some terminals, including tmux, only purge
+        // scrollback reliably when the visible screen is cleared before CSI 3 J.
+        terminal
+            .backend_mut()
+            .write_all(b"\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H")?;
         terminal.backend_mut().flush()?;
-        execute!(
-            terminal.backend_mut(),
-            Clear(ClearType::Purge),
-            Clear(ClearType::All),
-            MoveTo(0, 0),
-            Hide
-        )?;
+        execute!(terminal.backend_mut(), Hide)?;
         Ok(())
     })();
     let end_result = execute!(terminal.backend_mut(), EndSynchronizedUpdate);

--- a/crates/aion-tui/src/terminal.rs
+++ b/crates/aion-tui/src/terminal.rs
@@ -77,6 +77,27 @@ pub(super) fn clear_synchronized(terminal: &mut AppTerminal) -> anyhow::Result<(
     Ok(())
 }
 
+pub(super) fn reset_inline_synchronized(terminal: &mut AppTerminal) -> anyhow::Result<()> {
+    execute!(terminal.backend_mut(), BeginSynchronizedUpdate)?;
+    let reset_result = (|| -> anyhow::Result<()> {
+        terminal.autoresize()?;
+        terminal.clear()?;
+        terminal.backend_mut().flush()?;
+        execute!(
+            terminal.backend_mut(),
+            Clear(ClearType::Purge),
+            Clear(ClearType::All),
+            MoveTo(0, 0),
+            Hide
+        )?;
+        Ok(())
+    })();
+    let end_result = execute!(terminal.backend_mut(), EndSynchronizedUpdate);
+    reset_result?;
+    end_result?;
+    Ok(())
+}
+
 pub(super) fn insert_history_lines(terminal: &mut AppTerminal, lines: Vec<Line<'static>>) -> anyhow::Result<()> {
     for chunk in lines.chunks(usize::from(u16::MAX)) {
         let height = u16::try_from(chunk.len()).unwrap_or(u16::MAX);
@@ -194,15 +215,8 @@ impl TerminalSession {
 
     pub(super) fn reset_inline(&mut self) -> anyhow::Result<()> {
         debug_assert!(!self.picker_mode);
-        self.inline_terminal.draw(|frame| frame.buffer_mut().reset())?;
-        self.inline_terminal.backend_mut().flush()?;
-        execute!(
-            self.inline_terminal.backend_mut(),
-            Clear(ClearType::Purge),
-            Clear(ClearType::All),
-            MoveTo(0, 0),
-            Hide
-        )?;
+        reset_inline_synchronized(&mut self.inline_terminal)?;
+        self.inline_terminal = inline_terminal(io::stdout())?;
         Ok(())
     }
 }

--- a/crates/aion-tui/src/terminal_event_reader.rs
+++ b/crates/aion-tui/src/terminal_event_reader.rs
@@ -1,0 +1,58 @@
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crossterm::event::{self, Event};
+use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+pub(super) struct TerminalEventReader {
+    receiver: UnboundedReceiver<io::Result<Event>>,
+    shutdown: Arc<AtomicBool>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl TerminalEventReader {
+    pub(super) fn new() -> Self {
+        let (sender, receiver) = unbounded_channel();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let worker_shutdown = shutdown.clone();
+        let worker = thread::spawn(move || {
+            while !worker_shutdown.load(Ordering::Acquire) {
+                match event::poll(EVENT_POLL_INTERVAL) {
+                    Ok(true) => {
+                        if sender.send(event::read()).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        let _ = sender.send(Err(error));
+                        break;
+                    }
+                }
+            }
+        });
+        Self {
+            receiver,
+            shutdown,
+            worker: Some(worker),
+        }
+    }
+
+    pub(super) async fn next(&mut self) -> Option<io::Result<Event>> {
+        self.receiver.recv().await
+    }
+}
+
+impl Drop for TerminalEventReader {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}

--- a/crates/aion-tui/src/terminal_event_reader.rs
+++ b/crates/aion-tui/src/terminal_event_reader.rs
@@ -46,13 +46,21 @@ impl TerminalEventReader {
     pub(super) async fn next(&mut self) -> Option<io::Result<Event>> {
         self.receiver.recv().await
     }
-}
 
-impl Drop for TerminalEventReader {
-    fn drop(&mut self) {
+    pub(super) fn stop(&mut self) {
         self.shutdown.store(true, Ordering::Release);
         if let Some(worker) = self.worker.take() {
             let _ = worker.join();
         }
+    }
+
+    pub(super) fn restart(&mut self) {
+        *self = Self::new();
+    }
+}
+
+impl Drop for TerminalEventReader {
+    fn drop(&mut self) {
+        self.stop();
     }
 }

--- a/crates/aion-tui/src/transcript.rs
+++ b/crates/aion-tui/src/transcript.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use aion_agent::compact::auto::is_compact_boundary;
 use aion_types::message::{ContentBlock, Message, Role};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,6 +78,10 @@ impl TranscriptEntry {
         self.display_offset = self.display_offset.saturating_add(byte_count).min(self.text.len());
     }
 
+    pub(super) fn reset_display_offset(&mut self) {
+        self.display_offset = 0;
+    }
+
     pub(super) fn is_stable_for_history(&self) -> bool {
         self.kind != EntryKind::Tool || self.tool_status.is_some_and(ToolStepStatus::is_terminal)
     }
@@ -85,7 +90,16 @@ impl TranscriptEntry {
 pub(super) fn entries_from_messages(messages: &[Message]) -> Vec<TranscriptEntry> {
     let mut entries = Vec::new();
     let mut tool_entries = HashMap::new();
+    let mut skip_compact_summary = false;
     for message in messages {
+        if skip_compact_summary {
+            skip_compact_summary = false;
+            continue;
+        }
+        if is_compact_boundary(message) {
+            skip_compact_summary = true;
+            continue;
+        }
         for block in &message.content {
             match block {
                 ContentBlock::Text { text } => match message.role {

--- a/crates/aion-tui/src/ui.rs
+++ b/crates/aion-tui/src/ui.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::markdown::{MarkdownTheme, render_markdown};
-use crate::state::AppState;
+use crate::state::{AppState, ApprovalChoice};
 use crate::transcript::{EntryKind, ToolStepStatus, TranscriptEntry};
 
 const MAX_COMPOSER_HEIGHT: u16 = 8;
@@ -126,6 +126,11 @@ fn render_transcript(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
 
 pub(super) fn pending_history_lines(state: &AppState, width: u16) -> Vec<Line<'static>> {
     transcript_lines(state.pending_transcript(), width.max(1), state)
+}
+
+pub(super) fn history_prefix_lines(state: &AppState, count: usize, width: u16) -> Vec<Line<'static>> {
+    let count = count.min(state.transcript.len());
+    transcript_lines(&state.transcript[..count], width.max(1), state)
 }
 
 pub(super) struct StreamingHistoryCommit {
@@ -659,24 +664,72 @@ fn render_approval(frame: &mut Frame<'_>, bounds: Rect, state: &AppState) {
         return;
     };
     let width = bounds.width.saturating_sub(4).clamp(20, 88);
-    let height = bounds.height.saturating_sub(2).clamp(6, 12);
+    let height = bounds.height.saturating_sub(2).clamp(8, 14);
     let area = centered_rect(width, height, bounds);
     let description = if request.description.trim().is_empty() {
         "This tool needs your approval."
     } else {
         request.description.as_str()
     };
-    let content = format!("{}\n\n{}\n\n{}", request.name, description, request.input);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Tool approval ")
+        .border_style(warning(state));
+    let inner = block.inner(area);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1), Constraint::Length(1)])
+        .split(inner);
+    let body = Text::from(vec![
+        Line::from(Span::styled(
+            request.name.clone(),
+            normal(state).add_modifier(Modifier::BOLD),
+        )),
+        Line::default(),
+        Line::from(description.to_string()),
+        Line::default(),
+        Line::from(Span::styled(request.input.clone(), muted(state))),
+    ]);
     frame.render_widget(Clear, area);
+    frame.render_widget(block, area);
+    frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), chunks[0]);
+    frame.render_widget(Paragraph::new(approval_actions(request.choice, inner.width)), chunks[1]);
     frame.render_widget(
-        Paragraph::new(content).wrap(Wrap { trim: false }).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Tool approval ")
-                .border_style(warning(state)),
-        ),
-        area,
+        Paragraph::new(Line::from(Span::styled(
+            fit_line(" ←/→ select · Enter confirm · Esc deny", inner.width),
+            muted(state),
+        ))),
+        chunks[2],
     );
+}
+
+fn approval_actions(choice: ApprovalChoice, width: u16) -> Line<'static> {
+    let labels = if width >= 34 {
+        [
+            (ApprovalChoice::Once, " Allow once "),
+            (ApprovalChoice::Always, " Always allow "),
+            (ApprovalChoice::Deny, " Deny "),
+        ]
+    } else {
+        [
+            (ApprovalChoice::Once, " Once "),
+            (ApprovalChoice::Always, " Always "),
+            (ApprovalChoice::Deny, " Deny "),
+        ]
+    };
+    let mut spans = Vec::with_capacity(labels.len() * 2);
+    for (index, (action, label)) in labels.into_iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::raw(" "));
+        }
+        let style = if choice == action {
+            Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED)
+        } else {
+            Style::default()
+        };
+        spans.push(Span::styled(label, style));
+    }
+    Line::from(spans).alignment(Alignment::Center)
 }
 
 fn centered_rect(width: u16, height: u16, bounds: Rect) -> Rect {

--- a/crates/aion-tui/src/ui_test.rs
+++ b/crates/aion-tui/src/ui_test.rs
@@ -6,8 +6,9 @@ use ratatui::style::{Color, Modifier};
 use super::{
     aion_mark_lines, entry_style, pending_history_lines, render, streaming_history_commit, welcome_history_lines,
 };
+use crate::event::AgentEvent;
 use crate::session_picker::TuiSession;
-use crate::state::AppState;
+use crate::state::{AppState, ApprovalChoice};
 use crate::transcript::{EntryKind, ToolStepStatus, TranscriptEntry};
 
 #[test]
@@ -173,6 +174,51 @@ fn welcome_renders_ascii_aion_mark() {
     let rendered = terminal.backend().to_string();
     assert!(rendered.contains("::::::::"));
     assert!(rendered.contains("AionCLI"));
+}
+
+#[test]
+fn approval_modal_keeps_actions_visible_and_marks_the_selected_choice() {
+    let mut state = AppState::new(
+        "model".to_string(),
+        "provider".to_string(),
+        "/workspace".to_string(),
+        true,
+    );
+    state.handle_agent_event(AgentEvent::ApprovalRequested {
+        call_id: "call-1".to_string(),
+        name: "shell".to_string(),
+        description: "Run a command".to_string(),
+        input: "very long input ".repeat(30),
+    });
+    state.approval.as_mut().expect("approval should exist").choice = ApprovalChoice::Always;
+
+    let backend = TestBackend::new(80, 24);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| render(frame, &state))
+        .expect("render should succeed");
+
+    let rendered = terminal.backend().to_string();
+    assert!(rendered.contains("Allow once"));
+    assert!(rendered.contains("Always allow"));
+    assert!(rendered.contains("Enter confirm"));
+    let action_row = rendered
+        .lines()
+        .position(|line| line.contains("Always allow"))
+        .expect("approval actions should be visible") as u16;
+    let action_line = rendered
+        .lines()
+        .nth(usize::from(action_row))
+        .expect("action row should exist");
+    let action_column = action_line
+        .find("Always allow")
+        .expect("selected action should be present") as u16;
+    let selected = terminal
+        .backend()
+        .buffer()
+        .cell((action_column, action_row))
+        .expect("selected action cell should exist");
+    assert!(selected.modifier.contains(Modifier::REVERSED));
 }
 
 #[test]

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -357,19 +357,21 @@ When in plan mode, the agent follows a structured 4-phase process:
 
 ## Context Compression
 
-A three-tier automatic compaction strategy that prevents context window overflow during long conversations.
+A cache-friendly context strategy that bounds each tool result once when it enters history, then uses token-based compaction to prevent context window overflow during long conversations.
 
 ### Tiers
 
 | Tier | Trigger | Method | LLM Call |
 |------|---------|--------|----------|
-| **Microcompact** | Tool result count exceeds threshold or time gap | Clears old tool result content, keeping the N most recent | No |
+| **Tool output limit** | A tool result exceeds `tool_output_max_bytes` | Preserves the beginning and end once before storing the result | No |
 | **Autocompact** | Input tokens approach context limit | LLM summarizes the conversation | Yes |
 | **Emergency** | Input tokens near absolute limit | Blocks further API calls, asks user to start fresh | No |
 
 ### How It Works
 
-- **Microcompact** runs automatically: replaces old Read/ExecCommand/Grep/Glob/Write/Edit results with `[Tool result cleared]`, keeping the 5 most recent results intact. Triggered by count (>10 compactable results) or time (>1 hour since last assistant message).
+- **Tool output limiting** runs once per result after structural output compaction. Results longer than 10,000 UTF-8 bytes retain their beginning and end with a truncation marker in the middle. Stored history is not rewritten later, preserving a stable prompt-cache prefix.
+
+- **Legacy microcompact** can still be enabled explicitly for compatibility, but defaults to off because it rewrites old history and can invalidate prompt caches.
 
 - **Autocompact** triggers when input tokens reach a threshold. By default this is `context_window - output_reserve - autocompact_buffer` (200,000 - 20,000 - 13,000 = 167,000 tokens). Alternatively, set `autocompact_threshold_pct` to trigger at a percentage of the context window (e.g. `50` = 50% of 200k = 100k tokens). The agent calls the LLM to produce a conversation summary, then replaces history with a compact boundary marker. A circuit breaker stops retrying after 3 consecutive failures.
 
@@ -385,7 +387,8 @@ output_reserve = 20000      # Reserved for output generation
 autocompact_buffer = 13000  # Buffer before autocompact triggers
 emergency_buffer = 3000     # Buffer before emergency block
 max_failures = 3            # Circuit breaker threshold
-micro_keep_recent = 5       # Keep N most recent tool results
+tool_output_max_bytes = 10000 # Maximum model-facing bytes per tool result
+microcompact_enabled = false  # Legacy history rewriting; not recommended
 # autocompact_threshold_pct = 50  # Override: trigger at N% of context_window
 ```
 
@@ -442,8 +445,9 @@ TOON instructions are injected into the system prompt so the LLM understands the
 
 ```toml
 [compact]
-compaction = "safe"   # off | safe | full (default: safe)
-toon = false          # Enable TOON encoding (default: false)
+tool_output_max_bytes = 10000 # Final model-facing limit per tool result
+compaction = "safe"          # off | safe | full (default: safe)
+toon = false                 # Enable TOON encoding (default: false)
 ```
 
 ### Runtime Control


### PR DESCRIPTION
## Summary

- Bound every model-facing tool result once with a configurable UTF-8 byte limit, preserving the head and tail, and disable legacy history-rewriting microcompact by default to keep prompt prefixes cache-friendly.
- Keep existing tool-execution entry points compatible while applying the configured output limit to both terminal and protocol approval flows.
- Stabilize TUI approval selection, responsive Markdown tables, and inline history reflow across terminal resize and session resume.
- Prevent cursor-position query contention during `/resume`, omit unsupported `thinking` parameters from compact requests, and hide internal compact boundary/summary messages from resumed transcripts.
- Update configuration examples and context-compression documentation, with regression coverage for agent, config, orchestration, compact, and TUI behavior.

## Why

Frequent microcompact passes rewrote historical tool results and invalidated stable prompt-cache prefixes. Tool outputs instead need a predictable bound at the point they enter model history.

The TUI also reused stale inline viewport state and shared Crossterm's event reader with terminal cursor queries. This caused repeated separators after resize, excess whitespace after resume, and occasional leaked cursor-position responses. Approval prompts and Markdown tables were not responsive enough for narrow terminals.

## Compatibility

- Existing configuration files remain valid through Serde defaults.
- `tool_output_max_bytes` defaults to 10,000 bytes.
- Legacy microcompact remains available with `microcompact_enabled = true`, but now defaults to disabled.
- No cross-repository API or protocol migration is required.

## Non-goals

- This does not introduce a separate persisted display transcript; resumed TUI history filters compact-internal context as a short-term presentation fix.
- This does not upgrade unrelated dependencies reported by the current RustSec advisory database.

## Validation

- `just push -u origin jiahe/refactor/tool-output-truncation`
  - lint/fix and formatting passed
  - 2,353 workspace tests passed; 2 diagnostic watcher tests skipped by profile
  - Hakari generation/dependency verification passed
  - branch push succeeded
- `cargo build -p aion-cli` passed.
- Manual tmux validation covered terminal resize, `/resume` picker selection, resumed short/long sessions, and reflow without duplicate current-viewport rendering or leaked cursor responses.
- `just check-all` passed formatting, workspace Clippy, all 2,353 CI-profile tests, and Hakari, then stopped at `cargo audit` because baseline `quinn-proto 0.11.14` is affected by RUSTSEC-2026-0185 (fixed in 0.11.15). The same version is present on `origin/main` and is not introduced by this PR.
